### PR TITLE
Editorial: M.receiver, not C.callee

### DIFF
--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -2666,7 +2666,7 @@ then
             call_context = M.call_context;
             callback = call.callback
           };
-          caller = C.callee;
+          caller = M.receiver;
           callee = call.callee;
           method_name = call.method_name;
           arg = call.arg;


### PR DESCRIPTION
probably a fallout from the cherry-pick in
d442081f8c060017708f583c85d327f39e3404de.