### PR TITLE
EXC-1122: Update idle_cycles_burned

### DIFF
--- a/spec/changelog.adoc
+++ b/spec/changelog.adoc
@@ -4,7 +4,7 @@
 [#unreleased]
 === ∞ (unreleased)
 
-* Spec: Idle consumption of resources in cycles per hour can be obtain via `canister_status` method of the management canister
+* Spec: Idle consumption of resources in cycles per day can be obtain via `canister_status` method of the management canister
 * Spec: Canister access to performance metrics
 * Spec: Expose Wasm custom sections in the state tree
 * Spec: User delegations include a principal scope

--- a/spec/changelog.adoc
+++ b/spec/changelog.adoc
@@ -4,6 +4,7 @@
 [#unreleased]
 === ∞ (unreleased)
 
+* Spec: Idle consumption of resources in cycles per hour can be obtain via `canister_status` method of the management canister
 * Spec: Canister access to performance metrics
 * Spec: Expose Wasm custom sections in the state tree
 * Spec: User delegations include a principal scope

--- a/spec/ic.did
+++ b/spec/ic.did
@@ -100,8 +100,7 @@ service ic : {
       module_hash: opt blob;
       memory_size: nat;
       cycles: nat;
-      freezing_threshold: nat;
-      idle_cycles_burned_per_second: float64;
+      idle_cycles_burned_per_hour: nat;
   });
   delete_canister : (record {canister_id : canister_id}) -> ();
   deposit_cycles : (record {canister_id : canister_id}) -> ();

--- a/spec/ic.did
+++ b/spec/ic.did
@@ -100,7 +100,7 @@ service ic : {
       module_hash: opt blob;
       memory_size: nat;
       cycles: nat;
-      idle_cycles_burned_per_hour: nat;
+      idle_cycles_burned_per_day: nat;
   });
   delete_canister : (record {canister_id : canister_id}) -> ();
   deposit_cycles : (record {canister_id : canister_id}) -> ();

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -3083,7 +3083,7 @@ The controllers of a canister can obtain information about the canister.
 
 The `Memory_size` is the (in this specification underspecified) total size of storage in bytes.
 
-The `idle_cycles_burned_per_second` is the idle consumption of resources in cycles per second. Therefore, the freezing threshold in cycles can be obtained using the following formula: `freezing_threshold` (in seconds) * `idle_cycles_burned_per_second`.
+The `idle_cycles_burned_per_hour` is the idle consumption of resources in cycles per hour. Therefore, the freezing threshold in cycles can be obtained using the following formula: `freezing_threshold` (in seconds) * `idle_cycles_burned_per_hour` /  3600 (seconds).
 
 Conditions::
 ....
@@ -3110,7 +3110,7 @@ S with
           memory_size = Memory_size;
           cycles = S.balance[A.canister_id];
           freezing_threshold = S.freezing_threshold[A.canister_id];
-          idle_cycles_burned_per_second = freezing_limit(S, A.canister_id) / freezing_threshold;
+          idle_cycles_burned_per_hour = freezing_limit(S, A.canister_id) / freezing_threshold * 3600;
         })
         refunded_cycles = M.transferred_cycles
       }

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -3083,7 +3083,7 @@ The controllers of a canister can obtain information about the canister.
 
 The `Memory_size` is the (in this specification underspecified) total size of storage in bytes.
 
-The `idle_cycles_burned_per_hour` is the idle consumption of resources in cycles per hour. Therefore, the freezing threshold in cycles can be obtained using the following formula: `freezing_threshold` (in seconds) * `idle_cycles_burned_per_hour` /  3600 (seconds).
+The `idle_cycles_burned_per_day` is the idle consumption of resources in cycles per day. Therefore, the freezing threshold in cycles can be obtained using the following formula: `freezing_threshold` (in seconds) * `idle_cycles_burned_per_day` /  (24 * 3600) (seconds).
 
 Conditions::
 ....
@@ -3110,7 +3110,7 @@ S with
           memory_size = Memory_size;
           cycles = S.balance[A.canister_id];
           freezing_threshold = S.freezing_threshold[A.canister_id];
-          idle_cycles_burned_per_hour = freezing_limit(S, A.canister_id) / freezing_threshold * 3600;
+          idle_cycles_burned_per_day = freezing_limit(S, A.canister_id) / freezing_threshold * 3600 * 24;
         })
         refunded_cycles = M.transferred_cycles
       }

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -3083,7 +3083,7 @@ The controllers of a canister can obtain information about the canister.
 
 The `Memory_size` is the (in this specification underspecified) total size of storage in bytes.
 
-The `idle_cycles_burned_per_day` is the idle consumption of resources in cycles per day. Therefore, the freezing threshold in cycles can be obtained using the following formula: `freezing_threshold` (in seconds) * `idle_cycles_burned_per_day` /  (24 * 3600) (seconds).
+The `idle_cycles_burned_per_day` is the idle consumption of resources in cycles per day. Therefore, the freezing threshold in cycles can be obtained using the following formula: `freezing_threshold` (in seconds) * `idle_cycles_burned_per_day` /  (3600 * 24) (seconds).
 
 Conditions::
 ....


### PR DESCRIPTION
Based on previous MR  https://github.com/dfinity/interface-spec/pull/31, which introduced `idle_cycles_burned_seconds`, and a few follow-up discussions, there was reached the agreement that we should avoid `float` types in the replica. 

This MR:
* change `idle_cycles_burned_seconds` the type from float to nat.
* due to the previous change,  we lose some precision. Therefore, to increase the precision we will provide `idle_cycles_burned_hour`.
* fix: remove `freezing_threshold: nat;` from the canister status. It is already specified in the `definite_canister_settings `.