### PR TITLE
Canister status - Add idle consumption rate 

### DIFF
--- a/spec/ic.did
+++ b/spec/ic.did
@@ -48,7 +48,7 @@ service ic : {
       memory_size: nat;
       cycles: nat;
       freezing_threshold: nat;
-      freezing_threshold_in_cycles: nat;
+      idle_cycles_burned_per_second: float64;
   });
   delete_canister : (record {canister_id : canister_id}) -> ();
   deposit_cycles : (record {canister_id : canister_id}) -> ();

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -2849,7 +2849,7 @@ The controllers of a canister can obtain information about the canister.
 
 The `Memory_size` is the (in this specification underspecified) total size of storage in bytes.
 
-The `freezing_threshold_in_cycles` is the current estimate of the smallest number of cycles the canister can have without entering the frozen state. The system uses the `freezing_threshold` setting to compute this field.
+The `idle_cycles_burned_per_second` is the idle consumption of resources in cycles per second. Therefore, the freezing threshold in cycles can be obtained using the following formula: `freezing_threshold` (in seconds) * `idle_cycles_burned_per_second`.
 
 Conditions::
 ....
@@ -2876,7 +2876,7 @@ S with
           memory_size = Memory_size;
           cycles = S.balance[A.canister_id];
           freezing_threshold = S.freezing_threshold[A.canister_id];
-          freezing_threshold_in_cycles = freezing_limit(S, A.canister_id);
+          idle_cycles_burned_per_second = freezing_limit(S, A.canister_id) / freezing_threshold;
         })
         refunded_cycles = M.transferred_cycles
       }


### PR DESCRIPTION
This PR as discussed in a previous [PR](https://github.com/dfinity/interface-spec/pull/18#issuecomment-1090303378), adds the idle consumption rate of the resources of a canister. This can be used to compute the freezing threshold in cycles.