### PR TITLE
IC-530:Canister HTTP requests

### DIFF
--- a/spec/ic.did
+++ b/spec/ic.did
@@ -16,6 +16,20 @@ type definite_canister_settings = record {
   freezing_threshold : nat;
 };
 
+type http_header = record { 0: text; 1: text };
+
+type http_response = record {
+  status: nat;
+  headers: vec http_header;
+  body: blob;
+};
+
+type http_request_error = variant {
+  no_consensus;
+  timeout;
+  bad_tls;
+};
+
 service ic : {
   create_canister : (record {
     settings : opt canister_settings
@@ -43,6 +57,15 @@ service ic : {
   delete_canister : (record {canister_id : canister_id}) -> ();
   deposit_cycles : (record {canister_id : canister_id}) -> ();
   raw_rand : () -> (blob);
+  http_request : (record {
+    url : text;
+    method : variant { get };
+    headers: vec http_header;
+    body : opt blob;
+    transform : opt variant {
+      function: func (http_response) -> (http_response) query
+    };
+  }) -> (variant { Ok : http_response; Err: opt http_request_error });
 
   // provisional interfaces for the pre-ledger world
   provisional_create_canister_with_cycles : (record {

--- a/spec/ic.did
+++ b/spec/ic.did
@@ -16,7 +16,7 @@ type definite_canister_settings = record {
   freezing_threshold : nat;
 };
 
-type http_header = record { 0: text; 1: text };
+type http_header = record { name: text; value: text };
 
 type http_response = record {
   status: nat;

--- a/spec/ic.did
+++ b/spec/ic.did
@@ -28,6 +28,7 @@ type http_request_error = variant {
   no_consensus;
   timeout;
   bad_tls;
+  invalid_url;
 };
 
 service ic : {

--- a/spec/ic.did
+++ b/spec/ic.did
@@ -29,6 +29,10 @@ type http_request_error = variant {
   timeout;
   bad_tls;
   invalid_url;
+  transform_error;
+  dns_error;
+  unreachable;
+  conn_timeout;
 };
 
 service ic : {

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1659,7 +1659,7 @@ This method takes no input and returns 32 pseudo-random bytes to the caller. The
 
 This method makes an HTTP request to a given URL and returns the HTTP response, possibly after a transformation.
 
-For security, the request is executed by multiple IC replicas (usually the entire subnet) and therefore must be _idempotent_. This means that the request must not change state at the remote server, or that the remote server has means to identify duplicated requests and return the same response to all of them.
+For security, the request is executed by multiple IC replicas (usually the entire subnet) and therefore must be _idempotent_. This means that the request must not change state at the remote server, or that the remote server has means to identify duplicated requests.
 
 The responses for all the requests must be, eventually, identical. However, it is possible that a web service would return slightly different responses for the same idempotent request. For example, it may include some unique identification or a timestamp that would vary across responses.
 
@@ -1676,7 +1676,7 @@ The maximal size of a request URL is 2048 bytes.
 The maximal size of a response is `TBD`. If a response is larger than this size, only the first `TBD` bytes will be returned. This size limit also applies to the value returned by the `transform` function.
 // NOTE: the size above should be up to 2MB which is the maximal size of a message in the consensus queue
 
-The follwing paramters should be supplied for the call:
+The following parameters should be supplied for the call:
 
 - `url` - the requested URL
 - `method` - currently only GET is supported

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1530,7 +1530,6 @@ The binary encoding of arguments and results are as per Candid specification.
 Before deploying a canister, the administrator of the canister first has to register it with the IC, to get a canister id (with an empty canister behind it), and then separately install the code.
 
 The optional `settings` parameter can be used to set the following settings:
-
 * `controllers` (`vec principal`)
 +
 A list of principals. Must be between 0 and 10 in size. This value is assigned to the _controllers_ attribute of the canister.
@@ -1659,45 +1658,34 @@ This method takes no input and returns 32 pseudo-random bytes to the caller. The
 
 This method makes an HTTP request to a given URL and returns the HTTP response, possibly after a transformation.
 
-For security, the request is executed by multiple IC replicas (usually the entire subnet) and therefore must be _idempotent_. This means that the request must not change state at the remote server, or that the remote server has means to identify duplicated requests.
+The request must be _idempotent_, meaning that it must not change the state at the remote server, or the remote server has the means to identify duplicated requests.
 
-The responses for all the requests must be, eventually, identical. However, it is possible that a web service would return slightly different responses for the same idempotent request. For example, it may include some unique identification or a timestamp that would vary across responses.
+The responses for all identical requests must match too. However, a web service would return slightly different responses for identical idempotent requests. For example, it may include some unique identification or a timestamp that would vary across responses.
 
-For this reason, the calling canister can supply a transformation function, which is used by the IC to let the canister sanitize the responses from such unique values, and therefore eventually agree on an identical response. The transformation function is executed separately by each replica on the corresponding response it has received for the request. The final response will only be available to the calling canister if enough replicas have agreed on an identical response.
+For this reason, the calling canister can supply a transformation function, which the IC uses to let the canister sanitize the responses from such unique values. The transformation function is executed separately on the corresponding response received for a request. The final response will only be available to the calling canister.
 
-Currently, only GET method is supported for HTTP requests.
+Currently, only the `GET` method is supported for HTTP requests.
 
 For security reasons, only HTTPS connections are allowed (URLs must start with `https://`). The IC uses industry-standard root CA lists to validate certificates of remote web servers.
 
-The cost of each call to the `http_request` method is `TBD` (the `transform` should also be charged).
-
 The maximal size of a request URL is 2048 bytes.
 
-The maximal size of a response is `TBD`. If a response is larger than this size, only the first `TBD` bytes will be returned. This size limit also applies to the value returned by the `transform` function.
-// NOTE: the size above should be up to 2MB which is the maximal size of a message in the consensus queue
+The maximal size of a response is `2MiB`. Therefore, only the first `2MiB` will be returned if a response is larger than this size. This size limit also applies to the value returned by the `transform` function.
 
 The following parameters should be supplied for the call:
 
 - `url` - the requested URL
-- `method` - currently only GET is supported
+- `method` - currently, only GET is supported
 - `headers` - list of HTTP request headers and their corresponding values
-- `transform` - an optional function that transforms raw responses to sanitized responses. This must be a function exported by the canister itself (and not another canister).
+- `transform` - an optional function that transforms raw responses to sanitized responses. If provided, the calling canister itself must export this function.
 
-The returned response (and the response provided to the `transform` function, if specified), contains the following fields:
+The returned response (and the response provided to the `transform` function, if specified) contains the following fields:
 
 - `status` - the response status (e.g., 200, 404)
 - `headers` - list of HTTP response headers and their corresponding values
 - `body` - the response's body
 
 The `transform` function may, for example, transform the body in any way, add or remove headers, modify headers, etc.
-
-// TODO: Flesh out the documentation. Some information you might want to include:
-// * Can you make any HTTP request? What are the constraints?
-//
-// * Is there a cost associated with this call? If we know we'll charge for it, but don't know
-//   the exact amount, adding a placeholder would be sufficient in the first draft.
-//
-// * The `func` in the `transform` parameter must be a function exported by the canister itself (and not another canister).
 
 [#ic-provisional_create_canister_with_cycles]
 === IC method `provisional_create_canister_with_cycles`

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1657,7 +1657,34 @@ This method takes no input and returns 32 pseudo-random bytes to the caller. The
 [#ic-http_request]
 === IC method `http_request`
 
-This method makes an HTTP request.
+This method makes an HTTP request to a given URL and returns the HTTP response, possibly after a transformation.
+
+For security, the request is executed by multiple IC replicas (usually the entire subnet) and therefore must be _idempotent_. This means that the request must not change state at the remote server, or that the remote server has means to identify duplicated requests and return the same response to all of them.
+
+The responses for all the requests must be, eventually, identical. However, it is possible that a web service would return slightly different responses for the same idempotent request. For example, it may include some unique identification or a timestamp that would vary across responses.
+
+For this reason, the calling canister can supply a transformation function, which is used by the IC to let the canister sanitize the responses from such unique values, and therefore eventually agree on an identical response. The transformation function is executed separately by each replica on the corresponding response it has received for the request. The final response will only be available to the calling canister if enough replicas have agreed on an identical response.
+
+Currently, only GET method is supported for HTTP requests.
+
+For security reasons, only HTTPS connections are allowed (URLs must start with `https://`). The IC uses industry-standard root CA lists to validate certificates of remote web servers.
+
+The cost of each call to the `http_request` method is `TBD` (the `transform` should also be charged).
+
+The follwing paramters should be supplied for the call:
+
+- `url` - the requested URL
+- `method` - currently only GET is supported
+- `headers` - list of HTTP request headers and their corresponding values
+- `transform` - an optional function that transforms raw responses to sanitized responses. This must be a function exported by the canister itself (and not another canister).
+
+The returned response (and the response provided to the `transform` function, if specified), contains the following fields:
+
+- `status` - the response status (e.g., 200, 404)
+- `headers` - list of HTTP response headers and their corresponding values
+- `body` - the response's body
+
+The `transform` function may, for example, transform the body in any way, add or remove headers, modify headers, etc.
 
 // TODO: Flesh out the documentation. Some information you might want to include:
 // * Can you make any HTTP request? What are the constraints?

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1530,6 +1530,7 @@ The binary encoding of arguments and results are as per Candid specification.
 Before deploying a canister, the administrator of the canister first has to register it with the IC, to get a canister id (with an empty canister behind it), and then separately install the code.
 
 The optional `settings` parameter can be used to set the following settings:
+
 * `controllers` (`vec principal`)
 +
 A list of principals. Must be between 0 and 10 in size. This value is assigned to the _controllers_ attribute of the canister.
@@ -1660,7 +1661,7 @@ This method makes an HTTP request to a given URL and returns the HTTP response, 
 
 The request must be _idempotent_, meaning that it must not change the state at the remote server, or the remote server has the means to identify duplicated requests.
 
-The responses for all identical requests must match too. However, a web service would return slightly different responses for identical idempotent requests. For example, it may include some unique identification or a timestamp that would vary across responses.
+The responses for all identical requests must match too. However, a web service could return slightly different responses for identical idempotent requests. For example, it may include some unique identification or a timestamp that would vary across responses.
 
 For this reason, the calling canister can supply a transformation function, which the IC uses to let the canister sanitize the responses from such unique values. The transformation function is executed separately on the corresponding response received for a request. The final response will only be available to the calling canister.
 

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1654,6 +1654,13 @@ There is no restriction on who can invoke this method.
 
 This method takes no input and returns 32 pseudo-random bytes to the caller. The return value is unknown to any part of the IC at time of the submission of this call. A new return value is generated for each call to this method.
 
+[#ic-http_request]
+=== IC method `http_request`
+
+This method makes an HTTP request.
+
+// TODO: Flesh out the documentation
+
 [#ic-provisional_create_canister_with_cycles]
 === IC method `provisional_create_canister_with_cycles`
 

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1659,7 +1659,13 @@ This method takes no input and returns 32 pseudo-random bytes to the caller. The
 
 This method makes an HTTP request.
 
-// TODO: Flesh out the documentation
+// TODO: Flesh out the documentation. Some information you might want to include:
+// * Can you make any HTTP request? What are the constraints?
+//
+// * Is there a cost associated with this call? If we know we'll charge for it, but don't know
+//   the exact amount, adding a placeholder would be sufficient in the first draft.
+//
+// * The `func` in the `transform` parameter must be a function exported by the canister itself (and not another canister).
 
 [#ic-provisional_create_canister_with_cycles]
 === IC method `provisional_create_canister_with_cycles`

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1659,7 +1659,7 @@ This method takes no input and returns 32 pseudo-random bytes to the caller. The
 
 This method makes an HTTP request to a given URL and returns the HTTP response, possibly after a transformation.
 
-The request must be _idempotent_, meaning that it must not change the state at the remote server, or the remote server has the means to identify duplicated requests.
+The canister should aim to issue _idempotent_ requests, meaning that it must not change the state at the remote server, or the remote server has the means to identify duplicated requests. Otherwise, the risk of failure increases.
 
 The responses for all identical requests must match too. However, a web service could return slightly different responses for identical idempotent requests. For example, it may include some unique identification or a timestamp that would vary across responses.
 

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1671,6 +1671,11 @@ For security reasons, only HTTPS connections are allowed (URLs must start with `
 
 The cost of each call to the `http_request` method is `TBD` (the `transform` should also be charged).
 
+The maximal size of a request URL is 2048 bytes.
+
+The maximal size of a response is `TBD`. If a response is larger than this size, only the first `TBD` bytes will be returned. This size limit also applies to the value returned by the `transform` function.
+// NOTE: the size above should be up to 2MB which is the maximal size of a message in the consensus queue
+
 The follwing paramters should be supplied for the call:
 
 - `url` - the requested URL


### PR DESCRIPTION
This PR provides the specifications for the feature IC-530: Canister HTTP requests.

The spec explains what are the constraints without explaining intricacies related to the underlying protocol. 

For this first iteration:
* the maximal size of the response is defined to `2MiB` (maximal size of a message in the consensus queue). 
* no mentions of cycles-related charges; Specifying additional cost that this call will incur should be added in the developers' guide, [Computation costs](https://smartcontracts.org/docs/developers-guide/computation-and-storage-costs.html ), once the cost is established.