### PR TITLE
Fix inconsistency in naming algorithm to verify a delegation

### DIFF
--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1812,9 +1812,9 @@ Delegation =
 A chain of delegations is verified using the following algorithm, which also returns the delegated key (a DER-encoded BLS key):
 
 ....
-check_delegations(NoDelegation) : public_bls_key =
+check_delegation(NoDelegation) : public_bls_key =
   return root_public_key
-check_delegations(Delegation d) : public_bls_key =
+check_delegation(Delegation d) : public_bls_key =
   verify_cert(d.certificate)
   return lookup(["subnet",d.subnet_id,"public_key"],d.certificate)
 ....


### PR DESCRIPTION
The section on `Certificate`s currently refers to an algorithm named `check_delegation` in the `Delegation` section, but this algorithm is named `check_delegations` (note the additional "s"). This change fixes this inconsistency by renaming the algorithm to `check_delegation`.

On naming: Although the algorithm in fact verifies a *chain* of delegation*s* (i.e., potentially multiple), the provided parameter is just a single delegation, so I opted to use the singular. We could also consider directly naming this, e.g., `check_delegation_chain`.