### PR TITLE
IC00 HTTP request - Return error via Reject

### DIFF
--- a/spec/ic.did
+++ b/spec/ic.did
@@ -16,23 +16,12 @@ type definite_canister_settings = record {
   freezing_threshold : nat;
 };
 
-type http_header = record { name: text; value: text };
+type http_header = record { name: text; value: blob };
 
 type http_response = record {
   status: nat;
   headers: vec http_header;
   body: blob;
-};
-
-type http_request_error = variant {
-  no_consensus;
-  timeout;
-  bad_tls;
-  invalid_url;
-  transform_error;
-  dns_error;
-  unreachable;
-  conn_timeout;
 };
 
 service ic : {
@@ -70,7 +59,7 @@ service ic : {
     transform : opt variant {
       function: func (http_response) -> (http_response) query
     };
-  }) -> (variant { Ok : http_response; Err: opt http_request_error });
+  }) -> (http_response);
 
   // provisional interfaces for the pre-ledger world
   provisional_create_canister_with_cycles : (record {

--- a/spec/ic.did
+++ b/spec/ic.did
@@ -16,7 +16,7 @@ type definite_canister_settings = record {
   freezing_threshold : nat;
 };
 
-type http_header = record { name: text; value: blob };
+type http_header = record { name: text; value: text };
 
 type http_response = record {
   status: nat;


### PR DESCRIPTION
This MR updates the candid return type for the `http_request` management method. A `Reply` will contain the `http_response`, while any error encountered in IC will be reflected via the `Reject` (reject_code, reject_message).
