### PR TITLE
Update query call prose to cover the case of frozen canisters

### DIFF
--- a/spec/changelog.adoc
+++ b/spec/changelog.adoc
@@ -6,6 +6,7 @@
 
 * Spec: Canister access to performance metrics
 * Spec: User delegations include a principal scope
+* Spec: Query calls are rejected when the canister is frozen
 
 [#0_18_5]
 === 0.18.5 (2022-07-08)

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -3718,7 +3718,7 @@ S with
 
 ==== Query call
 
-Canister query calls to `/api/v2/canister/<ECID>/query` can be executed directly.  They can only be executed against canisters which are `Running`.
+Canister query calls to `/api/v2/canister/<ECID>/query` can be executed directly.  They can only be executed against canisters which have a status of `Running` and are also not frozen.
 
 During the execution of a query call, a certificate is provided to the canister that is valid, contains a current state tree (or “recent enough”; the specification is currently vague about how old the certificate may be) and reveals the canister’s <<system-api-certified-data,Certified Data>>.
 
@@ -3730,7 +3730,7 @@ Conditions::
   is_effective_canister_id(E.content, ECID)
   S.system_time <= Q.ingress_expiry
   S.canisters[Q.canister_id] ≠ EmptyCanister
-  S.canister_status[Q.canister_id] = Running
+  S.canister_status[Q.canister_id] = Running ∧ S.balances[Q.canister_id] >= freezing_limit(S, Q.canister_id)
   C = S.canisters[Q.canister_id]
   F = C.module.query_methods[Q.method_name]
   Arg = {


### PR DESCRIPTION
Canisters are currently allowed to execute query calls even if when they are frozen. This can lead to confusion as canisters with heavy or query-only workload can look as if they're completely fine and can catch canister owners off-guard as their canister can get uninstalled even they are not proactive enough to monitor its cycles balance closely. On top of this, query calls will be charged cycles anyway in the future, so disallowing queries to frozen canisters seems like a reasonable thing to enforce.