### PR TITLE
EXC-783: Remove limit on Cycles in a canister

### DIFF
--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -98,9 +98,9 @@ Amount of cycles that a canister has to have before a message is attempted to be
 +
 Amount of cycles that the IC sets aside when a canister performs a call. This is used to pay for processing the response message, and unused cycles after the execution of the response are refunded. See <<rule-message-execution>>.
 
-* `MAX_CANISTER_BALANCE`
+* `DEFAULT_PROVISIONAL_CYCLES_BALANCE`
 +
-Maximum canister cycle balance. Any excess is discarded. Less than 2^128^.
+Amount of cycles allocated to a new canister by default, if not explicitly specified. See <<ic-provisional_create_canister_with_cycles>>.
 
 [#principal]
 === Principals
@@ -207,6 +207,7 @@ If an empty canister receives a response, that response is dropped, as if the ca
 ==== Canister cycles
 
 The IC relies on _cycles_, a utility token, to manage its resources. A canister pays for the resources it uses from its _cycle balance_.
+The _cycle_balance_ is stored as 128-bit unsigned integers and operations on them are saturating. In particular, if _cycles_ are added to a canister that would bring its total balance beyond 2^128-1, then the balance will be capped at 2^128-1 and any additional cycles will be lost.
 
 When the cycle balance of a canister falls to zero, the canister is _deallocated_. This has the same effect as
 
@@ -1274,8 +1275,6 @@ This moves cycles from the call to the canister balance. It moves as many cycles
 
 * It moves no more cycles than available according to `ic0.msg_cycles_available`, and
 
-* The canister balance afterwards does not exceed `MAX_CANISTER_BALANCE` minus any possible outstanding balances. The precise logic of this limit is not yet specified here.
-
 It can be called multiple times, each time possibly adding more cycles to the balance.
 
 The return value indicates how many cycles were actually moved.
@@ -1296,8 +1295,6 @@ This moves cycles from the call to the canister balance. It moves as many cycles
 * It moves no more cycles than the amount obtained by combining `max_amount_high` and `max_amount_low`. Cycles are represented by 128-bit values.
 
 * It moves no more cycles than available according to `ic0.msg_cycles_available128`, and
-
-* The canister balance afterwards does not exceed `MAX_CANISTER_BALANCE` minus any possible outstanding balances. The precise logic of this limit is not yet specified here.
 
 It can be called multiple times, each time possibly adding more cycles to the balance.
 
@@ -1657,7 +1654,7 @@ This method takes no input and returns 32 pseudo-random bytes to the caller. The
 [#ic-provisional_create_canister_with_cycles]
 === IC method `provisional_create_canister_with_cycles`
 
-As a provisional method on development instances, the `provisional_create_canister_with_cycles` method is provided. It behaves as `create_canister`, but initializes the canister’s balance with `amount` fresh cycles (using `MAX_CANISTER_BALANCE` if `amount = null`, else capping the balance at `MAX_CANISTER_BALANCE`).
+As a provisional method on development instances, the `provisional_create_canister_with_cycles` method is provided. It behaves as `create_canister`, but initializes the canister’s balance with `amount` fresh cycles (using `DEFAULT_PROVISIONAL_CYCLES_BALANCE` if `amount = null`).
 
 Cycles added to this call via `ic0.call_cycles_add128` are returned to the caller.
 
@@ -1666,7 +1663,7 @@ This method is only available in local development instances.
 [#ic-provisional_top_up_canister]
 === IC method `provisional_top_up_canister`
 
-As a provisional method on development instances, the `provisional_top_up_canister` method is provided. It adds `amount` cycles to the balance of canister identified by `amount` (implicitly capping it at `MAX_CANISTER_BALANCE`).
+As a provisional method on development instances, the `provisional_top_up_canister` method is provided. It adds `amount` cycles to the balance of canister identified by `amount`.
 
 Cycles added to this call via `ic0.call_cycles_add128` are returned to the caller.
 
@@ -2584,13 +2581,11 @@ if
   Cycles_used ≤ (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE)
   res.cycles_accepted ≤ Available
   New_balance =
-      min(
-        S.balances[M.receiver]
-        + res.cycles_accepted
-        + (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE)
-        - Cycles_used
-        - ∑ [ MAX_CYCLES_PER_RESPONSE + call.transferred_cycles | call ∈ res.new_calls ]
-      , MAX_CANISTER_BALANCE)
+      S.balances[M.receiver]
+      + res.cycles_accepted
+      + (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE)
+      - Cycles_used
+      - ∑ [ MAX_CYCLES_PER_RESPONSE + call.transferred_cycles | call ∈ res.new_calls ]
   New_balance > if Is_response then 0 else freezing_limit(S, CM.callee);
   (res.response = NoResponse) or S.call_contexts[M.call_context].needs_to_respond
 then
@@ -3161,7 +3156,7 @@ State after::
 ....
 S with
     balances[CanisterId] =
-      min(S.balances[A.canister_id] + M.transferred_cycles, MAX_CANISTER_BALANCE)
+      S.balances[A.canister_id] + M.transferred_cycles
     messages = Older_messages · Younger_messages ·
       ResponseMessage {
         origin = M.origin
@@ -3216,7 +3211,7 @@ S with
     canisters[CanisterId] = EmptyCanister
     time[CanisterId] = CurrentTime
     controllers[CanisterId] = [M.caller]
-    balances[CanisterId] = min(A.amount, MAX_CANISTER_BALANCE)
+    balances[CanisterId] = A.amount
     certified_data[CanisterId] = ""
     messages = Older_messages · Younger_messages ·
       ResponseMessage {
@@ -3241,7 +3236,7 @@ Conditions::
 State after::
 ....
 S with
-    balances[CanisterId] = min(balances[CanisterId] + A.amount, MAX_CANISTER_BALANCE)
+    balances[CanisterId] = balances[CanisterId] + A.amount
 ....
 
 ==== Callback invocation
@@ -3263,8 +3258,7 @@ State after::
 ....
 S with
     balances[S.call_contexts[Ctxt_id].canister] =
-      min(balances[S.call_contexts[Ctxt_id].canister] + RM.refunded_cycles,
-          MAX_CANISTER_BALANCE)
+      balances[S.call_contexts[Ctxt_id].canister] + RM.refunded_cycles
     messages =
       Older_messages ·
       FuncMessage {
@@ -3292,8 +3286,7 @@ State after::
 ....
 S with
     balances[S.call_contexts[Ctxt_id].canister] =
-      min(balances[S.call_contexts[Ctxt_id].canister] + RM.refunded_cycles + MAX_CYCLES_PER_RESPONSE,
-          MAX_CANISTER_BALANCE)
+      balances[S.call_contexts[Ctxt_id].canister] + RM.refunded_cycles + MAX_CYCLES_PER_RESPONSE
     messages = Older_messages · Younger_messages
 ....
 
@@ -3946,7 +3939,7 @@ ic0.msg_method_name_copy<es>(dst : i32, offset : i32, size : i32) : i32 =
   copy_to_canister<es>(dst, offset, size, es.params.method_name)
 
 ic0.msg_cycles_accept<es>(max_amount : i64) : i64 =
-  let amount = min(max_amount, es.cycles_available, MAX_CANISTER_BALANCE - es.balance)
+  let amount = min(max_amount, es.cycles_available)
   es.cycles_available := es.cycles_available - amount
   es.cycles_accepted := es.cycles_accepted + amount
   es.balance := es.balance + amount
@@ -3954,7 +3947,7 @@ ic0.msg_cycles_accept<es>(max_amount : i64) : i64 =
 
 ic0.msg_cycles_accept128<es>(max_amount_high : i64, max_amount_low : i64, dst : i32) =
   let max_amount = max_amount_high * 2^64 + max_amount_low
-  let amount = min(max_amount, es.cycles_available, MAX_CANISTER_BALANCE - es.balance)
+  let amount = min(max_amount, es.cycles_available)
   es.cycles_available := es.cycles_available - amount
   es.cycles_accepted := es.cycles_accepted + amount
   es.balance := es.balance + amount
@@ -4059,7 +4052,7 @@ ic0.call_peform<es>() : ( err_code : i32 ) =
 // helper function
 discard_pending_call<es>() =
   if es.pending_call ≠ NoPendingCall then
-    es.balance := min(es.balance + MAX_CYCLES_PER_RESPONSE + es.pending_call.transferred_cycles, MAX_CANISTER_BALANCE)
+    es.balance := es.balance + MAX_CYCLES_PER_RESPONSE + es.pending_call.transferred_cycles
     es.pending_call := NoPendingCall
 
 ic0.stable_size<es>() : (page_count : i32) =


### PR DESCRIPTION
We no longer enforce a limit on the amount of cycles a canister can
hold, so this limit should be removed from the spec.