### PR TITLE
Canister http request - Add a note about the expected caller id

### DIFF
--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1690,6 +1690,7 @@ The returned response (and the response provided to the `transform` function, if
 - `body` - the response's body
 
 The `transform` function may, for example, transform the body in any way, add or remove headers, modify headers, etc.
+When the transform function was invoked due to a canister HTTP request, the caller's identity is the principal of the management canister.
 
 [#ic-provisional_create_canister_with_cycles]
 === IC method `provisional_create_canister_with_cycles`


### PR DESCRIPTION
Follow up of Canister HTTP requests: https://github.com/dfinity/interface-spec/pull/7. 

Motivation: The implementation introduces an "internal query" that does not provide a caller id because the transformation function of the HTTP response is triggered by an internal component from the networking layer.

Given that the transform function is exported as `canister_query`, for consistency, we will return the canister management id if `msg_caller_copy` is called inside the transformation function.
 