### PR TITLE
Clean up changelog (Editorial)

### DIFF
--- a/spec/changelog.adoc
+++ b/spec/changelog.adoc
@@ -5,8 +5,11 @@
 === ∞ (unreleased)
 
 * Canister access to performance metrics
-* Expose Wasm custom sections in the state tree
-* User delegations include a principal scope
+* Expose Wasm custom sections as metadata in the state tree
+* User delegations include a principal scope (`senders`)
+* Canister cycle balances are represnted by 128 bits, and no system-defined upper limit exists anymore
+* Canister modules can be gzip-encoded
+* Canisters can make HTTP requests via the `http_request` method of the management canister
 
 [#0_18_3]
 === 0.18.3 (2022-01-10)

--- a/spec/changelog.adoc
+++ b/spec/changelog.adoc
@@ -4,78 +4,78 @@
 [#unreleased]
 === ∞ (unreleased)
 
-* Spec: Canister access to performance metrics
-* Spec: Expose Wasm custom sections in the state tree
-* Spec: User delegations include a principal scope
+* Canister access to performance metrics
+* Expose Wasm custom sections in the state tree
+* User delegations include a principal scope
 
 [#0_18_3]
 === 0.18.3 (2022-01-10)
 
-* Spec: New System API which uses 128-bit values to represent the amount of cycles
-* Spec: Subnet delegations include a canister id scope
+* New System API which uses 128-bit values to represent the amount of cycles
+* Subnet delegations include a canister id scope
 
 [#0_18_2]
 === 0.18.2 (2021-09-29)
 
-* Spec: Canister heartbeat
-* Spec: Terminology changes
-* Spec: Support for 64-bit stable memory
+* Canister heartbeat
+* Terminology changes
+* Support for 64-bit stable memory
 
 [#0_18_1]
 === 0.18.1 (2021-08-04)
 
-* Spec: Support RSA PKCS#1 v1.5 signatures in web authentication
+* Support RSA PKCS#1 v1.5 signatures in web authentication
 * Spec clarification: Fix various typos and improve textual clarity
 
 [#0_18_0]
 === 0.18.0 (2021-05-18)
 
-* Spec: A canister has a set of controllers, instead of always one
+* A canister has a set of controllers, instead of always one
 
 [#0_17_0]
 === 0.17.0 (2021-04-22)
 
-* Spec: Canister Signatures are introduced
+* Canister Signatures are introduced
 * Spec clarification: the signature in the WebAuthn scheme is prefixed by the CBOR self-identifying tag
-* Spec: Cycle-depleted canisters are forcibly uninstalled
-* Spec: Canister settings in `create_canister` and `update_settings`. `install_code` no longer takes allocation settings.
-* Spec: A freezing threshold can be configured via the canister settings
+* Cycle-depleted canisters are forcibly uninstalled
+* Canister settings in `create_canister` and `update_settings`. `install_code` no longer takes allocation settings.
+* A freezing threshold can be configured via the canister settings
 
 [#0_16_1]
 === 0.16.1 (2021-04-14)
 
-* Spec: The cleanup callback is introduced
+* The cleanup callback is introduced
 
 [#0_16_0]
 === 0.16.0 (2021-03-25)
 
-* Spec: New http v2 API that allows for stateless boundary nodes
+* New http v2 API that allows for stateless boundary nodes
 
 [#0_15_6]
 === 0.15.6 (2021-03-25)
 
-* Spec: The system may impose limits on the number of globals and functions
-* Spec: No ingress messages towards empty canisters are accepted
-* Spec: No ingress messages towards `raw_rand` and `deposit_cycles` are accepted
-* Spec: A memory allocation of `0` means “best effort”
+* The system may impose limits on the number of globals and functions
+* No ingress messages towards empty canisters are accepted
+* No ingress messages towards `raw_rand` and `deposit_cycles` are accepted
+* A memory allocation of `0` means “best effort”
 
 [#0_15_5]
 === 0.15.5 (2021-03-11)
 
-* Spec: deposit_cycles(): any caller allowed
+* deposit_cycles(): any caller allowed
 
 [#0_15_4]
 === 0.15.4 (2021-03-04)
 
-* Spec: Ingress message filtering
-* Spec: Add ECDSA signatures on curve secp256k1
-* Spec: Clarify that the `ic0.data_certificate_present` system function may be
+* Ingress message filtering
+* Add ECDSA signatures on curve secp256k1
+* Clarify that the `ic0.data_certificate_present` system function may be
   called in all contexts.
 
 [#0_15_3]
 === 0.15.3 (2021-02-26)
 
-* Spec: Expose module hash and controller via `read_state`
+* Expose module hash and controller via `read_state`
 
 [#0_15_2]
 === 0.15.2 (2021-02-09)
@@ -85,12 +85,12 @@
 [#0_15_0]
 === 0.15.0 (2020-12-17)
 
-* Spec: Support for raw Ed25519 keys is removed
+* Support for raw Ed25519 keys is removed
 
 [#0_14_1]
 === 0.14.1 (2020-12-08)
 
-* Spec: The default `memory_allocation` becomes unspecified
+* The default `memory_allocation` becomes unspecified
 
 [#0_14_0]
 === 0.14.0 (2020-11-18)
@@ -103,56 +103,50 @@
 [#0_13_2]
 === 0.13.2 (2020-11-12)
 
-* Spec: The `ic0.canister_status` system call
+* The `ic0.canister_status` system call
 
 [#0_13_1]
 === 0.13.1 (2020-11-06)
 
-* Spec: Delegation between user public keys
+* Delegation between user public keys
 
 [#0_13_0]
 === 0.13.0 (2020-10-19)
 
-* Spec: Certification (also removes “request-status” request)
+* Certification (also removes “request-status” request)
 
 [#0_12_2]
 === 0.12.2 (2020-10-23)
 
-* Spec: User authentication method based on WebAuthn is introduced
-* Spec: User authentication can use ECDSA
-* Spec: Public keys are DER-encoded
+* User authentication method based on WebAuthn is introduced
+* User authentication can use ECDSA
+* Public keys are DER-encoded
 
 [#0_12_1]
 === 0.12.1 (2020-10-16)
 
-* Spec: Return more information in the `canister_status` management call
+* Return more information in the `canister_status` management call
 
 [#0_12_0]
 === 0.12.0 (2020-10-13)
 
-* Spec: Anonymous requests must have the sender field set
+* Anonymous requests must have the sender field set
 
 [#0_11_1]
 === 0.11.1 (2020-10-01)
 
-* Spec: The `deposit_funds` call
-* ic-ref(-test): Implement and test the above changes
+* The `deposit_funds` call
 
 [#0_11_0]
 === 0.11.0 (2020-09-23)
 
-* Spec: Inter-canister calls are now performed using a builder-like API
-* Spec: Support for funds (balances and transfers)
+* Inter-canister calls are now performed using a builder-like API
+* Support for funds (balances and transfers)
 
 [#v0_10_3]
 === 0.10.3 (2020-09-21)
 
-* Spec: The anonymous user is introduced
-
-[#v0_10_2]
-=== 0.10.2 (2020-09-08)
-
-* ic-ref(-test): Bugfix: A query response should _not_ include a `time` field
+* The anonymous user is introduced
 
 [#v0_10_1]
 === 0.10.1 (2020-09-01)
@@ -162,23 +156,19 @@
 [#v0_10_0]
 === 0.10.0 (2020-08-06)
 
-* Spec: Users can set/update a memory allocation when installing/upgrading a canister.
-* Spec: The `expiry` field is added to requests
-* ic-ref(-test): Implement and test the above changes, as far as possible
+* Users can set/update a memory allocation when installing/upgrading a canister.
+* The `expiry` field is added to requests
 
 [#v0_9_3]
 === 0.9.3 (2020-09-01)
 
-* Spec: The management canister supports the `raw_rand` method
-* ic-ref(-test): Implement and test the above changes
+* The management canister supports the `raw_rand` method
 
 [#v0_9_2]
 === 0.9.2 (2020-08-05)
 
-* Spec: Canister controllers can stop/start canisters and can query their status.
-* Spec: Canister controllers can delete canisters
-* ic-ref(-test): Implement and test the above changes
-* ic-ref: refactorings
+* Canister controllers can stop/start canisters and can query their status.
+* Canister controllers can delete canisters
 
 [#v0_9_1]
 === 0.9.1 (2020-07-20)
@@ -188,55 +178,46 @@
 [#v0_9_0]
 === 0.9.0 (2020-07-15)
 
-* Spec: Introduction of a domain separator (again)
-* Spec: The calculation of “derived ids” has changed
-* Spec: The self-authenticating and derived id forms use a truncated hash
-* Spec: The textual representation of principals has changed
-* ic-ref(-test): Implement the above changes
-* ic-ref-test: Also send read requests with nonces
+* Introduction of a domain separator (again)
+* The calculation of “derived ids” has changed
+* The self-authenticating and derived id forms use a truncated hash
+* The textual representation of principals has changed
 
 [#v0_8_2]
 === 0.8.2 (2020-07-17)
 
-* ic-ref-test: Also send read requests with nonces
-* Spec: Installing code via `reinstall` works also on the empty canister
-* ic-ref(-test): Implement and test the above changes
+* Installing code via `reinstall` works also on the empty canister
 
 [#v0_8_1]
 === 0.8.1 (2020-07-10)
 
 * Reflect refined process in README and intro.
-* Spec: `ic0.time` added
-* ic-ref(-test): Implement and test `ic0.time`
+* `ic0.time` added
 
 [#v0_8_0]
 === 0.8.0 (2020-06-23)
 
-* Spec: Revert the introduction of a domain separator
-* ic-ref(-test): Implement and test the above changes
+* Revert the introduction of a domain separator
 
 [#v0_6_2]
 === 0.6.2 (2020-06-23)
 
-* Spec: Fix meaning-changing typos in `ic.did`
-* ic-ref-test: Be more liberal about the precise reject code in some cases.
+* Fix meaning-changing typos in `ic.did`
 
 [#v0_6_0]
 === 0.6.0 (2020-06-08)
 
-* Spec: Make all canister ids system-chosen
-* Spec: HTTP requests for management features are removed
-* ic-ref(-test): Implement and test the above changes
+* Make all canister ids system-chosen
+* HTTP requests for management features are removed
 
 [#v0_4_0]
 === 0.4.0 (2020-05-25)
 
-* Spec (editorial): the term “principal” is now used for the _id_ of a canister or
+* (editorial) the term “principal” is now used for the _id_ of a canister or
   user, not the canister or user itself
-* Spec: The signature of a request needs to be calculated using a domain separator
-* Spec: Describe the `controller` attribute, add a request to change it
-* Spec: The IC management canister is introduced
-* ic-ref(-test): Implement and test the above changes
+* The signature of a request needs to be calculated using a domain separator
+* Describe the `controller` attribute, add a request to change it
+* The IC management canister is introduced
 
 [#v0_2_16]
 === 0.2.16 (2020-05-29)
@@ -246,63 +227,19 @@
 [#v0_2_14]
 === 0.2.14 (2020-05-14)
 
-* Spec: Bugfix: Mode should be `reinstall`, not `replace`
-* ic-ref-test: A few more tests, refactorings
-
-[#v0_2_12]
-=== 0.2.12 (2020-05-06)
-
-* ic-ref-test: Remove code to work around lack of creater canister.
-* ic-ref-test: Stricter tests for bad signatures
-* ic-ref: Also accept CBOR maps of indeterminate length
-
-[#v0_2_10]
-=== 0.2.10 (2020-04-29)
-
-* ic-ref: Bind to 127.0.0.1 instead of 0.0.0.0
-* ic-ref: Set content-type even for error responses
-* ic-ref-test: Tests related to query calls
-* ic-ref-test: Test “reply after trap in prior callback”
+* Bugfix: Mode should be `reinstall`, not `replace`
 
 [#v0_2_8]
 === 0.2.8 (2020-04-23)
 
-* Spec: Include section with CDDL description
-* ic-ref-test: Block less tests on `create_canister` support
-
-[#v0_2_6]
-=== 0.2.6 (2020-04-01)
-
-* ic-ref-run: Accept any canister id in `install` commands
-* ic-ref-test: More defensive printing of HTTP bodies
+* Include section with CDDL description
 
 [#v0_2_4]
 === 0.2.4 (2020-03-23)
 
 * simplify versioning (only three components), skip 0.2.2 to avoid confusion with 0.2.0.2
-* spec: Clarification: `reply` field is always present
-* spec: General cleanup based on front-to-back reading
-* ic-ref(-test): Enforce signature checking
-* ic-ref(-test): Desired canister ids must be derived from sender
-* ic-ref(-test): Require the 55799 semantic CBOR tag, as specified
-* ic-ref: Ignore duplicate requests
-* ic-ref-test: Run more tests independent of each other (try `-j 8`)
-* ic-ref-test: Submit requests with nonces
-* ic-ref-test: Test various trap conditions in reply and reject callbacks.
-* ic-ref-test: Test that `ic0.debug_print` with invalid bounds does _not_ trap
-* ic-ref-test: Allow unspecified fields to appear in the status response
-* ic-ref-test: Canister upgrade tests
-
-[#v0_2_0_2]
-=== 0.2.0.2 (2020-03-19)
-
-* ic-ref: Return status 202, empty body, on `submit`, to match spec
-* ic-ref: Allow update or inter-canister calls to query methods
-* ic-ref: Trap upon calls from queries
-* ic-ref-test: If the IC does not claim to be spec compliant, always succeed
-  (but still report errors)
-* ic-ref-test: Support --html reports
-* ic-ref-test: Use the “Universal Canister” to drive tests; more tests.
+* Clarification: `reply` field is always present
+* General cleanup based on front-to-back reading
 
 [#v0_2_0_0]
 === 0.2.0.0 (2020-03-11)


### PR DESCRIPTION
now that this repo no longer contains what is in
https://github.com/dfinity/ic-hs it seems prudent to remove the non-spec
entries from the changelog. Will also make more sense on
https://smartcontracts.org/docs/interface-spec/index.html#changelog