### PR TITLE
define freezing_limit in terms of idle_cycles_burned_per_day

### DIFF
--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -3091,7 +3091,7 @@ The controllers of a canister can obtain information about the canister.
 
 The `Memory_size` is the (in this specification underspecified) total size of storage in bytes.
 
-The `idle_cycles_burned_per_day` is the idle consumption of resources in cycles per day. Therefore, the freezing threshold in cycles can be obtained using the following formula: `freezing_threshold` (in seconds) * `idle_cycles_burned_per_day` /  (3600 * 24) (seconds).
+The `idle_cycles_burned_per_day` is the idle consumption of resources in cycles per day. Therefore, the freezing threshold in cycles can be obtained using the following formula: (`freezing_threshold` (seconds) * `idle_cycles_burned_per_day`) / (3600 * 24 (seconds)).
 
 Conditions::
 ....
@@ -3118,7 +3118,7 @@ S with
           memory_size = Memory_size;
           cycles = S.balance[A.canister_id];
           freezing_threshold = S.freezing_threshold[A.canister_id];
-          idle_cycles_burned_per_day = freezing_limit(S, A.canister_id) / freezing_threshold * 3600 * 24;
+          idle_cycles_burned_per_day = (freezing_limit(S, A.canister_id) * 3600 * 24) / freezing_threshold;
         })
         refunded_cycles = M.transferred_cycles
       }

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -2698,7 +2698,14 @@ S with
 
 A call to a canister which is stopping, stopped, or frozen is automatically rejected.
 
-The (unspecified) function `freezing_limit(S, cid)` determines the freezing threshold in cycles of the canister with id `cid`, given its current memory footprint, storage cost, memory and compute allocation, and current `freezing_threshold` setting.
+The (unspecified) function `idle_cycles_burned_rate(S, cid)` determines the idle resource consumption rate in cycles per day of the canister with id `cid`,
+given its current memory footprint, compute and storage cost, and memory and compute allocation.
+The function `freezing_limit(S, cid)` determines the freezing threshold in cycles of the canister with id `cid`,
+given its current memory footprint, compute and storage cost, memory and compute allocation, and current `freezing_threshold` setting.
+The value `freezing_limit(S, cid)` is derived from `idle_cycles_burned_rate(S, cid)` and `freezing_threshold` as follows:
+....
+    freezing_limit(S, cid) = idle_cycles_burned_rate(S, cid) * S.freezing_threshold[cid] / (24 * 60 * 60)
+....
 
 Conditions::
 ....
@@ -3091,7 +3098,7 @@ The controllers of a canister can obtain information about the canister.
 
 The `Memory_size` is the (in this specification underspecified) total size of storage in bytes.
 
-The `idle_cycles_burned_per_day` is the idle consumption of resources in cycles per day. Therefore, the freezing threshold in cycles can be obtained using the following formula: (`freezing_threshold` (seconds) * `idle_cycles_burned_per_day`) / (3600 * 24 (seconds)).
+The `idle_cycles_burned_per_day` is the idle consumption of resources in cycles per day.
 
 Conditions::
 ....
@@ -3118,7 +3125,7 @@ S with
           memory_size = Memory_size;
           cycles = S.balance[A.canister_id];
           freezing_threshold = S.freezing_threshold[A.canister_id];
-          idle_cycles_burned_per_day = (freezing_limit(S, A.canister_id) * 3600 * 24) / freezing_threshold;
+          idle_cycles_burned_per_day = idle_cycles_burned_rate(S, A.canister_id);
         })
         refunded_cycles = M.transferred_cycles
       }


### PR DESCRIPTION
Because `freeze_threshold` can be equal to zero, the equation
```
idle_cycles_burned_per_day = freezing_limit * seconds_per_day / freeze_threshold
```
might yield undefined value (if `freeze_threshold = 0`).

Hence, we make  `idle_cycles_burned_per_day` unspecified and derive `freezing_limit` from  `idle_cycles_burned_per_day` and `freeze_threshold`.