### PR TITLE
feat: add support for canister properties

### DIFF
--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -440,7 +440,11 @@ It is recommended for the canister to have a custom section called "icp:public c
 
 * `/canister/<canister_id>/property/<name>` (blob):
 +
-Users can set arbitrary canister properties via settings, see <<ic-create_canister>> and <<ic-update_settings>>. The (blob) is optional. There is a maximum combined size limit for all properties of 4KB. Properties may be used to enable or disable system features, e.g.:
+The systems maintains for each canister a generic key-value store, called the “Canister properties”. The system does not interpret these keys and values, but other platform components (e.g. the HTTP gateway protocol or Internet Identity) can.
+
+The system may impose a size limit on the properties; it allows at least 4KB of combined size of the keys keys and values. Values can be empty.
+
+These properties are configured and kept independently from installing or uninstalling code.
 * disable_ic0_app_service_worker
 * allow_internet_identity_aliases where (blob) is a comma separated of canister ids and/or domains.
 

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -420,7 +420,7 @@ The certified data of the canister with the given id, see <<system-api-certified
 [#state-tree-canister-information]
 === Canister information
 
-Users have the ability to learn about the hash of the canister's module, its current controllers, and metadata in a certified way.
+Users have the ability to learn about the hash of the canister's module, its current controllers, metadata and properties in a certified way.
 
 * `/canister/<canister_id>/module_hash` (blob):
 +
@@ -437,6 +437,13 @@ The current controllers of the canister. The value consists of a CBOR data item 
 If the canister has a https://webassembly.github.io/spec/core/binary/modules.html#custom-section[custom section] called `icp:public <name>` or `icp:private <name>`, this path contains the content of the custom section. Otherwise, this path does not exist.
 +
 It is recommended for the canister to have a custom section called "icp:public candid:service", which contains the UTF-8 encoding of https://github.com/dfinity/candid/blob/master/spec/Candid.md#core-grammar[the Candid interface] for the canister.
+
+* `/canister/<canister_id>/property/<name>` (blob):
++
+Users can set arbitrary canister properties via settings, see <<ic-create_canister>> and <<ic-update_settings>>. The (blob) is optional. There is a maximum combined size limit for all properties of 4KB. Properties may be used to enable or disable system features, e.g.:
+* disable_ic0_app_service_worker
+* allow_internet_identity_aliases where (blob) is a comma separated of canister ids and/or domains.
+
 
 [#http-interface]
 == HTTPS Interface
@@ -1559,6 +1566,12 @@ A canister is considered frozen whenever the IC estimates that the canister woul
 Calls to a frozen canister will be rejected (like for a stopping canister). Additionally, a canister cannot perform calls if that would, due the cost of the call and transferred cycles, would push the balance into frozen territory; these calls fail with `ic0.call_perform` returning a non-zero error code.
 +
 Default value: 2592000 (approximately 30 days).
+
+* `properties` (`vec record { name: text; value: opt blob; }`)
++
+A set of arbitrary named properties with optional blob values.  The total size of the properties must be less than 4KB.
++
+Default value: The empty list.
 
 
 [#ic-update_settings]

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -440,13 +440,11 @@ It is recommended for the canister to have a custom section called "icp:public c
 
 * `/canister/<canister_id>/property/<name>` (blob):
 +
-The systems maintains for each canister a generic key-value store, called the “Canister properties”. The system does not interpret these keys and values, but other platform components (e.g. the HTTP gateway protocol or Internet Identity) can.
+The systems maintains for each canister a generic key-value store, called the “canister properties”. These properties are provided by canister aministrators and while the system does not interpret them other platform components (e.g. the HTTP gateway protocol or Internet Identity) may. In contrast, metadata is provided by canister developers and may be interpreted by the system.
 
 The system may impose a size limit on the properties; it allows at least 4KB of combined size of the keys keys and values. Values can be empty.
 
 These properties are configured and kept independently from installing or uninstalling code.
-* disable_ic0_app_service_worker
-* allow_internet_identity_aliases where (blob) is a comma separated of canister ids and/or domains.
 
 
 [#http-interface]

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1587,6 +1587,12 @@ This is atomic: If the response to this request is a `reject`, then this call ha
 
 NOTE: Some canisters may not be able to make sense of callbacks after upgrades; these should be stopped first, to wait for all outstanding callbacks, or be uninstalled first, to prevent outstanding callbacks from being invoked. It is expected that the canister admin (or their tooling) does that separately.
 
+The `wasm_module` field specifies the canister module to be installed.
+The system supports multiple encodings of the `wasm_module` field:
+
+  * If the `wasm_module` starts with byte sequence `[0x00, 'a', 's', 'm']`,  the system parses `wasm_module` as a raw WebAssembly binary.
+  * If the `wasm_module` starts with byte sequence `[0x1f, 0x8b, 0x08]`, the system decompresses the contents of `wasm_module` as a gzip stream according to https://datatracker.ietf.org/doc/html/rfc1952.html[RFC-1952] and then parses the output as a WebAssembly binary.
+
 [#ic-uninstall_code]
 === IC method `uninstall_code`
 

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -440,7 +440,7 @@ It is recommended for the canister to have a custom section called "icp:public c
 
 * `/canister/<canister_id>/property/<name>` (blob):
 +
-The systems maintains for each canister a generic key-value store, called the “canister properties”. These properties are provided by canister aministrators and while the system does not interpret them other platform components (e.g. the HTTP gateway protocol or Internet Identity) may. In contrast, metadata is provided by canister developers and may be interpreted by the system.
+The system maintains for each canister list of key-value pairs, called “canister properties” controlled by canister aministrators and while the system does not interpret them other platform components (e.g. the HTTP gateway protocol or Internet Identity) may. In contrast, metadata is provided by canister developers and may be interpreted by the system.
 
 The system may impose a size limit on the properties; it allows at least 4KB of combined size of the keys keys and values. Values can be empty.
 

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -440,7 +440,7 @@ It is recommended for the canister to have a custom section called "icp:public c
 
 * `/canister/<canister_id>/property/<name>` (blob):
 +
-The system maintains for each canister list of key-value pairs, called “canister properties” controlled by canister aministrators and while the system does not interpret them other platform components (e.g. the HTTP gateway protocol or Internet Identity) may. In contrast, metadata is provided by canister developers and may be interpreted by the system.
+Canister administrators may set and update a list of named canister setting properties.
 
 The system may impose a size limit on the properties; it allows at least 4KB of combined size of the keys keys and values. Values can be empty.
 

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1571,9 +1571,9 @@ Calls to a frozen canister will be rejected (like for a stopping canister). Addi
 +
 Default value: 2592000 (approximately 30 days).
 
-* `properties` (`vec record { name: text; value: opt blob; }`)
+* `properties` (`vec record { name: text; value: blob; }`)
 +
-A set of arbitrary named properties with optional blob values.  The total size of the properties must be less than 4KB.
+A set of arbitrary named properties with arbitrary values. The names in the list must be free of duplicates. See `_state-tree-canister-information`.
 +
 Default value: The empty list.
 


### PR DESCRIPTION
This PR adds support for arbitrary properties which are stored as canister information in the state tree and which are set and updated as canister settings.  The purpose of these properties is to enable or disable system features without having the change the canister WASM.  The immediate use cases are:
* disable the service worker on ic0.app to enable custom service workers or opt out e.g. to enable HTML preview
* allow Internet Identity aliases for domains and/or canister ids

Signed-off-by: John Plevyak <jplevyak@gmail.com>