### PR TITLE
Canister status - Add flag low on cycles

### DIFF
--- a/spec/ic.did
+++ b/spec/ic.did
@@ -58,6 +58,7 @@ service ic : {
       module_hash: opt blob;
       memory_size: nat;
       cycles: nat;
+      low_on_cycles: bool;
   });
   delete_canister : (record {canister_id : canister_id}) -> ();
   deposit_cycles : (record {canister_id : canister_id}) -> ();

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -2848,6 +2848,10 @@ The controllers of a canister can obtain information about the canister.
 
 The `Memory_size` is the (in this specification underspecified) total size of storage in bytes.
 
+A canister is considered low on cycles when the balance approaches the equivalent value in cycles of the freezing threshold.
+This means that soon the canister will start acting like a frozen one.
+For example, it may not be able to perform calls due to the cost of the call and transferred cycles which push the balance into frozen territory.
+
 Conditions::
 ....
     S.messages = Older_messages · CallMessage M · Younger_messages
@@ -2872,6 +2876,10 @@ S with
           controllers = S.controllers[A.canister_id];
           memory_size = Memory_size;
           cycles = S.balance[A.canister_id];
+          low_on_cycles =
+            if S.balance[A.canister_id] < (freezing_limit(S, A.canister_id) + 100 * MAX_CYCLES_PER_MESSAGE)
+            then true
+            else false
         })
         refunded_cycles = M.transferred_cycles
       }


### PR DESCRIPTION
The developers recently requested a mechanism that would quickly show if the canister is frozen without needing an update call to the canister to find out it was rejected due to low balance.   

Since it is not so simple to say exactly when the canister is going to start behaving like a frozen one unless the balance is below the freezing threshold. But if the balance is slightly above, it may not have enough to perform an operation and still have the leftover balance above the threshold.

So this PR proposes to add a flag that marks the canister as `low on cycles` when the balance is smaller than the sum of the freezing threshold in cycles plus a **flat amount of additional cycles**:

canister.balance < canister.freezing_threshold_cycles + N *  MAX_CYCLES_PER_MESSAGE 
 