### PR TITLE
Add network parameter to bitcoin_get_current_fee_percentiles

### DIFF
--- a/spec/ic.did
+++ b/spec/ic.did
@@ -57,6 +57,10 @@ type get_utxos_request = record {
   };
 };
 
+type get_current_fee_percentiles_request = record {
+  network: bitcoin_network;
+};
+
 type get_utxos_response = record {
   utxos: vec utxo;
   tip_block_hash: block_hash;
@@ -132,7 +136,7 @@ service ic : {
   bitcoin_get_balance: (get_balance_request) -> (satoshi);
   bitcoin_get_utxos: (get_utxos_request) -> (get_utxos_response);
   bitcoin_send_transaction: (send_transaction_request) -> ();
-  bitcoin_get_current_fee_percentiles: () -> (vec millisatoshi_per_byte);
+  bitcoin_get_current_fee_percentiles: (get_current_fee_percentiles_request) -> (vec millisatoshi_per_byte);
 
   // provisional interfaces for the pre-ledger world
   provisional_create_canister_with_cycles : (record {

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1792,7 +1792,7 @@ The transaction fees in the Bitcoin network change dynamically based on the numb
 pending transactions.
 It must be possible for a canister to determine an adequate fee when creating a Bitcoin transaction.
 
-This function returns the 100 fee percentiles, measured in millisatoshi/byte (10^3 millisatoshi = 1 satoshi), over the last 10,000 transactions, i.e.,
+This function returns the 100 fee percentiles, measured in millisatoshi/byte (10^3 millisatoshi = 1 satoshi), over the last 10,000 transactions in the specified network, i.e.,
 over the transactions in the last approximately 4-10 blocks.
 
 [#certification]


### PR DESCRIPTION
The network parameter is necessary in that endpoint for us to distinguish whether the user
wants the fee percentiles of mainnet or testnet.

Note that this change is not backward-compatible, but the API was never made public so
this change is acceptable.