### PR TITLE
Canister status - Add Freezing threshold in cycles

### DIFF
--- a/spec/ic.did
+++ b/spec/ic.did
@@ -59,7 +59,7 @@ service ic : {
       memory_size: nat;
       cycles: nat;
       freezing_threshold: nat;
-      freezing_threshold_cycles: nat;
+      freezing_threshold_in_cycles: nat;
   });
   delete_canister : (record {canister_id : canister_id}) -> ();
   deposit_cycles : (record {canister_id : canister_id}) -> ();

--- a/spec/ic.did
+++ b/spec/ic.did
@@ -58,6 +58,8 @@ service ic : {
       module_hash: opt blob;
       memory_size: nat;
       cycles: nat;
+      freezing_threshold: nat;
+      freezing_threshold_cycles: nat;
   });
   delete_canister : (record {canister_id : canister_id}) -> ();
   deposit_cycles : (record {canister_id : canister_id}) -> ();

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -2849,8 +2849,7 @@ The controllers of a canister can obtain information about the canister.
 
 The `Memory_size` is the (in this specification underspecified) total size of storage in bytes.
 
-The `freezing_threshold_cycles` is the freezing threshold in cycles of the canister, which is computed based on its current memory footprint, storage cost, memory and compute allocation, and current `freezing_threshold` setting.
-
+The `freezing_threshold_in_cycles` is the current estimate of the smallest amount of cycles the canister can have without entering the frozen state. The system uses the `freezing_threshold` setting to compute this field.
 
 Conditions::
 ....
@@ -2877,7 +2876,7 @@ S with
           memory_size = Memory_size;
           cycles = S.balance[A.canister_id];
           freezing_threshold = S.freezing_threshold[A.canister_id];
-          freezing_threshold_cycles = freezing_limit(S, A.canister_id);
+          freezing_threshold_in_cycles = freezing_limit(S, A.canister_id);
         })
         refunded_cycles = M.transferred_cycles
       }

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -2849,7 +2849,7 @@ The controllers of a canister can obtain information about the canister.
 
 The `Memory_size` is the (in this specification underspecified) total size of storage in bytes.
 
-The `freezing_threshold_in_cycles` is the current estimate of the smallest amount of cycles the canister can have without entering the frozen state. The system uses the `freezing_threshold` setting to compute this field.
+The `freezing_threshold_in_cycles` is the current estimate of the smallest number of cycles the canister can have without entering the frozen state. The system uses the `freezing_threshold` setting to compute this field.
 
 Conditions::
 ....

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -2849,6 +2849,9 @@ The controllers of a canister can obtain information about the canister.
 
 The `Memory_size` is the (in this specification underspecified) total size of storage in bytes.
 
+The `freezing_threshold_cycles` is the freezing threshold in cycles of the canister, which is computed based on its current memory footprint, storage cost, memory and compute allocation, and current `freezing_threshold` setting.
+
+
 Conditions::
 ....
     S.messages = Older_messages · CallMessage M · Younger_messages
@@ -2873,6 +2876,8 @@ S with
           controllers = S.controllers[A.canister_id];
           memory_size = Memory_size;
           cycles = S.balance[A.canister_id];
+          freezing_threshold = S.freezing_threshold[A.canister_id];
+          freezing_threshold_cycles = freezing_limit(S, A.canister_id);
         })
         refunded_cycles = M.transferred_cycles
       }


### PR DESCRIPTION
This MR enhanced the status of the canister with the freezing threshold in cycles. 
 
This data will be used by the developers and can be used to check when the canister is approaching the freeze threshold in cycles which would mean that the canister may start behaving like a frozen one. In this case, certain operations may fail because there is not enough balance to perform the operation and still have the leftover cycles above the threshold.