### PR TITLE
CI: Add a netlify configuration

### DIFF
--- a/.netlify.sh
+++ b/.netlify.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+#
+# Deploy a preview of the interface specification to netlify
+#
+
+set -e
+
+export NP_GIT=$(which git)
+
+wget -nv https://github.com/DavHau/nix-portable/releases/download/v009/nix-portable
+chmod +x nix-portable
+
+./nix-portable nix-build -A interface-spec default.nix
+
+# The "result" symlink only valid inside the nix-portable sandbox, so use nix-shell
+./nix-portable nix-shell -p bash --run "cp -rL result/spec/ _netlify-deploy"
+
+chmod -R u+w _netlify-deploy

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  command = "./.netlify.sh"
+  publish = "_netlify-deploy"


### PR DESCRIPTION
It is really very useful use to have rendered previews of PRs easily available online, and also of the `master` branch, and Netlify is the easiest way to to achieve that.

This PR, which fixes #9, provides a simple netlify configuration using the existing nix builds. No further configuration or infrastructure is needed (e.g. no extra caches or such).

So all we need to get this live is 

 * merge this PR
 * someone with sufficient permissions creates a new site at netlify (I suggest `ic-interface-spec.netlify.app` to begin with) and adds this repo

I think the default configuration works just fine, and will create preview deployes for PRs. 

They will look like this: https://ic-spec-pr-preview.netlify.app/