### PR TITLE
Add a maximal response size parameter for the HTTP Request feature

### DIFF
--- a/spec/ic.did
+++ b/spec/ic.did
@@ -57,7 +57,7 @@ service ic : {
   raw_rand : () -> (blob);
   http_request : (record {
     url : text;
-    max_response_size: opt nat;
+    max_response_bytes: opt nat;
     method : variant { get };
     headers: vec http_header;
     body : opt blob;

--- a/spec/ic.did
+++ b/spec/ic.did
@@ -57,6 +57,7 @@ service ic : {
   raw_rand : () -> (blob);
   http_request : (record {
     url : text;
+    max_response_size: opt nat;
     method : variant { get };
     headers: vec http_header;
     body : opt blob;

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1637,7 +1637,7 @@ For security reasons, only HTTPS connections are allowed (URLs must start with `
 
 The maximal size of a request URL is 2048 bytes.
 
-Each request should specify the maximal expected size for the response. The maximal size of a response is `2MiB`. Therefore, only the first number of bytes as specified in the request (up to 2MiB), will be returned if a response is larger than these limits. The 2MiB size limit also applies to the value returned by the `transform` function.
+Each request should specify the maximal expected size for the response. The upper limit on the size of a response is `2MiB`. Therefore, only the first number of bytes as specified in the request (up to 2MiB), will be returned if a response is larger than these limits. The 2MiB size limit also applies to the value returned by the `transform` function.
 
 
 The following parameters should be supplied for the call:

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1637,11 +1637,13 @@ For security reasons, only HTTPS connections are allowed (URLs must start with `
 
 The maximal size of a request URL is 2048 bytes.
 
-The maximal size of a response is `2MiB`. Therefore, only the first `2MiB` will be returned if a response is larger than this size. This size limit also applies to the value returned by the `transform` function.
+Each request should specify the maximal expected size for the response. The maximal size of a response is `2MiB`. Therefore, only the first number of bytes as specified in the request (up to 2MiB), will be returned if a response is larger than these limits. The 2MiB size limit also applies to the value returned by the `transform` function.
+
 
 The following parameters should be supplied for the call:
 
 - `url` - the requested URL
+- `max_response_size` - the maximal size of the response. The call will be charged based on this parameter. The raw response (before applying the `transform` function) will be truncated if necessary, but can be longer than the given value.
 - `method` - currently, only GET is supported
 - `headers` - list of HTTP request headers and their corresponding values
 - `transform` - an optional function that transforms raw responses to sanitized responses. If provided, the calling canister itself must export this function.

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1647,14 +1647,14 @@ Currently, only the `GET` method is supported for HTTP requests.
 
 For security reasons, only HTTPS connections are allowed (URLs must start with `https://`). The IC uses industry-standard root CA lists to validate certificates of remote web servers.
 
-Each request can specify the maximal expected size for the response. The upper limit on the size of a response is `2MiB` if no maximal size value is specified.
+Each request can specify the maximal expected size for the response from the remote HTTP server. The upper limit on the size of a response defaults to `2MiB` if no maximal size value is specified.
 An error will be returned when the response is larger than the maximal size. 
 The `2MiB` size limit also applies to the value returned by the `transform` function.
 
 The following parameters should be supplied for the call:
 
 - `url` - the requested URL
-- `max_response_size` - optinal, specifies the maximal size of the response in bytes. The call will be charged based on this parameter. If not provided, the maximum of `2MiB` will be used.
+- `max_response_bytes` - optional, specifies the maximal size of the response in bytes. The call will be charged based on this parameter. If not provided, the maximum of `2MiB` will be used.
 - `method` - currently, only GET is supported
 - `headers` - list of HTTP request headers and their corresponding values
 - `transform` - an optional function that transforms raw responses to sanitized responses. If provided, the calling canister itself must export this function.

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1635,8 +1635,8 @@ Currently, only the `GET` method is supported for HTTP requests.
 
 For security reasons, only HTTPS connections are allowed (URLs must start with `https://`). The IC uses industry-standard root CA lists to validate certificates of remote web servers.
 
-Each request can specify the maximal expected size for the response. The upper limit on the size of a response is `2MiB`.
-If the response is larger than the specified size, or than `2MiB` if no maxmial size is specified, an error will be returned.
+Each request can specify the maximal expected size for the response. The upper limit on the size of a response is `2MiB` if no maximal size value is specified.
+An error will be returned when the response is larger than the maximal size. 
 The `2MiB` size limit also applies to the value returned by the `transform` function.
 
 The following parameters should be supplied for the call:

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1635,15 +1635,14 @@ Currently, only the `GET` method is supported for HTTP requests.
 
 For security reasons, only HTTPS connections are allowed (URLs must start with `https://`). The IC uses industry-standard root CA lists to validate certificates of remote web servers.
 
-The maximal size of a request URL is 2048 bytes.
-
-Each request should specify the maximal expected size for the response. The upper limit on the size of a response is `2MiB`. Therefore, only the first number of bytes as specified in the request (up to 2MiB), will be returned if a response is larger than these limits. The 2MiB size limit also applies to the value returned by the `transform` function.
-
+Each request can specify the maximal expected size for the response. The upper limit on the size of a response is `2MiB`.
+If the response is larger than the specified size, or than `2MiB` if no maxmial size is specified, an error will be returned.
+The `2MiB` size limit also applies to the value returned by the `transform` function.
 
 The following parameters should be supplied for the call:
 
 - `url` - the requested URL
-- `max_response_size` - the maximal size of the response. The call will be charged based on this parameter. The raw response (before applying the `transform` function) will be truncated if necessary, but can be longer than the given value.
+- `max_response_size` - optinal, specifies the maximal size of the response in bytes. The call will be charged based on this parameter. If not provided, the maximum of `2MiB` will be used.
 - `method` - currently, only GET is supported
 - `headers` - list of HTTP request headers and their corresponding values
 - `transform` - an optional function that transforms raw responses to sanitized responses. If provided, the calling canister itself must export this function.


### PR DESCRIPTION
We would like to add a new parameter for the HTTP request feature to specify the maximal size of the response.
This will be used for charging the requests and for limiting the bandwidth used by the feature.