### PR TITLE
Cut release 0.18.6

### DIFF
--- a/.github/workflows/isabelle.yml
+++ b/.github/workflows/isabelle.yml
@@ -1,0 +1,23 @@
+name: Build on Ubuntu
+on:
+  push:
+    paths:
+      - 'theories/**'
+
+jobs:
+  isabelle:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Run Isabelle with Docker
+        uses: addnab/docker-run-action@v3
+        with:
+          image: martin2718/isabelle
+          options: -v ${{ github.workspace }}:/interface-spec
+          run: Isabelle/bin/isabelle build -e -v -D /interface-spec/theories/
+      - name: Haskell Code
+        uses: actions/upload-artifact@v2
+        with:
+          name: haskell-code
+          path: ${{ github.workspace }}/theories/code

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ spec/index.html
 spec/*.png
 spec/.asciidoctor/
 impl/.tasty-rerun-log
+theories/code

--- a/README.md
+++ b/README.md
@@ -30,6 +30,26 @@ The `master` branch contains finished designs, but is not directly scheduled
 for implementation. It lists version version number `∞`. The reference
 implementation on this branch typically does _not_ fully implement the spec. This branch should always be “ahead” of all the release branches.
 
+## Formal Model
+
+We are developing a formal model of Interface Spec in the interactive theorem prover [Isabelle/HOL](https://isabelle.in.tum.de/).
+The formal development is included in the directory `theories/`.
+
+To setup the environment, follow the standard [instructions](https://isabelle.in.tum.de/installation.html) for Isabelle/HOL.
+Additionally, you may want to setup `isabelle` as an alias for the path `bin/isabelle` in your local Isabelle directory.
+
+To browse the formal model, open Isabelle/jEdit:
+```
+isabelle jedit theories/IC.thy
+```
+from the root directory of this repository.
+
+To build the formal model and export Haskell code from the formal model, run
+```
+isabelle build -e -v -D theories/
+```
+in the root directory of this repository. The exported Haskell code can then be found under `theories/code/`.
+
 ## Contributing
 
 This repository accepts external contributions, conditioned on acceptance of the [https://github.com/dfinity/cla/](Contributor Lincense Agreement).

--- a/spec/changelog.adoc
+++ b/spec/changelog.adoc
@@ -6,6 +6,7 @@
 * Canister access to performance metrics
 * Query calls are rejected when the canister is frozen
 * Support for implementation-specific error codes for requests
+* Formal model in Isabelle
 
 [#0_18_5]
 === 0.18.5 (2022-07-08)

--- a/spec/changelog.adoc
+++ b/spec/changelog.adoc
@@ -6,6 +6,8 @@
 * Canister access to performance metrics
 * Query calls are rejected when the canister is frozen
 * Support for implementation-specific error codes for requests
+* Deleted call contexts do not prevent canister from reaching Stopped state
+* Update effective canister id checks in certificate delegations
 * Formal model in Isabelle
 
 [#0_18_5]

--- a/spec/changelog.adoc
+++ b/spec/changelog.adoc
@@ -1,6 +1,12 @@
 [#changelog]
 == Changelog
 
+[#0_18_6]
+=== 0.18.6 (2022-08-09)
+* Canister access to performance metrics
+* Query calls are rejected when the canister is frozen
+* Support for implementation-specific error codes for requests
+
 [#0_18_5]
 === 0.18.5 (2022-07-08)
 * Idle consumption of resources in cycles per day can be obtain via `canister_status` method of the management canister

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -543,7 +543,10 @@ The HTTP response to this request consists of a CBOR map with the following fiel
 
 * `certificate` (`blob`): A certificate (see <<certification>>).
 +
-If this `certificate` includes subnet delegations (possibly nested), then the `effective_canister_id` must be included in each delegation’s canister id range (see <<certification-delegation>>), unless the `effective_canister_id` is that of the Management Canister (`aaaaa-aa`). In other words, we define `aaaaa-aa` to belong to every canister range for the purposes of certificate checking. Note that `aaaaa-aa` is a valid canister id only for calls to `provisional_create_canister_with_cycles`, so it cannot appear in `read_state` requests on production networks.
+If this `certificate` includes subnet delegations (possibly nested), then the `effective_canister_id` must be included in each delegation’s canister id range (see <<certification-delegation>>), unless
+- the `effective_canister_id` is that of the Management Canister (`aaaaa-aa`),
+- all requested paths have `/request_status/<request_id>` as prefix where the (single) original request referenced by `<request_id>` is an update call to the Management Canister (`aaaaa-aa`) and the method name is `provisional_create_canister_with_cycles`, and
+- whenever the certificate contains the path `/request_status/<request_id>/reply`, then its value is a Candid-encoded record with a `canister_id` field of type `principal` and the `canister_id` must be included in each delegation’s canister id range.
 
 The returned certificate reveals all values whose path is a suffix of the list of requested paths. It also always reveals `/time`, even if not explicitly requested.
 
@@ -551,10 +554,10 @@ All requested paths must have one of the following paths as prefix:
 
  * `/time`. Can be requested by anyone.
  * `/subnet`. Can be requested by anyone.
- * `/request_status/<request_id>`. Can only be read if `/request_id/<request_id>` is not present in the state tree, or if this `read_state` request was signed by same sender as the original request referenced by `<request_id>`, and the effective canister id of the original request matches the `<effective_canister_id>` (see <<http-effective-canister-id>>) in this HTTP request’s path.
- * `/canisters/<canister_id>/module_hash`. Can be requested by anyone, if `<canister_id>` matches `<effective_canister_id>`.
- * `/canisters/<canister_id>/controllers`. Can be requested by anyone, if `<canister_id>` matches `<effective_canister_id>`. The order may vary depending on the implementation.
- * `/canisters/<canister_id>/metadata/<name>`. Can be read by anyone if `<canister_id>` matches `<effective_canister_id>`, and `<name>` is a public custom section. If `<name>` is a private custom section, it can only be read if this `read_state` request was signed by one of the controllers of the canister.
+ * `/request_status/<request_id>`. Can only be requested by the same sender as the original request referenced by `<request_id>` and if the effective canister id of the original request matches `<effective_canister_id>`.
+ * `/canisters/<canister_id>/module_hash`. Can be requested by anyone if `<canister_id>` matches `<effective_canister_id>`.
+ * `/canisters/<canister_id>/controllers`. Can be requested by anyone if `<canister_id>` matches `<effective_canister_id>`. The order may vary depending on the implementation.
+ * `/canisters/<canister_id>/metadata/<name>`. Can be requested by anyone if `<canister_id>` matches `<effective_canister_id>` and `<name>` is a public custom section. If `<name>` is a private custom section, it can only be requested by the controllers of the canister.
 
 Note that the paths `/canisters/<canister_id>/certified_data` are not accessible with this method; these paths are only exposed to the canister themselves via the System API (see <<system-api-certified-data>>).
 
@@ -592,25 +595,24 @@ Canister methods that do not change the canister state can be executed more effi
 
 The `<effective_canister_id>` in the URL paths of requests is the _effective_ destination of the request.
 
-* If the call is to the Management Canister (`aaaaa-aa`), then:
-   - If the `arg` is Candid-encoded where the first argument is a record with a `canister_id` field of type `principal`, then the effective canister id is that principal.
-   - Otherwise, if the call is to the `provisional_create_canister_with_cycles` method, then any principal is a valid effective canister id for this call.
-   - Otherwise, there is no effective canister id. In particular, the `create_canister` and `raw_rand` methods have no effective canister ID, and these methods cannot be called by users, only via canisters.
+* If the request is an update call to the Management Canister (`aaaaa-aa`), then:
+   - If the call is to the `provisional_create_canister_with_cycles` method, then any principal can be used as the effective canister id for this call.
+   - Otherwise, if the `arg` is a Candid-encoded record with a `canister_id` field of type `principal`, then the effective canister id must be that principal.
+   - Otherwise, the call is rejected by the system independently of the effective canister id.
+
+* If the request is an update call to a canister that is not the Management Canister (`aaaaa-aa`) or if the request is a query call, then the effective canister id must be the `canister_id` in the request.
 
 +
 [NOTE]
 ====
-The Internet Computer blockchain mainnet does not support `provisional_create_canister_with_cycles`. This means that using an effective canister id that could be an existing canister would lead to the request being routed to a node on the corresponding subnet and produce an error response there, while using an effective canister id that cannot be an existing canister id would cause an error response from the node receiving the request -- either is fine.
+The expectation is that user-side agent code shields users and developers from the notion of effective canister ID, in analogy to how the System API interface shields canister developers from worrying about routing.
 
-In multi-subnet development instances of the Internet Computer Protocol (e.g. testnets), users with privileged access to `provisional_create_canister_with_cycles` (or possibly similar, internal methods) and knowledge of the mapping from canisters to subnets can use their choice of the effective canister id in the URL to steer the request to a specific subnet.
+The Internet Computer blockchain mainnet rejects all requests whose effective canister id is in no subnet's canister ranges, independently of whether the remaining conditions on the effective canister id are satisfied.
 
-In a local canister execution environment, the effective canister id is ignored, and thus `aaaaa-aa` can be used.
+The Internet Computer blockchain mainnet does not support `provisional_create_canister_with_cycles` and thus all calls to this method are rejected independently of the effective canister id.
+
+In development instances of the Internet Computer Protocol (e.g. testnets), the effective canister id of a request submitted to a node must be a canister id from the canister ranges of the subnet to which the node belongs, unless the request is an update call to the Management Canister (`aaaaa-aa`), the method name is `provisional_create_canister_with_cycles`, and the effective canister id is that of the Management Canister (`aaaaa-aa`).
 ====
-
-* Else, the effective canister id must be the `canister_id` in the request.
-
-NOTE: The expectation is that user-side agent code shields users and developers from this concept, in analogy to how the System API interface shields canister developers from worrying about routing.
-
 
 [#authentication]
 === Authentication
@@ -2623,8 +2625,8 @@ delegation_targets(DS)
 A `Request` has an effective canister id according to the rules in <<#http-effective-canister-id>>:
 
 ....
-is_effective_canister_id(Request {canister_id = ic_principal, arg = candid({canister_id = p, …}), …}, p)
 is_effective_canister_id(Request {canister_id = ic_principal, method = provisional_create_canister_with_cycles, p)
+is_effective_canister_id(Request {canister_id = ic_principal, arg = candid({canister_id = p, …}), …}, p)
 is_effective_canister_id(Request {canister_id = p, …}, p), if p ≠ ic_principal
 ....
 
@@ -3086,6 +3088,7 @@ To avoid clashes with potential user ids or is derived from users or canisters, 
  * `is_system_assigned (mk_self_authenticating_id pk) = false` for possible public keys `pk` and
  * `is_system_assigned (mk_derived_id p dn) = false` for any `p` that could be a user id or canister id.
  * `is_system_assigned p = false` for `|p| > 29`.
+ * `is_system_assigned ic_principal = false`.
 
 ==== IC Management Canister: Changing settings
 

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -145,8 +145,6 @@ When the IC creates a _fresh_ id, it never creates a self-authenticating id, an 
 [#textual-ids]
 ==== Textual representation of principals
 
-NOTE: This textual representation does not actually show up in the interface (which always deals with blobs), so it is merely a recommended convention.
-
 We specify a _canonical textual format_ that is recommended whenever principals need to be printed or read in textual format, e.g. in log messages, transactions browser, command line tools, source code.
 
 The textual representation of a blob `b` is `Grouped(Base32(CRC32(b) · b))` where
@@ -2262,10 +2260,8 @@ WasmState = (abstract)
 StableMemory = (abstract)
 Callback = (abstract)
 
-Arg = {
-  data : Blob
-  caller: Principal
-}
+Arg = Blob;
+CallerId = Principal;
 
 Timestamp = Nat;
 Env = {
@@ -2299,14 +2295,14 @@ AvailableCycles = Nat
 RefundedCycles = Nat
 
 CanisterModule = {
-  init : (CanisterId, Arg, Env) -> Trap | Return WasmState
+  init : (CanisterId, Arg, CallerId, Env) -> Trap | Return WasmState
   pre_upgrade : (WasmState, Principal, Env) -> Trap | Return StableMemory
-  post_upgrade : (CanisterId, StableMemory, Arg, Env) -> Trap | Return WasmState
-  update_methods : MethodName ↦ ((Arg, Env, AvailableCycles) -> UpdateFunc)
-  query_methods : MethodName ↦ ((Arg, Env) -> QueryFunc)
+  post_upgrade : (CanisterId, StableMemory, Arg, CallerId, Env) -> Trap | Return WasmState
+  update_methods : MethodName ↦ ((Arg, CallerId, Env, AvailableCycles) -> UpdateFunc)
+  query_methods : MethodName ↦ ((Arg, CallerId, Env) -> QueryFunc)
   heartbeat : (Env) -> WasmState -> Trap | Return WasmState
   callbacks : (Callback, Response, RefundedCycles, Env, AvailableCycles) -> UpdateFunc
-  inspect_message : (MethodName, WasmState, Arg, Env) -> Trap | Return (Accept | Reject)
+  inspect_message : (MethodName, WasmState, Arg, CallerId, Env) -> Trap | Return (Accept | Reject)
 }
 ....
 
@@ -2337,7 +2333,7 @@ Request = {
     sender : UserId;
     canister_id : CanisterId;
     method_name : Text;
-    data : Blob;
+    arg : Blob;
   }
 CallId = (abstract)
 CallOrigin
@@ -2376,7 +2372,7 @@ Message
       caller : Principal;
       callee : CanisterId;
       method_name : Text;
-      data : Blob;
+      arg : Blob;
       transferred_cycles : Nat;
       queue : Queue;
     }
@@ -2417,7 +2413,7 @@ APIReadRequest
     sender : UserId;
     canister_id : CanisterId;
     method_name : Text;
-    data : Blob;
+    arg : Blob;
   }
 ....
 
@@ -2497,6 +2493,13 @@ S = {
   messages : List Message; // ordered!
   root_key : PublicKey
 }
+....
+
+To convert `CanStatus` into `status : Running | Stopping | Stopped` from `Env`, we define the following conversion function:
+....
+simple_status(Running) = Running
+simple_status(Stopping _) = Stopping
+simple_status(Stopped) = Stopped
 ....
 
 ==== Initial state
@@ -2632,9 +2635,15 @@ Conditions::
     ) ∨ (
       E.content.canister_id ≠ ic_principal
       S.canisters[E.content.canister_id] ≠ EmptyCanister
-      Arg = { data = E.content.arg; caller = E.content.sender; method = E.content.method_name; time = S.time[E.content.canister_id] }
+      Env = {
+        time = S.time[E.content.canister_id];
+        balance = S.balances[E.content.canister_id]
+        freezing_limit = freezing_limit(S, E.content.canister_id);
+        certificate = NoCertificate;
+        status = simple_status(S.canister_status[E.content.canister_id]);
+      }
       S.canisters[E.content.canister_id].module.inspect_message
-        (E.content.method_name, C.wasm_state, Arg, S.balance[E.content.canister_id]) = Return Accept
+        (E.content.method_name, C.wasm_state, E.content.arg, E.content.sender, Env) = Return Accept
    )
 ....
 State after::
@@ -2755,7 +2764,7 @@ S with
       FuncMessage {
         call_context = Ctxt_id;
         receiver = CM.callee;
-        entry_point = PublicMethod CM.method_name CM.caller CM.data;
+        entry_point = PublicMethod CM.method_name CM.caller CM.arg;
         queue = CM.queue;
       } ·
       Younger_messages
@@ -2827,13 +2836,12 @@ Conditions::
       balance = S.balances[M.receiver]
       freezing_limit = freezing_limit(S, M.receiver);
       certificate = NoCertificate;
-      status = S.status[M.receiver];
+      status = simple_status(S.canister_status[M.receiver]);
     }
 
     Available = S.call_contexts[M.call_contexts].available_cycles
-    ( M.entry_point = PublicMethod Name Caller Data
-      Arg = { data = Data; caller = Caller }
-      (F = Mod.update_methods[Name](Arg, Env, Available)) or (F = query_as_update(Mod.query_methods[Name], Arg, Env))
+    ( M.entry_point = PublicMethod Name Caller Arg
+      (F = Mod.update_methods[Name](Arg, Caller, Env, Available)) or (F = query_as_update(Mod.query_methods[Name], Arg, Caller, Env))
     )
     or
     ( M.entry_point = Callback Callback Response RefundedCycles
@@ -3109,7 +3117,7 @@ S with
       ResponseMessage {
         origin = M.origin
         response = candid({
-          status = S.canister_status[A.canister_id];
+          status = simple_status(S.canister_status[A.canister_id]);
           module_hash =
             if S.canisters[A.canister_id] = EmptyCanister
             then null
@@ -3139,18 +3147,14 @@ Conditions::
       (A.mode = install && S.canisters[A.canister_id] = EmptyCanister)
     or A.mode = reinstall
     M.caller ∈ S.controllers[A.canister_id]
-    Arg = {
-      data = A.arg;
-      caller = M.caller;
-    }
     Env = {
       time = S.time[M.receiver];
       balance = S.balances[M.receiver];
       freezing_limit = freezing_limit(S, M.receiver);
       certificate = NoCertificate;
-      status = S.status[M.receiver];
+      status = simple_status(S.canister_status[M.receiver]);
     }
-    Mod.init(A.canister_id, Arg, Env) = Return New_state
+    Mod.init(A.canister_id, A.arg, M.caller, Env) = Return New_state
     dom(Mod.update_methods) ∩ dom(Mod.query_methods) = ∅
 ....
 State after::
@@ -3188,14 +3192,10 @@ Conditions::
       balance = S.balances[M.receiver];
       freezing_limit = freezing_limit(S, M.receiver);
       certificate = NoCertificate;
-      status = S.status[M.receiver];
+      status = simple_status(S.canister_status[M.receiver]);
     }
     Old_module.pre_upgrade(Old_State, M.caller, Env) = Return Stable_memory
-    Arg = {
-      data = A.arg;
-      caller = M.caller;
-    }
-    Mod.post_upgrade(A.canister_id, Stable_memory, Arg, Env) = Return New_state
+    Mod.post_upgrade(A.canister_id, Stable_memory, A.arg, M.caller, Env) = Return New_state
     dom(Mod.update_methods) ∩ dom(Mod.query_methods) = ∅
 ....
 State after::
@@ -3278,7 +3278,7 @@ State after::
 ....
 S with
     messages = Older_messages · Younger_messages
-    S.status[A.canister_id] = Stopping [(M.origin, M.transferred_cycles)]
+    canister_status[A.canister_id] = Stopping [(M.origin, M.transferred_cycles)]
 ....
 
 The next two transitions record any additional 'stop_canister' requests that arrive at a stopping (or stopped) canister in its status.
@@ -3297,7 +3297,7 @@ State after::
 ....
 S with
     messages = Older_messages · Younger_messages
-    S.status[A.canister_id] = Stopping (Origins · (M.origin, M.transferred_cycles))
+    canister_status[A.canister_id] = Stopping (Origins · [(M.origin, M.transferred_cycles)])
 ....
 
 
@@ -3310,8 +3310,9 @@ Conditions::
 ....
 State after::
 ....
-    S.canister_status[CanisterId] = Stopped
-    S.messages = Messages ·
+S with
+    canister_status[CanisterId] = Stopped
+    messages = Messages ·
         [ ResponseMessage {
             origin = O
             response = Accepted (candid())
@@ -3355,13 +3356,13 @@ Conditions::
     M.callee = ic_principal
     M.method_name = 'start_canister'
     M.arg = candid(A)
-    S.status[A.canister_id] = Running or S.status[A.canister_id] = Stopped
+    S.canister_status[A.canister_id] = Running or S.canister_status[A.canister_id] = Stopped
     M.caller ∈ S.controllers[A.canister_id]
 ....
 State after::
 ....
 S with
-    S.status[A.canister_id] = Running
+    canister_status[A.canister_id] = Running
     messages = Older_messages · Younger_messages ·
         ResponseMessage{
             origin = M.origin
@@ -3380,13 +3381,13 @@ Conditions::
     M.callee = ic_principal
     M.method_name = 'start_canister'
     M.arg = candid(A)
-    S.status[A.canister_id] = Stopping Origins
+    S.canister_status[A.canister_id] = Stopping Origins
     M.caller ∈ S.controllers[A.canister_id]
 ....
 State after::
 ....
 S with
-    S.status[A.canister_id] = Running
+    canister_status[A.canister_id] = Running
     messages = Older_messages · Younger_messages ·
         ResponseMessage{
             origin = M.origin
@@ -3559,7 +3560,7 @@ S with
       Younger_messages
 ....
 
-If the responded call context does not exist anymore, because the canister has been uninstalled since, the refundend cycles are still added to the canister balance, but
+If the responded call context does not exist anymore, because the canister has been uninstalled since, the refunded cycles are still added to the canister balance, but
 no function invocation is enqueued:
 
 Conditions::
@@ -3719,10 +3720,6 @@ Conditions::
   S.canister_status[Q.canister_id] = Running ∧ S.balances[Q.canister_id] >= freezing_limit(S, Q.canister_id)
   C = S.canisters[Q.canister_id]
   F = C.module.query_methods[Q.method_name]
-  Arg = {
-    data = Q.arg;
-    caller = Q.sender;
-  }
   verify_cert(Cert)
   lookup(["canister",Q.canister_id,"certified_data"], Cert) = Found S.certified_data[Q.canister_id]
   lookup(["time"], Cert) = Found S.system_time // or “recent enough”
@@ -3731,21 +3728,21 @@ Conditions::
     balance = S.balances[Q.canister_id];
     freezing_limit = freezing_limit(S, Q.canister_id);
     certificate = Cert;
-    status = S.status[Q.receiver];
+    status = simple_status(S.canister_status[Q.receiver]);
   }
 ....
 Read response::
-* If `F(Arg, Env) = Trap` then
+* If `F(Q.Arg, Q.sender, Env) = Trap` then
 +
 ....
 {status: rejected; reject_code: CANISTER_ERROR, reject_message: <implementation-specific>, error_code: <implementation-specific>}
 ....
-* Else if `F(Arg, Env) = Return (Reject (code, msg))` then
+* Else if `F(Q.Arg, Q.sender, Env) = Return (Reject (code, msg))` then
 +
 ....
 {status: rejected; reject_code: <code>: reject_message: <msg>, error_code: <implementation-specific>}
 ....
-* Else if `F(Arg, Env) = Return (Reply R)` then
+* Else if `F(Q.Arg, Q.sender, Env) = Return (Reply R)` then
 +
 ....
 {status: success; reply: { arg :  <R> } }
@@ -3856,13 +3853,13 @@ Callback = {
 We can model the execution of WebAssembly functions as stateful functions that have access to the WebAssembly store. In order to also model the behavior of the system imports, which have access to additional data structures, we extend the state as follows:
 ....
 Params = {
-  data : NoData | Blob;
+  arg : NoArg | Blob;
   caller : NoCaller | Principal;
   reject_code : 0 | SYS_FATAL | SYS_TRANSIENT | …;
   reject_message : Text;
   sysenv : Env;
   cycles_refunded : Nat;
-  method_name : Text;
+  method_name : NoText | Text;
 }
 ExecutionState = {
   wasm_state : WasmState;
@@ -3894,11 +3891,12 @@ Finally we can specify the abstract `CanisterModule` that models a concrete WebA
 +
 ....
 empty_params = {
-  data = NoData;
+  arg = NoArg;
   caller = NoCaller;
   reject_code = 0;
   reject_message = "";
   cycles_refunded = 0;
+  method_name = NoText;
 }
 
 empty_execution_state = {
@@ -3922,17 +3920,17 @@ empty_execution_state = {
 If the WebAssembly module does not export a function called under the name `canister_init`, then the argument blob is ignored and the `initial_wasm_store` is returned:
 +
 ....
-init = λ (self_id, arg, sysenv) →
+init = λ (self_id, arg, caller, sysenv) →
   Return { store = initial_wasm_store; self_id = self_id; stable_mem = "" }
 ....
 +
 Otherwise, if the WebAssembly module exports a function `func` under the name `canister_init`, it is
 +
 ....
-init = λ (self_id, arg, sysenv) →
+init = λ (self_id, arg, caller, sysenv) →
   let es = ref {empty_execution_state with
       wasm_state = { store = initial_wasm_store; self_id = self_id; stable_mem = "" }
-      params = empty_params with { data = arg.data; caller = arg.caller; sysenv }
+      params = empty_params with { arg = arg; caller = caller; sysenv }
       balance = sysenv.balance
     }
   try func<es>() with Trap then Trap
@@ -3974,17 +3972,17 @@ pre_upgrade = λ (old_state, caller, sysenv) →
 If the WebAssembly module does not export a function called under the name `canister_post_upgrade`, then the argument blob is ignored and the `initial_wasm_store` is returned:
 +
 ....
-post_upgrade = λ (self_id, stable_mem, arg, sysenv) →
+post_upgrade = λ (self_id, stable_mem, arg, caller, sysenv) →
   Return { store = initial_wasm_store; self_id = self_id; stable_mem = stable_mem }
 ....
 +
 Otherwise, if the WebAssembly module exports a function `func` under the name `canister_post_upgrade`, it is
 +
 ....
-post_upgrade = λ (self_id, stable_mem, arg, sysenv) →
+post_upgrade = λ (self_id, stable_mem, arg, caller, sysenv) →
   let es = ref {empty_execution_state with
       wasm_state = { store = initial_wasm_store; self_id = self_id; stable_mem = stable_mem }
-      params = { empty_params with data = arg.data; caller = arg.caller; sysenv }
+      params = { empty_params with arg = arg; caller = caller; sysenv }
       balance = sysenv.balance
     }
   try func<es>() with Trap then Trap
@@ -3997,12 +3995,12 @@ post_upgrade = λ (self_id, stable_mem, arg, sysenv) →
 * The partial map `update_methods` of the `CanisterModule` is defined for all method names `method` for which the WebAssembly program exports a function `func` named `canister_update <method>`, and has value
 +
 ....
-update_methods[method] = λ (arg, sysenv, available) → λ wasm_state →
+update_methods[method] = λ (arg, caller, sysenv, available) → λ wasm_state →
   let es = ref {empty_execution_state with
       wasm_state = wasm_state;
-      params = empty_params with { data = arg.data; caller = arg.caller; sysenv }
+      params = empty_params with { arg = arg; caller = caller; sysenv }
       balance = sysenv.balance
-      cycles_available = arg.cycles;
+      cycles_available = available;
     }
   try func<es>() with Trap then Trap
   if es.ingress_filter ≠ Reject then Trap
@@ -4018,10 +4016,10 @@ update_methods[method] = λ (arg, sysenv, available) → λ wasm_state →
 * The partial map `query_methods` of the `CanisterModule` is defined for all method names `method` for which the WebAssembly program exports a function `func` named `canister_query <method>`, and has value
 +
 ....
-query_methods[method] = λ (arg, sysenv) → λ wasm_state →
+query_methods[method] = λ (arg, caller, sysenv) → λ wasm_state →
   let es = ref {empty_execution_state with
       wasm_state = wasm_state;
-      params = empty_params with { data = arg.data; caller = arg.caller; sysenv }
+      params = empty_params with { arg = arg; caller = caller; sysenv }
       balance = sysenv.balance
     }
   try func<es>() with Trap then Trap
@@ -4042,7 +4040,7 @@ By construction, the (possibly modified) `es.wasm_state` is discarded.
 heartbeat = λ (sysenv) → λ wasm_state →
   let es = ref {empty_execution_state with
     wasm_state = wasm_state;
-    params = empty_params with { data = NoData; caller = NoCaller; sysenv }
+    params = empty_params with { arg = NoArg; caller = NoCaller; sysenv }
     balance = sysenv.balance
   }
   try func<es>() with Trap then Trap
@@ -4116,19 +4114,19 @@ present) is executed, and the canister has the chance to update its state.
 If the WebAssembly module does not export a function called under the name `canister_inspect_message`, then access is always granted:
 +
 ....
-inspect_message = λ (method_name, wasm_state, arg, sysenv) →
+inspect_message = λ (method_name, wasm_state, arg, caller, sysenv) →
   Return Accept
 ....
 Otherwise, if the WebAssembly module exports a function `func` under the name `canister_inspect_message`, it is
 +
 ....
-inspect_message = λ (method_name, wasm_state, arg, sysenv) →
+inspect_message = λ (method_name, wasm_state, arg, caller, sysenv) →
   let es = ref {empty_execution_state with
       wasm_state = wasm_state;
       params = empty_params with {
-        data = arg.data;
-        caller = arg.caller;
-        method_name = arg.method_name;
+        arg = arg;
+        caller = caller;
+        method_name = method_name;
         sysenv
       }
       balance = sysenv.balance;
@@ -4176,7 +4174,7 @@ ic0.msg_arg_data_size<es>() : i32 =
   return |es.params.arg|
 
 ic0.msg_arg_data_copy<es>(dst:i32, offset:i32, size:i32) =
-  copy_to_canister<es>(dst, offset, size, es.param.arg)
+  copy_to_canister<es>(dst, offset, size, es.params.arg)
 
 ic0.msg_caller_size() : i32 =
   return |es.params.caller|

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -402,6 +402,10 @@ If the status is `rejected`, then this path contains the reject code (see <<reje
 +
 If the status is `rejected`, then this path contains a textual diagnostic message, else it is not present.
 
+* `/request_status/<request_id>/error_code` (text)
++
+If the status is `rejected`, then this path might be present and contain an implementation-specific error code (see <<error-codes>>), else it is not present.
+
 NOTE: Immediately after submitting a request, the request may not show up yet as the Internet Computer is still working on accepting the request as pending.
 
 NOTE: Request statuses will not actually be kept around indefinitely, and eventually the Internet Computer forgets about the request. This will happen no sooner than the request’s expiry time, so that replay attacks are prevented.
@@ -581,6 +585,7 @@ If the call resulted in a reject, the response is a CBOR map with the following 
 * `status` (`text`): `rejected`
 * `reject_code` (`nat`): The reject code (see <<reject-codes>>).
 * `reject_message` (`text`): a textual diagnostic message.
+* `error_code` (text): an optional implementation-specific textual error code (see <<error-codes>>).
 
 Canister methods that do not change the canister state can be executed more efficiently. This method provides that ability, and returns the canister’s response directly within the HTTP response.
 
@@ -731,6 +736,13 @@ The symbolic names of this enumeration are used throughout this specification, b
 The error message is guaranteed to be a string, i.e. not arbitrary binary data.
 
 When canisters explicitly reject a message (see <<system-api-requests>>), they can specify the reject message, but _not_ the reject code; it is always `CANISTER_REJECT`. In this sense, the reject code is trustworthy: If the IC responds with a `SYS_FATAL` reject, then it really was the IC issuing this reject.
+
+[#error-codes]
+=== Error codes
+
+Implementations of the API can provide additional details for rejected messages in the form of a textual label identifying the error condition.
+API clients can use these labels to handle errors programmatically or suggest recovery paths to the user.
+The specification reserves error codes matching the regular expression `IC[0-9]+` (e.g., `IC502`) for the DFINITY implementation of the API.
 
 [#api-status]
 === Status endpoint
@@ -3726,12 +3738,12 @@ Read response::
 * If `F(Arg, Env) = Trap` then
 +
 ....
-{status: failed; error: "Query execution trapped"}
+{status: rejected; reject_code: CANISTER_ERROR, reject_message: <implementation-specific>, error_code: <implementation-specific>}
 ....
 * Else if `F(Arg, Env) = Return (Reject (code, msg))` then
 +
 ....
-{status: rejected; reject_code: <code>: reject_message: <msg>}
+{status: rejected; reject_code: <code>: reject_message: <msg>, error_code: <implementation-specific>}
 ....
 * Else if `F(Arg, Env) = Return (Reply R)` then
 +
@@ -3797,7 +3809,7 @@ request_status_tree(Received) =
 request_status_tree(Processing) =
   { "status": "processing" }
 request_status_tree(Rejected (code,msg)) =
-  { "status": "rejected"; "reject_code": code; "reject_message": msg }
+  { "status": "rejected"; "reject_code": code; "reject_message": msg, error_code: <implementation-specific>}
 request_status_tree(Replied arg) =
   { "status": "replied"; "reply": arg }
 request_status_tree(Done) =

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -2105,9 +2105,9 @@ The HTTP request is encoded into the `HttpRequest` Candid structure.
 
 === Upgrade to update calls
 
-If the canister sets `update = opt true` in the `HttpResponse` reply from `http_request`, then the Gateway ignores all other fields of the reply. The Gateway performs an _update_ call to `http_request_update`, passing the same `HttpRequest` record as the argument, and uses that response instead.
+If the canister sets `upgrade = opt true` in the `HttpResponse` reply from `http_request`, then the Gateway ignores all other fields of the reply. The Gateway performs an _update_ call to `http_request_update`, passing the same `HttpRequest` record as the argument, and uses that response instead.
 
-The value of the `update` field returned from `http_request_update` is ignored.
+The value of the `upgrade` field returned from `http_request_update` is ignored.
 
 === Response decoding
 

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1,6 +1,6 @@
 = The Internet Computer Interface Specification
 DFINITY Foundation
-0.18.5
+0.18.6
 // the following are ways to make this document work both in antora and stand alone
 :example: example$
 :partial: partial$

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -221,7 +221,7 @@ The canister status can be used to control whether the canister is processing ca
 
 * In status `running`, calls to the canister are processed as normal.
 * In status `stopping`, calls to the canister are rejected by the IC, but responses to the canister are processed as normal.
-* In status `stopped`, calls to the canister are rejected by the IC, and there are no outstanding responses.
+* In status `stopped`, calls to the canister are rejected by the IC, and there are no outstanding responses to call contexts that are not marked as deleted.
 
 In all cases, calls to the <<ic-management-canister,management canister>> are processed, regardless of the state of the managed canister.
 
@@ -1527,7 +1527,7 @@ Note that this is different from `uninstall_code` followed by `install_code`, as
 
 This is atomic: If the response to this request is a `reject`, then this call had no effect.
 
-NOTE: Some canisters may not be able to make sense of callbacks after upgrades; these should be stopped first, to wait for all outstanding callbacks, or be uninstalled first, to prevent outstanding callbacks from being invoked. It is expected that the canister admin (or their tooling) does that separately.
+NOTE: Some canisters may not be able to make sense of callbacks after upgrades; these should be stopped first, to wait for all outstanding callbacks that are not marked as deleted, or be uninstalled first, to prevent outstanding callbacks from being invoked (by marking the corresponding call contexts as deleted). It is expected that the canister admin (or their tooling) does that separately.
 
 The `wasm_module` field specifies the canister module to be installed.
 The system supports multiple encodings of the `wasm_module` field:
@@ -1569,7 +1569,7 @@ The controllers of a canister may stop a canister (e.g., to prepare for a canist
 Stopping a canister is not an atomic action. The immediate effect is that the status of the canister is changed to `stopping` (unless the canister is already stopped).
 The IC will reject all calls to a stopping canister, indicating that the canister is stopping.
 Responses to a stopping canister are processed as usual.
-When all outstanding responses have been processed (so there are no open call contexts), the canister status is changed to `stopped` and the management canister responds to the caller of the `stop_canister` request.
+When all outstanding responses to call contexts that are not marked as deleted have been processed (so there are no open call contexts that are not marked as deleted), the canister status is changed to `stopped` and the management canister responds to the caller of the `stop_canister` request.
 
 [#ic-start_canister]
 === IC method `start_canister`
@@ -3296,12 +3296,12 @@ S with
 
 ==== IC Management Canister: Stopping a canister
 
-The controllers of a canister can stop a canister. Stopping a canister goes through two steps. First, the status of the canister is set to `Stopping`; as explained above, a stopping canister rejects all incoming requests and continues processing outstanding responses. When a stopping canister has no more open call contexts, its status is changed to `Stopped` and a response is generated. Note that when processing responses, a stopping canister can make calls to other canisters and thus create new call contexts. In addition, a canister which is stopped, or stopping will accept (and respond) to further `stop_canister` requests.
+The controllers of a canister can stop a canister. Stopping a canister goes through two steps. First, the status of the canister is set to `Stopping`; as explained above, a stopping canister rejects all incoming requests and continues processing outstanding responses. When a stopping canister has no more open call contexts that are not marked as deleted, its status is changed to `Stopped` and a response is generated. Note that when processing responses, a stopping canister can make calls to other canisters and thus create new call contexts. In addition, a canister which is stopped, or stopping will accept (and respond) to further `stop_canister` requests.
 
 We encode this behavior via three (types of) transitions:
 
 1. First, any `stop_canister` call sets the state of the canister to `Stopping`; we record in the status the origin (and cycles) of all `stop_canister` calls which arrive at the canister while it is stopping (or stopped).
-2. Next, when the canister has no open call contexts (so, in particular, all outstanding responses to the canister have been processed), the status of the canister is set to `Stopped`.
+2. Next, when the canister has no open call contexts that are not marked as deleted (so, in particular, all outstanding responses to the canister have been processed or will be discared because the call context has been marked as deleted), the status of the canister is set to `Stopped`.
 3. Finally, each pending `stop_canister` call (which are encoded in the status) is responded to, to indicate that the canister is stopped.
 
 Conditions::
@@ -3341,12 +3341,12 @@ S with
 ....
 
 
-The status of a stopping canister which has no open call contexts is set to `Stopped`, and all pending `stop_canister` calls are replied to.
+The status of a stopping canister which has no open call contexts that are not marked as deleted is set to `Stopped`, and all pending `stop_canister` calls are replied to.
 
 Conditions::
 ....
     S.canister_status[Canister_id] = Stopping Origins
-    ∀ Ctxt_id. S.call_contexts[Ctxt_id].canister ≠ Canister_id
+    ∀ Ctxt_id. S.call_contexts[Ctxt_id].deleted or S.call_contexts[Ctxt_id].canister ≠ Canister_id
 ....
 State after::
 ....

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -229,9 +229,7 @@ In all cases, calls to the <<ic-management-canister,management canister>> are pr
 
 The controllers of the canister can initiate transitions between these states using <<ic-stop_canister,`stop_canister`>> and <<ic-start_canister,`start_canister`>>, and query the state using <<ic-canister_status,`canister_status`>>. The canister itself can also query its state using <<system-api-canister-status,`ic0.canister_status`>>.
 
-NOTE:
-This status is orthogonal to the question of whether a canister is empty or not: an empty canister can be in status `running`. Calls to such a canister are still rejected, but because the canister is empty.
-
+NOTE: This status is orthogonal to the question of whether a canister is empty or not: an empty canister can be in status `running`. Calls to such a canister are still rejected, but because the canister is empty.
 
 [#signatures]
 === Signatures
@@ -543,7 +541,7 @@ The HTTP response to this request consists of a CBOR map with the following fiel
 
 * `certificate` (`blob`): A certificate (see <<certification>>).
 +
-If this `certificate` includes subnet delegations (possibly nested), then the `effective_canister_id` must be included in each delegation’s canister id range (see <<certification-delegation>>).
+If this `certificate` includes subnet delegations (possibly nested), then the `effective_canister_id` must be included in each delegation’s canister id range (see <<certification-delegation>>), unless the `effective_canister_id` is that of the Management Canister (`aaaaa-aa`). In other words, we define `aaaaa-aa` to belong to every canister range for the purposes of certificate checking. Note that `aaaaa-aa` is a valid canister id only for calls to `provisional_create_canister_with_cycles`, so it cannot appear in `read_state` requests on production networks.
 
 The returned certificate reveals all values whose path is a suffix of the list of requested paths. It also always reveals `/time`, even if not explicitly requested.
 
@@ -591,11 +589,13 @@ Canister methods that do not change the canister state can be executed more effi
 
 The `<effective_canister_id>` in the URL paths of requests is the _effective_ destination of the request.
 
-* If the call is to the Management Canister (`aaaaa-aa`), and the `arg` is Candid-encoded where the first argument is a record with a `canister_id` field of type `principal`, then the effective canister id is that principal.
+* If the call is to the Management Canister (`aaaaa-aa`), then:
+   - If the `arg` is Candid-encoded where the first argument is a record with a `canister_id` field of type `principal`, then the effective canister id is that principal.
+   - Otherwise, if the call is to the `provisional_create_canister_with_cycles` method, then any principal is a valid effective canister id for this call.
+   - Otherwise, there is no effective canister id. In particular, the `create_canister` method has no effective canister ID, and this method cannot be called by users, only via canisters.
 
 * If the call is to the `raw_rand` method of the Management Canister (`aaaaa-aa`), then there is no effective canister id. This implies that this method cannot be called by users, only via canisters.
 
-* If the call is to the `provisional_create_canister_with_cycles` method of the Management Canister (`aaaaa-aa`), any principal is a valid effective canister id for this call.
 +
 [NOTE]
 ====
@@ -1351,9 +1351,26 @@ The time is given as nanoseconds since 1970-01-01. The IC guarantees that
  * the time, as observed by the canister, is monotonically increasing, even across canister upgrades.
  * within an invocation of one entry point, the time is constant.
 
-The system times of different canisters are unrelated, and calls from one canister to another may appear to travel “backwards in time”.
+The times observed by different canisters are unrelated, and calls from one canister to another may appear to travel “backwards in time”.
 
-NOTE: While an implementation will likely try to keep the System Time close to the real time, this is not formally part of this specification.
+NOTE: While an implementation will likely try to keep the time returned by `ic0.time` close to the real time, this is not formally part of this specification.
+
+[#system-api-performance-counter]
+=== Performance counter
+
+The canister can query the "performance counter", which is a deterministic monotonically increasing integer approximating the amount of work the canister has done since the beginning of the current execution.
+
+`+ic0.performance_counter : (counter_type : i32) -> i64+`
+
+The argument `type` decides which performance counter to return:
+
+* 0 : instruction counter. The number of WebAssembly instructions the system has determined that the canister has executed.
+
+In the future, we might expose more performance counters.
+
+The system resets the counter at the beginning of each <<entry-points>> invocation.
+
+The main purpose of this counter is to facilitate in-canister performance profiling.
 
 [#system-api-certified-data]
 === Certified data
@@ -2271,7 +2288,7 @@ RefundedCycles = Nat
 
 CanisterModule = {
   init : (CanisterId, Arg, Env) -> Trap | Return WasmState
-  pre_upgrade : (WasmState, caller : Principal, Env) -> Trap | Return StableMemory
+  pre_upgrade : (WasmState, Principal, Env) -> Trap | Return StableMemory
   post_upgrade : (CanisterId, StableMemory, Arg, Env) -> Trap | Return WasmState
   update_methods : MethodName ↦ ((Arg, Env, AvailableCycles) -> UpdateFunc)
   query_methods : MethodName ↦ ((Arg, Env) -> QueryFunc)
@@ -2302,13 +2319,14 @@ The Internet Computer provides certain messaging guarantees: If a user or a cani
 To ensure that only one response is generated, and also to detect when no response can be generated any more, the IC maintains a _call context_. The `needs_to_respond` field is set to `false` once the call has received a response. Further attempts to respond will now fail.
 
 ....
-CallCtxt = {
-  canister : CanisterId;
-  origin : CallOrigin;
-  needs_to_respond : bool;
-  deleted : bool;
-  available_cycles : Nat;
-}
+Request = {
+    nonce : Blob;
+    ingress_expiry : Nat;
+    sender : UserId;
+    canister_id : CanisterId;
+    method_name : Text;
+    data : Blob;
+  }
 CallId = (abstract)
 CallOrigin
   = FromUser {
@@ -2319,6 +2337,13 @@ CallOrigin
       callback: Callback
     }
   | FromHeartbeat
+CallCtxt = {
+  canister : CanisterId;
+  origin : CallOrigin;
+  needs_to_respond : bool;
+  deleted : bool;
+  available_cycles : Nat;
+}
 ....
 
 ==== Calls and Messages
@@ -2362,36 +2387,7 @@ A reference implementation would likely maintain a separate list of `messages` f
 
 ==== API requests
 
-We distinguish between the _asynchronous_ API requests passed to `/api/v2/…/call`, which may be present in the IC state, and the _synchronous_ API requests passed to `/api/v2/…/read_state` and `/api/v2/…/query`, which are only ephemeral.
-
-....
-Envelope = {
-  content : Request | APIReadRequest;
-  sender_pubkey : PublicKey | NoPublicKey;
-  sender_sig : Signature | NoSignature;
-  sender_delegation: [SignedDelegation]
-}
-
-Request
-  = CanisterUpdateCall = {
-    nonce : Blob;
-    ingress_expiry : Nat;
-    sender : UserId;
-    canister_id : CanisterId;
-    method_name : Text;
-    data : Blob;
-  }
-....
-
-The evolution of a `Request` goes through these states, as explained in <<http-call-overview>>:
-....
-RequestStatus
-  = Received
-  | Processing
-  | Rejected (RejectCode, Text)
-  | Replied Blob
-  | Done
-....
+We distinguish between the _asynchronous_ API requests (type `Request`) passed to `/api/v2/…/call`, which may be present in the IC state, and the _synchronous_ API requests passed to `/api/v2/…/read_state` and `/api/v2/…/query`, which are only ephemeral.
 
 These are the synchronous read messages:
 ....
@@ -2413,10 +2409,29 @@ APIReadRequest
   }
 ....
 
+....
+Envelope = {
+  content : Request | APIReadRequest;
+  sender_pubkey : PublicKey | NoPublicKey;
+  sender_sig : Signature | NoSignature;
+  sender_delegation: [SignedDelegation]
+}
+....
+
+The evolution of a `Request` goes through these states, as explained in <<http-call-overview>>:
+....
+RequestStatus
+  = Received
+  | Processing
+  | Rejected (RejectCode, Text)
+  | Replied Blob
+  | Done
+....
+
 A `Path` may refer to a request by way of a _request id_, as specified in <<request-id>>:
 ....
-Request = Blob
-hash_of_map: Request -> Request
+RequestId = Blob
+hash_of_map: Request -> RequestId
 ....
 
 For the signatures in a `Request`, we assume that the following function implements signature verification as described in <<authentication>>.
@@ -2444,6 +2459,18 @@ SignedDelegation = {
 Finally, we can describe the state of the IC as a record having the following fields:
 
 ....
+CanState
+ = EmptyCanister | {
+  wasm_state : WasmState;
+  module : CanisterModule;
+  raw_module : Blob;
+  public_custom_sections: Text ↦ Blob;
+  private_custom_sections: Text ↦ Blob;
+}
+CanStatus
+  = Running
+  | Stopping (List (CallOrigin, Nat))
+  | Stopped
 S = {
   requests : Request ↦ RequestStatus;
   canisters : CanisterId ↦ CanState;
@@ -2458,18 +2485,6 @@ S = {
   messages : List Message; // ordered!
   root_key : PublicKey
 }
-CanState
- = EmptyCanister | {
-  wasm_state : WasmState;
-  module : CanisterModule;
-  raw_module : Blob;
-  public_custom_sections: Text ↦ Blob;
-  private_custom_sections: Text ↦ Blob;
-}
-CanStatus
-  = Running
-  | Stopping (List (CallOrigin, Nat))
-  | Stopped
 ....
 
 ==== Initial state
@@ -2481,8 +2496,10 @@ The initial state of the IC is
   canisters = ();
   controllers = ();
   freezing_threshold = ();
+  canister_status = ();
   time = ();
   balances = ();
+  certified_data = ();
   system_time = T;
   call_contexts = ();
   messages = ();
@@ -2494,6 +2511,13 @@ for some time stamp `T`, some DER-encoded BLS public key `PublicKey`, and using 
 === Invariants
 
 The following is an incomplete list of invariants that should hold for the abstract state `S`, and are not already covered by the type annotations in this section.
+
+* No method name is the name of an update and query method in a CanisterModule at the same time:
++
+....
+∀ _ ↦ CanState ∈ S.canisters:
+  dom(CanState.module.update_methods) ∩ dom(CanState.module.query_methods) = ∅
+....
 
 * Deleted call contexts were not awaiting a response:
 +
@@ -2512,8 +2536,8 @@ The following is an incomplete list of invariants that should hold for the abstr
 * Referenced call contexts exists:
 +
 ....
-∀ CallMessage M ∈ S.messages.  M.origin.calling_context ∈ S.call_contexts
-∀ ResponseMessage M ∈ S.messages. M.origin.calling_context ∈ S.call_contexts
+∀ CallMessage {origin = FromCanister O, …} ∈ S.messages. O.calling_context ∈ S.call_contexts
+∀ ResponseMessage {origin = FromCanister O, …} ∈ S.messages. O.calling_context ∈ S.call_contexts
 ∀ _ ↦ Ctxt ∈ S.call_contexts:
   if Ctx.needs_to_respond:
      Ctxt.origin.calling_context ∈ S.call_contexts
@@ -2525,7 +2549,7 @@ Based on this abstract notion of the state, we can describe the behavior of the 
 
  * Asynchronous API requests that are submitted via `/api/v2/…/call`. These transitions describe checks that the request must pass to be considered received.
  * Spontaneous transitions that model the internal behavior of the IC, by describing conditions on the state that allow the transition to happen, and the state after.
- * Responses to reads (i.e. `/api/v2/…/read_state`). By definition, these do _not_ change the state of the IC, and merely describe the response based on the read request and the current state.
+ * Responses to reads (i.e. `/api/v2/…/read_state` and `/api/v2/…/query`). By definition, these do _not_ change the state of the IC, and merely describe the response based on the read request (or query, respectively) and the current state.
 
 The state transitions are not complete with regard to error handling. For example, the behavior of sending a request to a non-existent canister is not specified here. For now, we trust implementors to make sensible decisions there.
 
@@ -2564,9 +2588,9 @@ delegation_targets(DS)
 A `Request` has an effective canister id according to the rules in <<#http-effective-canister-id>>:
 
 ....
-is_effective_canister_id(CanisterUpdateCall {canister_id = ic_principal, arg = candid({canister_id = p, …}), …}, p)
-is_effective_canister_id(CanisterUpdateCall {canister_id = ic_principal, method = provisional_create_canister_with_cycles, p)
-is_effective_canister_id(CanisterUpdateCall {canister_id = p, …}, p), if p ≠ ic_principal
+is_effective_canister_id(Request {canister_id = ic_principal, arg = candid({canister_id = p, …}), …}, p)
+is_effective_canister_id(Request {canister_id = ic_principal, method = provisional_create_canister_with_cycles, p)
+is_effective_canister_id(Request {canister_id = p, …}, p), if p ≠ ic_principal
 ....
 
 ==== API Request submission
@@ -2591,7 +2615,7 @@ Conditions::
       E.content.arg = candid({canister_id = CanisterId, …})
       E.content.sender ∈ S.controllers[CanisterId]
       E.content.method_name ∈
-        { "install_code", "set_controller", "start_canister", "stop_canister",
+        { "install_code", "update_settings", "start_canister", "stop_canister",
           "canister_status", "delete_canister" }
     ) ∨ (
       E.content.canister_id ≠ ic_principal
@@ -2634,17 +2658,17 @@ The IC does not make any guarantees about the order of incoming messages.
 
 Conditions::
 ....
-    S.requests[CanisterUpdateCall R] = Received
+    S.requests[R] = Received
     S.system_time <= R.ingress_expiry
     C = S.canisters[R.canister_id]
 ....
 State after::
 ....
 S with
-    requests[CanisterUpdateCall R] = Processing
+    requests[R] = Processing
     messages =
       CallMessage {
-        origin = FromUser { request = CanisterUpdateCall R };
+        origin = FromUser { request = R };
         caller = R.sender;
         callee = R.canister_id;
         method_name = R.method_name;
@@ -2659,20 +2683,27 @@ S with
 
 A call to a canister which is stopping, stopped, or frozen is automatically rejected.
 
-The (unspecified) function `freezing_limit(S, cid)` determines the freezing threshold in cycles of the canister with id `cid`, given its current memory footprint, storage cost, memory and compute allocation, and current `freezing_threshold` setting.
+The (unspecified) function `idle_cycles_burned_rate(S, cid)` determines the idle resource consumption rate in cycles per day of the canister with id `cid`,
+given its current memory footprint, compute and storage cost, and memory and compute allocation.
+The function `freezing_limit(S, cid)` determines the freezing threshold in cycles of the canister with id `cid`,
+given its current memory footprint, compute and storage cost, memory and compute allocation, and current `freezing_threshold` setting.
+The value `freezing_limit(S, cid)` is derived from `idle_cycles_burned_rate(S, cid)` and `freezing_threshold` as follows:
+....
+    freezing_limit(S, cid) = idle_cycles_burned_rate(S, cid) * S.freezing_threshold[cid] / (24 * 60 * 60)
+....
 
 Conditions::
 ....
     S.messages = Older_messages · CallMessage CM · Younger_messages
     (CM.queue = Unordered) or (∀ msg ∈ Older_messages. msg.queue ≠ CM.queue)
-    S.canister_status[CM.callee] = Stopped or S.canister_status[CM.callee] = Stopping or balances[CM.callee] < freezing_limit(S, CM.callee)
+    S.canister_status[CM.callee] = Stopped or S.canister_status[CM.callee] = Stopping _ or balances[CM.callee] < freezing_limit(S, CM.callee)
 ....
 
 State after::
 ....
     S.messages = Older_messages · Younger_messages  ·
       ResponseMessage {
-          origin = S.call_contexts[CM.call_context].origin
+          origin = CM.origin;
           response = Reject (CANISTER_ERROR, "canister not running");
           refunded_cycles = CM.transferred_cycles;
       }
@@ -2699,7 +2730,7 @@ Conditions::
     S.messages = Older_messages · CallMessage CM · Younger_messages
     S.canisters[CM.callee] ≠ EmptyCanister
     S.canister_status[CM.callee] = Running
-    balances[CM.callee] ≥ freezing_limit(S, CM.callee) + MAX_CYCLES_PER_MESSAGE
+    S.balances[CM.callee] ≥ freezing_limit(S, CM.callee) + MAX_CYCLES_PER_MESSAGE
     Ctxt_id ∉ dom S.call_contexts
 ....
 +
@@ -2712,7 +2743,7 @@ S with
       FuncMessage {
         call_context = Ctxt_id;
         receiver = CM.callee;
-        entry_point = PublicMethod CM.method_name CM.caller CM.data
+        entry_point = PublicMethod CM.method_name CM.caller CM.data;
         queue = CM.queue;
       } ·
       Younger_messages
@@ -2790,9 +2821,7 @@ Conditions::
     Available = S.call_contexts[M.call_contexts].available_cycles
     ( M.entry_point = PublicMethod Name Caller Data
       Arg = { data = Data; caller = Caller }
-      (F = Mod.update_methods[Name](Arg, Env, Available)
-      or
-      (F = query_as_update(Mod.query_methods[Name], Arg, Env))
+      (F = Mod.update_methods[Name](Arg, Env, Available)) or (F = query_as_update(Mod.query_methods[Name], Arg, Env))
     )
     or
     ( M.entry_point = Callback Callback Response RefundedCycles
@@ -2811,12 +2840,11 @@ if
   R = Return res
   Cycles_used ≤ (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE)
   res.cycles_accepted ≤ Available
+  (Cycles_used + ∑ [ MAX_CYCLES_PER_RESPONSE + call.transferred_cycles | call ∈ res.new_calls ]) ≤
+    (S.balances[M.receiver] + res.cycles_accepted + (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE))
   New_balance =
-      S.balances[M.receiver]
-      + res.cycles_accepted
-      + (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE)
-      - Cycles_used
-      - ∑ [ MAX_CYCLES_PER_RESPONSE + call.transferred_cycles | call ∈ res.new_calls ]
+      (S.balances[M.receiver] + res.cycles_accepted + (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE))
+      - (Cycles_used + ∑ [ MAX_CYCLES_PER_RESPONSE + call.transferred_cycles | call ∈ res.new_calls ])
   New_balance > if Is_response then 0 else freezing_limit(S, CM.callee);
   (res.response = NoResponse) or S.call_contexts[M.call_context].needs_to_respond
 then
@@ -2859,9 +2887,8 @@ else
   S with
     messages = Older_messages · Younger_messages
     balances[M.receiver] =
-      S.balances[M.receiver]
-      + (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE)
-      - Cycles_used
+      S.balances[M.receiver] +
+      ((if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE) - Cycles_used)
 ....
 
 
@@ -2884,17 +2911,28 @@ If message execution <<define-wasm-fn,_returns_ (in the sense of a Wasm function
 Note that returning does _not_ imply that the call associated with this message now  _succeeds_ in the sense defined in <<responding, section responding>>; that would require a (unique) call to `ic0.reply`.
 Note also that the state changes are persisted even when the IC is set to synthesize a <<CANISTER_ERROR,CANISTER_ERROR>> reject immediately afterward (which happens when this returns without calling `ic0.reply` or `ic0.reject`, the corresponding call has not been responded to and there are no outstanding callbacks, see <<rule-starvation>>).
 
-The function `as_update` turns a query function into an update function, this is merely a notational trick to simplify the rule
+The functions `query_as_update` and `heartbeat_as_update` turns a query function resp the heartbeat into an update function; this is merely a notational trick to simplify the rule:
 ....
-as_update(f, arg, env) = λ wasm_state →
+query_as_update(f, arg, env) = λ wasm_state →
   match f(arg, env)(wasm_state) with
     Trap → Trap
     Return res → Return {
       new_state = wasm_state;
       new_calls = [];
+      new_certified_data = NoCertifiedData;
       response = res;
       cycles_accepted = 0;
+    }
+
+heartbeat_as_update(f, env) = λ wasm_state →
+  match f(env)(wasm_state) with
+    Trap → Trap
+    Return wasm_state → Return {
+      new_state = wasm_state;
+      new_calls = [];
       new_certified_data = NoCertifiedData;
+      response = NoResponse;
+      cycles_accepted = 0;
     }
 ....
 Note that by construction, a query function will either trap or return with a response; it will never send calls, and it will never change the state of the canister.
@@ -2908,9 +2946,9 @@ Conditions::
 ....
     S.call_contexts[Ctxt_id].needs_to_respond = true
     S.call_contexts[Ctxt_id].origin ≠ FromHeartbeat
-    ∀ CallMessage M ∈ S.messages. M.origin.calling_context ≠ Ctxt_id
-    ∀ ResponseMessage M ∈ S.messages. M.origin.calling_context ≠ Ctxt_id
-    ∀ ctxt_ids.
+    ∀ CallMessage {origin = FromCanister O, …} ∈ S.messages. O.calling_context ≠ Ctxt_id
+    ∀ ResponseMessage {origin = FromCanister O, …} ∈ S.messages. O.calling_context ≠ Ctxt_id
+    ∀ ctxt_ids ∈ dom(S.call_contexts).
         S.call_contexts[ctxt_ids].needs_to_respond
         ==> S.call_contexts[ctxt_ids].origin.calling_context ≠ Ctxt_id
 ....
@@ -2941,8 +2979,8 @@ Conditions::
       S.call_contexts[Ctxt_id].origin = FromHeartbeat
       ∀ FuncMessage M ∈ S.messages. M.call_context ≠ Ctxt_id
     )
-    ∀ CallMessage M ∈ S.messages. M.origin.calling_context ≠ Ctxt_id
-    ∀ ResponseMessage M ∈ S.messages. M.origin.calling_context ≠ Ctxt_id
+    ∀ CallMessage {origin = FromCanister O, …} ∈ S.messages. O.calling_context ≠ Ctxt_id
+    ∀ ResponseMessage {origin = FromCanister O, …} ∈ S.messages. O.calling_context ≠ Ctxt_id
     ∀ ctxt_ids.
         S.call_contexts[ctxt_ids].needs_to_respond = true
         ==> S.call_contexts[ctxt_ids].origin.calling_context ≠ Ctxt_id
@@ -3041,7 +3079,7 @@ The controllers of a canister can obtain information about the canister.
 
 The `Memory_size` is the (in this specification underspecified) total size of storage in bytes.
 
-The `idle_cycles_burned_per_day` is the idle consumption of resources in cycles per day. Therefore, the freezing threshold in cycles can be obtained using the following formula: `freezing_threshold` (in seconds) * `idle_cycles_burned_per_day` /  (3600 * 24) (seconds).
+The `idle_cycles_burned_per_day` is the idle consumption of resources in cycles per day.
 
 Conditions::
 ....
@@ -3068,7 +3106,7 @@ S with
           memory_size = Memory_size;
           cycles = S.balance[A.canister_id];
           freezing_threshold = S.freezing_threshold[A.canister_id];
-          idle_cycles_burned_per_day = freezing_limit(S, A.canister_id) / freezing_threshold * 3600 * 24;
+          idle_cycles_burned_per_day = idle_cycles_burned_rate(S, A.canister_id);
         })
         refunded_cycles = M.transferred_cycles
       }
@@ -3101,6 +3139,7 @@ Conditions::
       status = S.status[M.receiver];
     }
     Mod.init(A.canister_id, Arg, Env) = Return New_state
+    dom(Mod.update_methods) ∩ dom(Mod.query_methods) = ∅
 ....
 State after::
 ....
@@ -3145,6 +3184,7 @@ Conditions::
       caller = M.caller;
     }
     Mod.post_upgrade(A.canister_id, Stable_memory, Arg, Env) = Return New_state
+    dom(Mod.update_methods) ∩ dom(Mod.query_methods) = ∅
 ....
 State after::
 ....
@@ -3652,7 +3692,7 @@ S with
 
 ==== Query call
 
-Canister query calls to `/api/v2/canister/<ECID>/query` can be executed directly.  They can only be executed against canisters which are `Running`.
+Canister query calls to `/api/v2/canister/<ECID>/query` can be executed directly.  They can only be executed against canisters which have a status of `Running` and are also not frozen.
 
 During the execution of a query call, a certificate is provided to the canister that is valid, contains a current state tree (or “recent enough”; the specification is currently vague about how old the certificate may be) and reveals the canister’s <<system-api-certified-data,Certified Data>>.
 
@@ -3664,7 +3704,7 @@ Conditions::
   is_effective_canister_id(E.content, ECID)
   S.system_time <= Q.ingress_expiry
   S.canisters[Q.canister_id] ≠ EmptyCanister
-  S.canister_status[Q.canister_id] = Running
+  S.canister_status[Q.canister_id] = Running ∧ S.balances[Q.canister_id] >= freezing_limit(S, Q.canister_id)
   C = S.canisters[Q.canister_id]
   F = C.module.query_methods[Q.method_name]
   Arg = {
@@ -4370,6 +4410,8 @@ ic0.data_certificate_copy<es>(dst: i32, offset: i32, size: i32) =
   if es.params.sysenv.certificate = NoCertificate then Trap
   copy_to_canister<es>(dst, offset, size, es.params.sysenv.certificate)
 
+ic0.performance_counter<es>(counter_type : i32) : i64 =
+  arbitrary()
 
 ic0.debug_print<es>(src : i32, size : i32) =
   return

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -595,9 +595,7 @@ The `<effective_canister_id>` in the URL paths of requests is the _effective_ de
 * If the call is to the Management Canister (`aaaaa-aa`), then:
    - If the `arg` is Candid-encoded where the first argument is a record with a `canister_id` field of type `principal`, then the effective canister id is that principal.
    - Otherwise, if the call is to the `provisional_create_canister_with_cycles` method, then any principal is a valid effective canister id for this call.
-   - Otherwise, there is no effective canister id. In particular, the `create_canister` method has no effective canister ID, and this method cannot be called by users, only via canisters.
-
-* If the call is to the `raw_rand` method of the Management Canister (`aaaaa-aa`), then there is no effective canister id. This implies that this method cannot be called by users, only via canisters.
+   - Otherwise, there is no effective canister id. In particular, the `create_canister` and `raw_rand` methods have no effective canister ID, and these methods cannot be called by users, only via canisters.
 
 +
 [NOTE]
@@ -2282,27 +2280,47 @@ MethodCall = {
   callback: Callback;
 }
 
-UpdateFunc = WasmState -> Trap | Return {
+UpdateFunc = WasmState -> Trap { cycles_used : Nat; } | Return {
   new_state : WasmState;
   new_calls : List MethodCall;
   new_certified_data : NoCertifiedData | Blob
   response : NoResponse | Response;
   cycles_accepted : Nat;
+  cycles_used : Nat;
 }
-QueryFunc = WasmState -> Trap | Return Response
+QueryFunc = WasmState -> Trap { cycles_used : Nat; } | Return {
+  response : Response;
+  cycles_used : Nat;
+}
+HeartbeatFunc = WasmState -> Trap { cycles_used : Nat; } | Return {
+  new_state : WasmState;
+  cycles_used : Nat;
+}
 
 AvailableCycles = Nat
 RefundedCycles = Nat
 
 CanisterModule = {
-  init : (CanisterId, Arg, CallerId, Env) -> Trap | Return WasmState
-  pre_upgrade : (WasmState, Principal, Env) -> Trap | Return StableMemory
-  post_upgrade : (CanisterId, StableMemory, Arg, CallerId, Env) -> Trap | Return WasmState
+  init : (CanisterId, Arg, CallerId, Env) -> Trap { cycles_used : Nat; } | Return {
+    new_state : WasmState;
+    cycles_used : Nat;
+  }
+  pre_upgrade : (WasmState, Principal, Env) -> Trap { cycles_used : Nat; } | Return {
+    stable_memory : StableMemory;
+    cycles_used : Nat;
+  }
+  post_upgrade : (CanisterId, StableMemory, Arg, CallerId, Env) -> Trap { cycles_used : Nat; } | Return {
+    new_state : WasmState;
+    cycles_used : Nat;
+  }
   update_methods : MethodName ↦ ((Arg, CallerId, Env, AvailableCycles) -> UpdateFunc)
   query_methods : MethodName ↦ ((Arg, CallerId, Env) -> QueryFunc)
-  heartbeat : (Env) -> WasmState -> Trap | Return WasmState
+  heartbeat : (Env) -> HeartbeatFunc
   callbacks : (Callback, Response, RefundedCycles, Env, AvailableCycles) -> UpdateFunc
-  inspect_message : (MethodName, WasmState, Arg, CallerId, Env) -> Trap | Return (Accept | Reject)
+  inspect_message : (MethodName, WasmState, Arg, CallerId, Env) -> Trap { cycles_used : Nat; } | Return {
+    status : Accept | Reject;
+    cycles_used : Nat;
+  }
 }
 ....
 
@@ -2312,9 +2330,11 @@ The `CanisterId` parameter of `init` and `post_upgrade` is merely passed through
 
 The `Env` parameter provides synchronous read-only access to portions of the system state and canister metadata that are always available.
 
-The parsing of a blob to a canister module is modelled via the (possibly implicitly failing) function
+The parsing of a blob to a canister module and its public and private custom sections is modelled via the (possibly implicitly failing) functions
 ....
 parse_wasm_mod : Blob -> CanisterModule
+parse_public_custom_sections : Blob -> Text ↦ Blob
+parse_private_custom_sections : Blob -> Text ↦ Blob
 ....
 
 The concrete mapping of this abstract `CanisterModule` to actual WebAssembly concepts and the System API is described separately in section <<concrete-canisters>>.
@@ -2417,6 +2437,27 @@ APIReadRequest
   }
 ....
 
+Signed delegations contain the (unsigned) delegation data in a nested record, next to the signature of that data.
+....
+PublicKey = Blob
+Signature = Blob
+SignedDelegation = {
+  delegation : {
+    pubkey : PublicKey;
+    targets : [CanisterId] | Unrestricted;
+    senders : [Principal] | Unrestricted;
+    expiration : Timestamp
+  };
+  signature : Signature
+}
+....
+
+For the signatures in a `Request`, we assume that the following function implements signature verification as described in <<authentication>>.
+This function picks the corresponding signature scheme according to the DER-encoded metadata in the public key.
+....
+verify_signature : PublicKey -> Signature -> Blob -> Bool
+....
+
 ....
 Envelope = {
   content : Request | APIReadRequest;
@@ -2440,26 +2481,6 @@ A `Path` may refer to a request by way of a _request id_, as specified in <<requ
 ....
 RequestId = Blob
 hash_of_map: Request -> RequestId
-....
-
-For the signatures in a `Request`, we assume that the following function implements signature verification as described in <<authentication>>.
-This function picks the corresponding signature scheme according to the DER-encoded metadata in the public key.
-....
-PublicKey = Blob
-Signature = Blob
-verify_signature : PublicKey -> Signature -> Blob -> Bool
-....
-
-Signed delegations contain the (unsigned) delegation data in a nested record, next to the signature of that data.
-....
-SignedDelegation = {
-  delegation : {
-    pubkey : PublicKey;
-    targets : [CanisterId] | Unrestricted;
-    expiration : Timestamp
-  };
-  signature : Signature
-}
 ....
 
 ==== The system state
@@ -2517,7 +2538,7 @@ The initial state of the IC is
   certified_data = ();
   system_time = T;
   call_contexts = ();
-  messages = ();
+  messages = [];
   root_key = PublicKey;
 }
 ....
@@ -2548,14 +2569,13 @@ The following is an incomplete list of invariants that should hold for the abstr
   if Ctxt.needs_to_respond = false then Ctxt.available_cycles = 0
 ....
 
-* Referenced call contexts exists:
+* Referenced call contexts exist:
 +
 ....
-∀ CallMessage {origin = FromCanister O, …} ∈ S.messages. O.calling_context ∈ S.call_contexts
-∀ ResponseMessage {origin = FromCanister O, …} ∈ S.messages. O.calling_context ∈ S.call_contexts
-∀ _ ↦ Ctxt ∈ S.call_contexts:
-  if Ctx.needs_to_respond:
-     Ctxt.origin.calling_context ∈ S.call_contexts
+∀ CallMessage {origin = FromCanister O, …} ∈ S.messages. O.calling_context ∈ dom(S.call_contexts)
+∀ ResponseMessage {origin = FromCanister O, …} ∈ S.messages. O.calling_context ∈ dom(S.call_contexts)
+∀ _ ↦ {needs_to_respond = true, origin = FromCanister O, …} ∈ S.call_contexts: O.calling_context ∈ dom(S.call_contexts)
+∀ _ ↦ Stopping Origins ∈ S.canister_status: ∀(FromCanister O, _) ∈ Origins. O.calling_context ∈ dom(S.call_contexts)
 ....
 
 === State transitions
@@ -2619,19 +2639,29 @@ Requests that have expired are dropped here.
 
 Ingress message inspection is applied, and messages that are not accepted by the canister are dropped.
 
+The (unspecified) function `idle_cycles_burned_rate(S, cid)` determines the idle resource consumption rate in cycles per day of the canister with id `cid`,
+given its current memory footprint, compute and storage cost, and memory and compute allocation.
+The function `freezing_limit(S, cid)` determines the freezing threshold in cycles of the canister with id `cid`,
+given its current memory footprint, compute and storage cost, memory and compute allocation, and current `freezing_threshold` setting.
+The value `freezing_limit(S, cid)` is derived from `idle_cycles_burned_rate(S, cid)` and `freezing_threshold` as follows:
+....
+    freezing_limit(S, cid) = idle_cycles_burned_rate(S, cid) * S.freezing_threshold[cid] / (24 * 60 * 60)
+....
+
 Submitted request:: `E : Envelope`
 Conditions::
 ....
     E.content.canister_id ∈ verify_envelope(E, E.content.sender, S.system_time)
-    E.content ∉ requests
+    E.content ∉ dom(S.requests)
     S.system_time <= E.content.ingress_expiry
     is_effective_canister_id(E.content, ECID)
     ( E.content.canister_id = ic_principal
       E.content.arg = candid({canister_id = CanisterId, …})
       E.content.sender ∈ S.controllers[CanisterId]
       E.content.method_name ∈
-        { "install_code", "update_settings", "start_canister", "stop_canister",
-          "canister_status", "delete_canister" }
+        { "install_code", "uninstall_code", "update_settings", "start_canister", "stop_canister",
+          "canister_status", "delete_canister",
+          "provisional_create_canister_with_cycles", "provisional_top_up_canister" }
     ) ∨ (
       E.content.canister_id ≠ ic_principal
       S.canisters[E.content.canister_id] ≠ EmptyCanister
@@ -2643,13 +2673,16 @@ Conditions::
         status = simple_status(S.canister_status[E.content.canister_id]);
       }
       S.canisters[E.content.canister_id].module.inspect_message
-        (E.content.method_name, C.wasm_state, E.content.arg, E.content.sender, Env) = Return Accept
+        (E.content.method_name, S.canisters[E.content.canister_id].wasm_state, E.content.arg, E.content.sender, Env) = Return {status = Accept; cycles_used = Cycles_used;}
+      Cycles_used ≤ S.balances[E.content.canister_id]
    )
 ....
 State after::
 ....
 S with
     requests[E.content] = Received
+    if E.content.canister_id ≠ ic_principal then
+      balances[E.content.canister_id] = S.balances[E.content.canister_id] - Cycles_used
 ....
 
 NOTE: This is not instantaneous (the IC takes some time to agree it accepts the request) nor guaranteed (a node could just drop the request, or maybe it did not pass validation). But once the request has entered the IC state like this, it will be acted upon.
@@ -2704,15 +2737,6 @@ S with
 
 A call to a canister which is stopping, stopped, or frozen is automatically rejected.
 
-The (unspecified) function `idle_cycles_burned_rate(S, cid)` determines the idle resource consumption rate in cycles per day of the canister with id `cid`,
-given its current memory footprint, compute and storage cost, and memory and compute allocation.
-The function `freezing_limit(S, cid)` determines the freezing threshold in cycles of the canister with id `cid`,
-given its current memory footprint, compute and storage cost, memory and compute allocation, and current `freezing_threshold` setting.
-The value `freezing_limit(S, cid)` is derived from `idle_cycles_burned_rate(S, cid)` and `freezing_threshold` as follows:
-....
-    freezing_limit(S, cid) = idle_cycles_burned_rate(S, cid) * S.freezing_threshold[cid] / (24 * 60 * 60)
-....
-
 Conditions::
 ....
     S.messages = Older_messages · CallMessage CM · Younger_messages
@@ -2752,7 +2776,7 @@ Conditions::
     S.canisters[CM.callee] ≠ EmptyCanister
     S.canister_status[CM.callee] = Running
     S.balances[CM.callee] ≥ freezing_limit(S, CM.callee) + MAX_CYCLES_PER_MESSAGE
-    Ctxt_id ∉ dom S.call_contexts
+    Ctxt_id ∉ dom(S.call_contexts)
 ....
 +
 State after::
@@ -2775,7 +2799,7 @@ S with
       deleted = false;
       available_cycles = CM.transferred_cycles;
     }
-    balances[CM.callee] = balances[CM.callee] - MAX_CYCLES_PER_MESSAGE
+    balances[CM.callee] = S.balances[CM.callee] - MAX_CYCLES_PER_MESSAGE
 ....
 
 * Call context creation: Heartbeat
@@ -2788,7 +2812,7 @@ Conditions::
     S.canisters[C] ≠ EmptyCanister
     S.canister_status[C] = Running
     balances[C] ≥ freezing_limit(S, C) + MAX_CYCLES_PER_MESSAGE
-    Ctxt_id ∉ dom S.call_contexts
+    Ctxt_id ∉ dom(S.call_contexts)
 ....
 +
 State after::
@@ -2810,7 +2834,7 @@ S with
       deleted = false;
       available_cycles = 0;
     }
-    balances[C] = balances[C] - MAX_CYCLES_PER_MESSAGE
+    balances[C] = S.balances[C] - MAX_CYCLES_PER_MESSAGE
 ....
 
 The IC can execute any message that is at the head of its queue, i.e. there is no older message with the same abstract `queue` field.  The actual message execution, if successful, may enqueue further messages and -- if the function returns a response -- record this response.  The new call and response messages are enqueued at the end.
@@ -2858,14 +2882,14 @@ State after::
 ....
 if
   R = Return res
-  Cycles_used ≤ (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE)
+  res.cycles_used ≤ (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE)
   res.cycles_accepted ≤ Available
-  (Cycles_used + ∑ [ MAX_CYCLES_PER_RESPONSE + call.transferred_cycles | call ∈ res.new_calls ]) ≤
+  (res.cycles_used + ∑ [ MAX_CYCLES_PER_RESPONSE + call.transferred_cycles | call ∈ res.new_calls ]) ≤
     (S.balances[M.receiver] + res.cycles_accepted + (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE))
   New_balance =
       (S.balances[M.receiver] + res.cycles_accepted + (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE))
-      - (Cycles_used + ∑ [ MAX_CYCLES_PER_RESPONSE + call.transferred_cycles | call ∈ res.new_calls ])
-  New_balance > if Is_response then 0 else freezing_limit(S, CM.callee);
+      - (res.cycles_used + ∑ [ MAX_CYCLES_PER_RESPONSE + call.transferred_cycles | call ∈ res.new_calls ])
+  New_balance ≥ if Is_response then 0 else freezing_limit(S, M.receiver);
   (res.response = NoResponse) or S.call_contexts[M.call_context].needs_to_respond
 then
   S with
@@ -2907,8 +2931,8 @@ else
   S with
     messages = Older_messages · Younger_messages
     balances[M.receiver] =
-      S.balances[M.receiver] +
-      ((if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE) - Cycles_used)
+      (S.balances[M.receiver] + (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE))
+      - min (R.cycles_used, (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE))
 ....
 
 
@@ -2935,24 +2959,26 @@ The functions `query_as_update` and `heartbeat_as_update` turns a query function
 ....
 query_as_update(f, arg, env) = λ wasm_state →
   match f(arg, env)(wasm_state) with
-    Trap → Trap
+    Trap trap → Trap trap
     Return res → Return {
       new_state = wasm_state;
       new_calls = [];
       new_certified_data = NoCertifiedData;
-      response = res;
+      response = res.response;
       cycles_accepted = 0;
+      cycles_used = res.cycles_used;
     }
 
 heartbeat_as_update(f, env) = λ wasm_state →
   match f(env)(wasm_state) with
-    Trap → Trap
-    Return wasm_state → Return {
-      new_state = wasm_state;
+    Trap trap → Trap trap
+    Return res → Return {
+      new_state = res.new_state;
       new_calls = [];
       new_certified_data = NoCertifiedData;
       response = NoResponse;
       cycles_accepted = 0;
+      cycles_used = res.cycles_used;
     }
 ....
 Note that by construction, a query function will either trap or return with a response; it will never send calls, and it will never change the state of the canister.
@@ -2968,9 +2994,7 @@ Conditions::
     S.call_contexts[Ctxt_id].origin ≠ FromHeartbeat
     ∀ CallMessage {origin = FromCanister O, …} ∈ S.messages. O.calling_context ≠ Ctxt_id
     ∀ ResponseMessage {origin = FromCanister O, …} ∈ S.messages. O.calling_context ≠ Ctxt_id
-    ∀ ctxt_ids ∈ dom(S.call_contexts).
-        S.call_contexts[ctxt_ids].needs_to_respond
-        ==> S.call_contexts[ctxt_ids].origin.calling_context ≠ Ctxt_id
+    ∀ _ ↦ {needs_to_respond = true, origin = FromCanister O, …} ∈ S.call_contexts: O.calling_context ≠ Ctxt_id
 ....
 State after::
 ....
@@ -3001,9 +3025,8 @@ Conditions::
     )
     ∀ CallMessage {origin = FromCanister O, …} ∈ S.messages. O.calling_context ≠ Ctxt_id
     ∀ ResponseMessage {origin = FromCanister O, …} ∈ S.messages. O.calling_context ≠ Ctxt_id
-    ∀ ctxt_ids.
-        S.call_contexts[ctxt_ids].needs_to_respond = true
-        ==> S.call_contexts[ctxt_ids].origin.calling_context ≠ Ctxt_id
+    ∀ _ ↦ {needs_to_respond = true, origin = FromCanister O, …} ∈ S.call_contexts: O.calling_context ≠ Ctxt_id
+    ∀ _ ↦ Stopping Origins ∈ S.canister_status: ∀(FromCanister O, _) ∈ Origins. O.calling_context ≠ Ctxt_id
 ....
 State after::
 ....
@@ -3029,7 +3052,7 @@ Conditions::
     M.method_name = 'create_canister'
     M.arg = candid(A)
     is_system_assigned CanisterId
-    CanisterId ∉ dom S.canisters
+    CanisterId ∉ dom(S.canisters)
 ....
 State after::
 ....
@@ -3040,12 +3063,13 @@ S with
       controllers[CanisterId] = A.settings.controllers
     else:
       controllers[CanisterId] = [M.caller]
+    freezing_threshold[CanisterId] = 2592000
     balances[CanisterId] = M.transferred_cycles
     certified_data[CanisterId] = ""
     messages = Older_messages · Younger_messages ·
       ResponseMessage {
         origin = M.origin
-        response = Accepted (candid({canister_id = CanisterId}))
+        response = Reply (candid({canister_id = CanisterId}))
         refunded_cycles = 0
       }
     canister_status[CanisterId] = Running
@@ -3083,12 +3107,12 @@ State after::
 S with
     if A.settings.controllers is not null:
       controllers[A.canister_id] = A.settings.controllers
-    if A.settings.freezing_threshold exists:
+    if A.settings.freezing_threshold is not null:
       freezing_threshold[A.canister_id] = A.settings.freezing_threshold
     messages = Older_messages · Younger_messages ·
       ResponseMessage {
         origin = M.origin
-        response = Accepted (candid())
+        response = Reply (candid())
         refunded_cycles = M.transferred_cycles
       }
 ....
@@ -3121,10 +3145,10 @@ S with
           module_hash =
             if S.canisters[A.canister_id] = EmptyCanister
             then null
-            else opt (SHA-265(S.canisters[A.canister_id].raw_module));
+            else opt (SHA-256(S.canisters[A.canister_id].raw_module));
           controllers = S.controllers[A.canister_id];
           memory_size = Memory_size;
-          cycles = S.balance[A.canister_id];
+          cycles = S.balances[A.canister_id];
           freezing_threshold = S.freezing_threshold[A.canister_id];
           idle_cycles_burned_per_day = idle_cycles_burned_rate(S, A.canister_id);
         })
@@ -3144,29 +3168,38 @@ Conditions::
     M.method_name = 'install_code'
     M.arg = candid(A)
     Mod = parse_wasm_mod(A.wasm_module)
-      (A.mode = install && S.canisters[A.canister_id] = EmptyCanister)
-    or A.mode = reinstall
+    Public_custom_sections = parse_public_custom_sections(A.wasm_module);
+    Private_custom_sections = parse_private_custom_sections(A.wasm_module);
+    (A.mode = install and S.canisters[A.canister_id] = EmptyCanister) or A.mode = reinstall
     M.caller ∈ S.controllers[A.canister_id]
     Env = {
-      time = S.time[M.receiver];
-      balance = S.balances[M.receiver];
-      freezing_limit = freezing_limit(S, M.receiver);
+      time = S.time[A.canister_id];
+      balance = S.balances[A.canister_id];
+      freezing_limit = freezing_limit(S, A.canister_id);
       certificate = NoCertificate;
-      status = simple_status(S.canister_status[M.receiver]);
+      status = simple_status(S.canister_status[A.canister_id]);
     }
-    Mod.init(A.canister_id, A.arg, M.caller, Env) = Return New_state
+    Mod.init(A.canister_id, A.arg, M.caller, Env) = Return {new_state = New_state; cycles_used = Cycles_used;}
+    Cycles_used ≤ S.balances[A.canister_id]
     dom(Mod.update_methods) ∩ dom(Mod.query_methods) = ∅
+
 ....
 State after::
 ....
 S with
-    canisters[A.canister_id] =
-      { wasm_state = New_state; module = Mod; raw_module = A.wasm_module }
+    canisters[A.canister_id] = {
+      wasm_state = New_state;
+      module = Mod;
+      raw_module = A.wasm_module;
+      public_custom_sections = Public_custom_sections;
+      private_custom_sections = Private_custom_sections;
+    }
+    balances[A.canister_id] = S.balances[A.canister_id] - Cycles_used
     messages = Older_messages · Younger_messages ·
       ResponseMessage {
-        origin = M.origin
-        response = Accepted (candid())
-        refunded_cycles = M.transferred_cycles
+        origin = M.origin;
+        response = Reply (candid());
+        refunded_cycles = M.transferred_cycles;
       }
 ....
 
@@ -3182,32 +3215,39 @@ Conditions::
     M.method_name = 'install_code'
     M.arg = candid(A)
     Mod = parse_wasm_mod(A.wasm_module)
-
+    Public_custom_sections = parse_public_custom_sections(A.wasm_module)
+    Private_custom_sections = parse_private_custom_sections(A.wasm_module)
     A.mode = upgrade
-    S.canisters[A.canister_id] ≠ EmptyCanister
     M.caller ∈ S.controllers[A.canister_id]
-    S.canisters[A.canister_id] = { wasm_state = Old_state; module = Old_module }
+    S.canisters[A.canister_id] = { wasm_state = Old_state; module = Old_module, …}
     Env = {
-      time = S.time[M.receiver];
-      balance = S.balances[M.receiver];
-      freezing_limit = freezing_limit(S, M.receiver);
+      time = S.time[A.canister_id];
+      balance = S.balances[A.canister_id];
+      freezing_limit = freezing_limit(S, A.canister_id);
       certificate = NoCertificate;
-      status = simple_status(S.canister_status[M.receiver]);
+      status = simple_status(S.canister_status[A.canister_id]);
     }
-    Old_module.pre_upgrade(Old_State, M.caller, Env) = Return Stable_memory
-    Mod.post_upgrade(A.canister_id, Stable_memory, A.arg, M.caller, Env) = Return New_state
+    Old_module.pre_upgrade(Old_State, M.caller, Env) = Return {stable_memory = Stable_memory; cycles_used = Cycles_used;}
+    Mod.post_upgrade(A.canister_id, Stable_memory, A.arg, M.caller, Env) = Return {new_state = New_state; cycles_used = Cycles_used';}
+    Cycles_used + Cycles_used' ≤ S.balances[A.canister_id]
     dom(Mod.update_methods) ∩ dom(Mod.query_methods) = ∅
 ....
 State after::
 ....
 S with
-    canisters[A.canister_id] =
-      { wasm_state = New_state; module = Mod; raw_module = A.wasm_module }
+    canisters[A.canister_id] = {
+      wasm_state = New_state;
+      module = Mod;
+      raw_module = A.wasm_module;
+      public_custom_sections = Public_custom_sections;
+      private_custom_sections = Private_custom_sections;
+    }
+    balances[A.canister_id] = S.balances[A.canister_id] - (Cycles_used + Cycles_used');
     messages = Older_messages · Younger_messages ·
       ResponseMessage {
-        origin = M.origin
-        response = Accepted (candid())
-        refunded_cycles = M.transferred_cycles
+        origin = M.origin;
+        response = Reply (candid());
+        refunded_cycles = M.transferred_cycles;
       }
 ....
 
@@ -3234,7 +3274,7 @@ S with
     messages = Older_messages · Younger_messages ·
       ResponseMessage {
         origin = M.origin
-        response = Accepted (candid())
+        response = Reply (candid())
         refunded_cycles = M.transferred_cycles
       } ·
       [ ResponseMessage {
@@ -3305,17 +3345,17 @@ The status of a stopping canister which has no open call contexts is set to `Sto
 
 Conditions::
 ....
-    S.canister_status[A.canister_id] = Stopping Origins
-    ∀ Ctxt_id. S.call_contexts[Ctxt_id].canister ≠ A.canister_id
+    S.canister_status[Canister_id] = Stopping Origins
+    ∀ Ctxt_id. S.call_contexts[Ctxt_id].canister ≠ Canister_id
 ....
 State after::
 ....
 S with
     canister_status[CanisterId] = Stopped
-    messages = Messages ·
+    messages = S.Messages ·
         [ ResponseMessage {
             origin = O
-            response = Accepted (candid())
+            response = Reply (candid())
             refunded_cycles = C
           }
         | (O, C) ∈ Origins
@@ -3337,12 +3377,12 @@ Conditions::
 State after::
 ....
 S with
-    messages = Older_messages · Younger_messages
-    S.messages = Messages ·
-        ResponseMessage {
-          origin = M.origin
-          response = Accepted (candid())
-        }
+    messages = Older_messages · Younger_messages ·
+      ResponseMessage {
+        origin = M.origin;
+        response = Reply (candid());
+        refunded_cycles = M.transferred_cycles;
+      }
 ....
 
 ==== IC Management Canister: Starting a canister
@@ -3366,7 +3406,7 @@ S with
     messages = Older_messages · Younger_messages ·
         ResponseMessage{
             origin = M.origin
-            response = Accepted (candid())
+            response = Reply (candid())
             refunded_cycles = M.transferred_cycles
         }
 ....
@@ -3391,7 +3431,7 @@ S with
     messages = Older_messages · Younger_messages ·
         ResponseMessage{
             origin = M.origin
-            response = Accepted (candid())
+            response = Reply (candid())
             refunded_cycles = M.transferred_cycles
         } ·
         [ ResponseMessage {
@@ -3412,21 +3452,23 @@ Conditions::
     M.callee = ic_principal
     M.method_name = 'delete_canister'
     M.arg = candid(A)
-    S.canister_status[A.canister_id] = stopped
+    S.canister_status[A.canister_id] = Stopped
     M.caller ∈ S.controllers[A.canister_id]
 ....
 State after::
 ....
 S with
-    canisters[CanisterId] = (deleted)
-    controllers[CanisterId] = (deleted)
-    canister_status[CanisterId] = (deleted)
-    time[CanisterId] = (deleted)
-    balances[CanisterId] = (deleted)
+    canisters[A.canister_id] = (deleted)
+    controllers[A.canister_id] = (deleted)
+    freezing_threshold[A.canister_id] = (deleted)
+    canister_status[A.canister_id] = (deleted)
+    time[A.canister_id] = (deleted)
+    balances[A.canister_id] = (deleted)
+    certified_data[A.canister_id] = (deleted)
     messages = Older_messages · Younger_messages ·
       ResponseMessage {
         origin = M.origin
-        response = Accepted (candid())
+        response = Reply (candid())
         refunded_cycles = M.transferred_cycles
       }
 ....
@@ -3440,17 +3482,17 @@ Conditions::
     M.callee = ic_principal
     M.method_name = 'deposit_cycles'
     M.arg = candid(A)
-    Cycle_cost ≤ S.balances[A.canister_id] + M.transferred_cycles
+    A.canister_id ∈ dom(S.balances)
 ....
 State after::
 ....
 S with
-    balances[CanisterId] =
+    balances[A.canister_id] =
       S.balances[A.canister_id] + M.transferred_cycles
     messages = Older_messages · Younger_messages ·
       ResponseMessage {
         origin = M.origin
-        response = Accepted (candid())
+        response = Reply (candid())
         refunded_cycles = 0
       }
 ....
@@ -3476,7 +3518,7 @@ S with
     messages = Older_messages · Younger_messages ·
       ResponseMessage {
         origin = M.origin
-        response = Accepted (candid(B))
+        response = Reply (candid(B))
         refunded_cycles = M.transferred_cycles
       }
 ....
@@ -3493,7 +3535,7 @@ Conditions::
     M.method_name = 'provisional_create_canister_with_cycles'
     M.arg = candid(A)
     is_system_assigned CanisterId
-    CanisterId ∉ dom S.canisters
+    CanisterId ∉ dom(S.canisters)
 ....
 State after::
 ....
@@ -3501,12 +3543,13 @@ S with
     canisters[CanisterId] = EmptyCanister
     time[CanisterId] = CurrentTime
     controllers[CanisterId] = [M.caller]
+    freezing_threshold[CanisterId] = 2592000
     balances[CanisterId] = A.amount
     certified_data[CanisterId] = ""
     messages = Older_messages · Younger_messages ·
       ResponseMessage {
         origin = M.origin
-        response = Accepted (candid({canister_id = CanisterId}))
+        response = Reply (candid({canister_id = CanisterId}))
         transferred_cycles = M.transferred_cycles
       }
     canister_status[CanisterId] = Running
@@ -3521,12 +3564,12 @@ Conditions::
     M.callee = ic_principal
     M.method_name = 'provisional_top_up_canister'
     M.arg = candid(A)
-    A.canister_id ∈ dom S.canisters
+    A.canister_id ∈ dom(S.canisters)
 ....
 State after::
 ....
 S with
-    balances[CanisterId] = balances[CanisterId] + A.amount
+    balances[A.canister_id] = S.balances[A.canister_id] + A.amount
 ....
 
 ==== Callback invocation
@@ -3543,18 +3586,19 @@ Conditions::
         callback = Callback
       }
     not S.call_contexts[Ctxt_id].deleted
+    S.call_contexts[Ctxt_id].canister ∈ dom(S.balances)
 ....
 State after::
 ....
 S with
     balances[S.call_contexts[Ctxt_id].canister] =
-      balances[S.call_contexts[Ctxt_id].canister] + RM.refunded_cycles
+      S.balances[S.call_contexts[Ctxt_id].canister] + RM.refunded_cycles
     messages =
       Older_messages ·
       FuncMessage {
         call_context = Ctxt_id
-        receiver = C
-        entry_point = Callback Callback FM.response RM.refunded_cycles
+        receiver = S.call_contexts[Ctxt_id].canister
+        entry_point = Callback Callback RM.response RM.refunded_cycles
         queue = Unordered
       } ·
       Younger_messages
@@ -3571,12 +3615,13 @@ Conditions::
         callback = Callback
       }
     S.call_contexts[Ctxt_id].deleted
+    S.call_contexts[Ctxt_id].canister ∈ dom(S.balances)
 ....
 State after::
 ....
 S with
     balances[S.call_contexts[Ctxt_id].canister] =
-      balances[S.call_contexts[Ctxt_id].canister] + RM.refunded_cycles + MAX_CYCLES_PER_RESPONSE
+      S.balances[S.call_contexts[Ctxt_id].canister] + RM.refunded_cycles + MAX_CYCLES_PER_RESPONSE
     messages = Older_messages · Younger_messages
 ....
 
@@ -3586,17 +3631,17 @@ When an ingress method call has been responded to, we can record the response in
 
 Conditions::
 ....
-    S.requests[M] = Processing
     S.messages = Older_messages · ResponseMessage RM · Younger_messages
     RM.origin = FromUser { request = M }
+    S.requests[M] = Processing
 ....
 State after::
 ....
 S with
     messages = Older_messages · Younger_messages
     requests[M] =
-      | Replied R   if response = Reply R
-      | Rejected R  if response = Reject R
+      | Replied R        if M.response = Reply R
+      | Rejected (c, R)  if M.response = Reject (c, R)
 ....
 
 NB: The refunded cycles, `RM.refunded_cycles` are, by construction, empty.
@@ -3641,21 +3686,21 @@ State after::
 ....
 S with
     canisters[CanisterId] = EmptyCanister
-    certified_data[A.canister_id] = ""
+    certified_data[Canister_id] = ""
 
-    messages = Older_messages · Younger_messages ·
+    messages = S.messages ·
       [ ResponseMessage {
           origin = Ctxt.origin
           response = Reject (CANISTER_REJECT, 'Canister has been uninstalled')
           refunded_cycles = Ctxt.available_cycles
         }
       | Ctxt_id ↦ Ctxt ∈ S.call_contexts
-      , Ctxt.canister = A.canister_id
+      , Ctxt.canister = CanisterId
       , Ctxt.needs_to_respond = true
       ]
 
     for Ctxt_id ↦ Ctxt ∈ S.call_contexts:
-      if Ctxt.canister = A.canister_id:
+      if Ctxt.canister = CanisterId:
         call_contexts[Ctxt_id].deleted := true
         call_contexts[Ctxt_id].needs_to_respond := false
         call_contexts[Ctxt_id].available_cycles := 0
@@ -3732,17 +3777,17 @@ Conditions::
   }
 ....
 Read response::
-* If `F(Q.Arg, Q.sender, Env) = Trap` then
+* If `F(Q.Arg, Q.sender, Env) = Trap trap` then
 +
 ....
 {status: rejected; reject_code: CANISTER_ERROR, reject_message: <implementation-specific>, error_code: <implementation-specific>}
 ....
-* Else if `F(Q.Arg, Q.sender, Env) = Return (Reject (code, msg))` then
+* Else if `F(Q.Arg, Q.sender, Env) = Return {response = Reject (code, msg); …}` then
 +
 ....
 {status: rejected; reject_code: <code>: reject_message: <msg>, error_code: <implementation-specific>}
 ....
-* Else if `F(Q.Arg, Q.sender, Env) = Return (Reply R)` then
+* Else if `F(Q.Arg, Q.sender, Env) = Return {response = Reply R; …}` then
 +
 ....
 {status: success; reply: { arg :  <R> } }
@@ -3775,9 +3820,9 @@ may_read_path(S, _, ["request_status", Rid] · _) =
 may_read_path(S, _, ["canister", cid, "module_hash"]) = cid == ECID
 may_read_path(S, _, ["canister", cid, "controllers"]) = cid == ECID
 may_read_path(S, _, ["canister", cid, "metadata", name]) =
-  if name ∈ S.canisters[cid].public_custom_sections
+  if name ∈ dom(S.canisters[cid].public_custom_sections)
   then cid == ECID
-  else if name ∈ S.canisters[cid].private_custom_sections
+  else if name ∈ dom(S.canisters[cid].private_custom_sections)
   then cid == ECID ∧ RS.sender ∈ S.controllers[cid]
   else False
 may_read_path(S, _, _) = False
@@ -3867,6 +3912,7 @@ ExecutionState = {
   response : NoResponse | Response;
   cycles_accepted : Nat;
   cycles_available : Nat;
+  cycles_used : Nat;
   balance : Funds;
   reply_params : { arg : Blob };
   pending_call : MethodCall | NoPendingCall;
@@ -3905,6 +3951,7 @@ empty_execution_state = {
   response = NoResponse;
   cycles_accepted = 0;
   cycles_available = 0;
+  cycles_used = 0;
   balance = 0;
   reply_params = { arg = "" };
   pending_call = NoPendingCall;
@@ -3921,7 +3968,7 @@ If the WebAssembly module does not export a function called under the name `cani
 +
 ....
 init = λ (self_id, arg, caller, sysenv) →
-  Return { store = initial_wasm_store; self_id = self_id; stable_mem = "" }
+  Return {new_state = { store = initial_wasm_store; self_id = self_id; stable_mem = "" }; cycles_used = 0;}
 ....
 +
 Otherwise, if the WebAssembly module exports a function `func` under the name `canister_init`, it is
@@ -3933,11 +3980,11 @@ init = λ (self_id, arg, caller, sysenv) →
       params = empty_params with { arg = arg; caller = caller; sysenv }
       balance = sysenv.balance
     }
-  try func<es>() with Trap then Trap
-  if es.performed_calls ≠ [] then Trap
-  if es.response ≠ NoResponse then Trap
-  if es.ingress_filter ≠ Reject then Trap
-  Return es.wasm_state
+  try func<es>() with Trap then Trap {cycles_used = es.cycles_used;}
+  if es.calls ≠ [] then Trap {cycles_used = es.cycles_used;}
+  if es.response ≠ NoResponse then Trap {cycles_used = es.cycles_used;}
+  if es.ingress_filter ≠ Reject then Trap {cycles_used = es.cycles_used;}
+  Return {new_state = es.wasm_state; cycles_used = es.cycles_used;}
 ....
 +
 This formulation checks afterwards that the system calls `call.perform` or `msg.reply` were not invoked; an implementation can of course trap as soon as these system calls are invoked.
@@ -3947,7 +3994,7 @@ This formulation checks afterwards that the system calls `call.perform` or `msg.
 If the WebAssembly module does not export a function called under the name `canister_pre_upgrade`, then it simply returns the stable memory:
 +
 ....
-pre_upgrade = λ (old_state, caller, sysenv) → Return old_state.stable_mem
+pre_upgrade = λ (old_state, caller, sysenv) → Return {stable_memory = old_state.stable_mem; cycles_used = 0;}
 ....
 +
 Otherwise, if the WebAssembly module exports a function `func` under the name `canister_pre_upgrade`, it is
@@ -3959,11 +4006,11 @@ pre_upgrade = λ (old_state, caller, sysenv) →
       params = { empty_params with caller = caller; sysenv }
       balance = sysenv.balance
     }
-  try func<es>() with Trap then Trap
-  if es.performed_calls ≠ [] then Trap
-  if es.response ≠ NoResponse then Trap
-  if es.ingress_filter ≠ Reject then Trap
-  Return es.wasm_state.stable_mem
+  try func<es>() with Trap then Trap {cycles_used = es.cycles_used;}
+  if es.calls ≠ [] then Trap {cycles_used = es.cycles_used;}
+  if es.response ≠ NoResponse then Trap {cycles_used = es.cycles_used;}
+  if es.ingress_filter ≠ Reject then Trap {cycles_used = es.cycles_used;}
+  Return {stable_memory = es.wasm_state.stable_mem; cycles_used = es.cycles_used;}
 ....
 
 
@@ -3973,7 +4020,7 @@ If the WebAssembly module does not export a function called under the name `cani
 +
 ....
 post_upgrade = λ (self_id, stable_mem, arg, caller, sysenv) →
-  Return { store = initial_wasm_store; self_id = self_id; stable_mem = stable_mem }
+  Return {new_state = { store = initial_wasm_store; self_id = self_id; stable_mem = stable_mem }; cycles_used = 0;}
 ....
 +
 Otherwise, if the WebAssembly module exports a function `func` under the name `canister_post_upgrade`, it is
@@ -3985,11 +4032,11 @@ post_upgrade = λ (self_id, stable_mem, arg, caller, sysenv) →
       params = { empty_params with arg = arg; caller = caller; sysenv }
       balance = sysenv.balance
     }
-  try func<es>() with Trap then Trap
-  if es.performed_calls ≠ [] then Trap
-  if es.response ≠ NoResponse then Trap
-  if es.ingress_filter ≠ Reject then Trap
-  Return es.wasm_state
+  try func<es>() with Trap then Trap {cycles_used = es.cycles_used;}
+  if es.calls ≠ [] then Trap {cycles_used = es.cycles_used;}
+  if es.response ≠ NoResponse then Trap {cycles_used = es.cycles_used;}
+  if es.ingress_filter ≠ Reject then Trap {cycles_used = es.cycles_used;}
+  Return {new_state = es.wasm_state; cycles_used = es.cycles_used;}
 ....
 
 * The partial map `update_methods` of the `CanisterModule` is defined for all method names `method` for which the WebAssembly program exports a function `func` named `canister_update <method>`, and has value
@@ -4002,14 +4049,15 @@ update_methods[method] = λ (arg, caller, sysenv, available) → λ wasm_state �
       balance = sysenv.balance
       cycles_available = available;
     }
-  try func<es>() with Trap then Trap
-  if es.ingress_filter ≠ Reject then Trap
+  try func<es>() with Trap then Trap {cycles_used = es.cycles_used;}
+  if es.ingress_filter ≠ Reject then Trap {cycles_used = es.cycles_used;}
   Return {
     new_state = es.wasm_state;
     new_calls = es.calls;
     response = es.response;
     cycles_accepted = es.cycles_accepted;
-    new_certified_data = es.new_certified_data
+    cycles_used = es.cycles_used;
+    new_certified_data = es.new_certified_data;
   }
 ....
 
@@ -4022,12 +4070,15 @@ query_methods[method] = λ (arg, caller, sysenv) → λ wasm_state →
       params = empty_params with { arg = arg; caller = caller; sysenv }
       balance = sysenv.balance
     }
-  try func<es>() with Trap then Trap
-  if es.cycles_accepted ≠ 0 then Trap
-  if es.calls ≠ () then Trap
-  if es.ingress_filter ≠ Reject then Trap
-  if es.response = NoResponse then Trap
-  Return es.response;
+  try func<es>() with Trap then Trap {cycles_used = es.cycles_used;}
+  if es.cycles_accepted ≠ 0 then Trap {cycles_used = es.cycles_used;}
+  if es.calls ≠ [] then Trap {cycles_used = es.cycles_used;}
+  if es.ingress_filter ≠ Reject then Trap {cycles_used = es.cycles_used;}
+  if es.response = NoResponse then Trap {cycles_used = es.cycles_used;}
+  Return {
+    response = es.response;
+    cycles_used = es.cycles_used;
+  }
 ....
 +
 This formulation checks afterwards that the system call `ic0.call_perform` was not invoked; an implementation can of course trap already when these system calls have been invoked.
@@ -4043,15 +4094,18 @@ heartbeat = λ (sysenv) → λ wasm_state →
     params = empty_params with { arg = NoArg; caller = NoCaller; sysenv }
     balance = sysenv.balance
   }
-  try func<es>() with Trap then Trap
-  if es.cycles_accepted ≠ 0 then Trap
-  if es.ingress_filter ≠ Reject then Trap
-  if es.response ≠ NoResponse then Trap
-  Return es.wasm_state;
+  try func<es>() with Trap then Trap {cycles_used = es.cycles_used;}
+  if es.cycles_accepted ≠ 0 then Trap {cycles_used = es.cycles_used;}
+  if es.ingress_filter ≠ Reject then Trap {cycles_used = es.cycles_used;}
+  if es.response ≠ NoResponse then Trap {cycles_used = es.cycles_used;}
+  Return {
+    new_state = es.wasm_state;
+    cycles_used = es.cycles_used;
+  }
 ....
 otherwise it is
 ....
-heartbeat = λ (sysenv) → λ wasm_state → Trap
+heartbeat = λ (sysenv) → λ wasm_state → Trap {cycles_used = 0;}
 ....
 
 * The function `callbacks` of the `CanisterModule` is defined  as follows
@@ -4069,40 +4123,46 @@ callbacks = λ(callbacks, response, refunded_cycles, sysenv, available) → λ w
     Reject (reject_code, reject_message)->
       (callbacks.on_reject.fun, callbacks.on_reject.env,
         { params0 with reject_code; reject_message})
+  let es = ref {empty_execution_state with
+    wasm_state = wasm_state;
+    params = params;
+    balance = sysenv.balance;
+    cycles_available = available;
+  }
   try
     if fun > |es.wasm_state.store.table| then Trap
     let func = es.wasm_state.store.table[fun]
     if typeof(func) ≠ func (i32) -> () then Trap
 
-    let es = ref {empty_execution_state with
-      wasm_state = wasm_state;
-      params = params;
-      balance = sysenv.balance;
-      cycles_available = available;
-    }
     func<es>(env)
     Return {
       new_state = es.wasm_state;
       new_calls = es.calls;
       response = es.response;
       cycles_accepted = es.cycles_accepted;
+      cycles_used = es.cycles_used;
       new_certified_data = es.certified_data;
     }
   with Trap
-    if callbacks.on_cleanup = NoClosure then Trap
-    if callbacks.on_cleanup.fun > |es.wasm_state.store.table| then Trap
+    if callbacks.on_cleanup = NoClosure then Trap {cycles_used = es.cycles_used;}
+    if callbacks.on_cleanup.fun > |es.wasm_state.store.table| then Trap {cycles_used = es.cycles_used;}
     let func = es.wasm_state.store.table[callbacks.on_cleanup.fun]
-    if typeof(func) ≠ func (i32) -> () then Trap
+    if typeof(func) ≠ func (i32) -> () then Trap {cycles_used = es.cycles_used;}
 
-    let es = ref { empty_execution_state with
-      wasm_state;
+    let es' = ref { empty_execution_state with
+      wasm_state = wasm_state;
     }
-    func<es>(callbacks.on_cleanup.env)
+    try func<es'>(callbacks.on_cleanup.env) with Trap then Trap {cycles_used = es.cycles_used + es'.cycles_used;}
+    if es'.cycles_accepted ≠ 0 then Trap {cycles_used = es.cycles_used + es'.cycles_used;}
+    if es'.calls ≠ [] then Trap {cycles_used = es.cycles_used + es'.cycles_used;}
+    if es'.ingress_filter ≠ Reject then Trap {cycles_used = es.cycles_used + es'.cycles_used;}
+    if es'.response ≠ NoResponse then Trap {cycles_used = es.cycles_used + es'.cycles_used;}
     Return {
-      new_state = es.wasm_state;
+      new_state = es'.wasm_state;
       new_calls = [];
       response = NoResponse;
       cycles_accepted = 0;
+      cycles_used = es.cycles_used + es'.cycles_used;
     }
 ....
 +
@@ -4115,7 +4175,7 @@ If the WebAssembly module does not export a function called under the name `cani
 +
 ....
 inspect_message = λ (method_name, wasm_state, arg, caller, sysenv) →
-  Return Accept
+  Return {status = Accept; cycles_used = 0;}
 ....
 Otherwise, if the WebAssembly module exports a function `func` under the name `canister_inspect_message`, it is
 +
@@ -4132,10 +4192,10 @@ inspect_message = λ (method_name, wasm_state, arg, caller, sysenv) →
       balance = sysenv.balance;
       cycles_available = 0; // ingress requests have no funds
     }
-   try func<es>() with Trap then Trap
-   if es.calls ≠ () then Trap
-   if es.response ≠ NoResponse then Trap
-   Return es.ingress_filter;
+   try func<es>() with Trap then Trap {cycles_used = es.cycles_used;}
+   if es.calls ≠ [] then Trap {cycles_used = es.cycles_used;}
+   if es.response ≠ NoResponse then Trap {cycles_used = es.cycles_used;}
+   Return {status = es.ingress_filter; cycles_used = es.cycles_used;};
 ....
 
 ==== Helper functions
@@ -4144,12 +4204,12 @@ In the following section, we use the these helper functions
 
 ....
 copy_to_canister<es>(dst : i32, offset : i32, size : i32, data : blob) =
-  if offset+size > |data| then Trap
-  if dst+size > |es.wasm_state.store.mem| then Trap
+  if offset+size > |data| then Trap {cycles_used = es.cycles_used;}
+  if dst+size > |es.wasm_state.store.mem| then Trap {cycles_used = es.cycles_used;}
   es.wasm_state.store.mem[dst..dst+size] := data[offset..offset+size]
 
 copy_from_canister<es>(src : i32, size : i32) blob =
-  if src+size > |es.wasm_state.store.mem| then Trap
+  if src+size > |es.wasm_state.store.mem| then Trap {cycles_used = es.cycles_used;}
   return es.wasm_state.store.mem[src..src+size]
 ....
 
@@ -4158,7 +4218,7 @@ Cycles are represented by 128-bit values so they require 16 bytes of memory.
 ....
 copy_cycles_to_canister<es>(dst : i32, data : blob) =
  let size = 16;
- if dst+size > |es.wasm_state.store.mem| then Trap
+ if dst+size > |es.wasm_state.store.mem| then Trap {cycles_used = es.cycles_used;}
   es.wasm_state.store.mem[dst..dst+size] := data[0..size]
 
 ....
@@ -4192,21 +4252,21 @@ ic0.msg_reject_msg_copy<es>(dst:i32, offset:i32, size:i32) : i32 =
   copy_to_canister<es>(dst, offset, size, es.params.reject_msg)
 
 ic0.msg_reply_data_append<es>(src : i32, size : i32) =
-  if es.response ≠ NoResponse then Trap
+  if es.response ≠ NoResponse then Trap {cycles_used = es.cycles_used;}
   es.reply_params.arg := es.reply_params.arg · copy_from_canister<es>(src, size)
 
 ic0.msg_reply<es>() =
-  if es.response ≠ NoResponse then Trap
+  if es.response ≠ NoResponse then Trap {cycles_used = es.cycles_used;}
   es.response := Reply (es.reply_params.arg)
   es.cycles_available := 0
 
 ic0.msg_reject<es>(src : i32, size : i32) =
-  if es.response ≠ NoResponse then Trap
+  if es.response ≠ NoResponse then Trap {cycles_used = es.cycles_used;}
   es.response := Reject (CANISTER_REJECT, copy_from_canister<es>(src, size))
   es.cycles_available := 0
 
 ic0.msg_cycles_available<es>() : i64 =
-  if es.cycles_available >= 2^64^ then Trap
+  if es.cycles_available >= 2^64^ then Trap {cycles_used = es.cycles_used;}
   return es.cycles_available
 
 ic0.msg_cycles_available128<es>(dst : i32) =
@@ -4214,7 +4274,7 @@ ic0.msg_cycles_available128<es>(dst : i32) =
   copy_cycles_to_canister<es>(dst, amount.to_little_endian_bytes())
 
 ic0.msg_cycles_refunded<es>() : i64 =
-  if es.params.cycles_refunded >= 2^64^ then Trap
+  if es.params.cycles_refunded >= 2^64^ then Trap {cycles_used = es.cycles_used;}
   return es.params.cycles_refunded
 
 ic0.msg_cycles_refunded128<es>(dst : i32) =
@@ -4222,7 +4282,7 @@ ic0.msg_cycles_refunded128<es>(dst : i32) =
   copy_cycles_to_canister<es>(dst, amount.to_little_endian_bytes())
 
 ic0.accept_message<es>() =
-  if es.ingress_filter = Accept then Trap
+  if es.ingress_filter = Accept then Trap {cycles_used = es.cycles_used;}
   es.ingress_filter = Accept
 
 ic0.msg_method_name_size<es>() : i32 =
@@ -4253,7 +4313,7 @@ ic0.canister_self_copy<es>(dst:i32, offset:i32, size:i32) =
   copy_to_canister<es>(dst, offset, size, es.wasm_state.self_id)
 
 ic0.canister_cycle_balance<es>() : i64 =
-  if es.balance >= 2^64^ then Trap
+  if es.balance >= 2^64^ then Trap {cycles_used = es.cycles_used;}
   return es.balance
 
 ic0.canister_cycles_balance128<es>(dst : i32) =
@@ -4278,17 +4338,17 @@ ic0.call_new<es>(
   ) =
   discard_pending_call<es>()
 
-  if es.balance < MAX_CYCLES_PER_RESPONSE then Trap
+  if es.balance < MAX_CYCLES_PER_RESPONSE then Trap {cycles_used = es.cycles_used;}
   es.balance := es.balance - MAX_CYCLES_PER_RESPONSE
 
   callee := copy_from_canister<es>(callee_src, callee_size);
   method_name := copy_from_canister<es>(name_src, name_size);
 
-  if reply_fun > |es.wasm_state.store.table| then Trap
-  if typeof(es.wasm_state.store.table[reply_fun]) ≠ func (anyref, i32) -> () then Trap
+  if reply_fun > |es.wasm_state.store.table| then Trap {cycles_used = es.cycles_used;}
+  if typeof(es.wasm_state.store.table[reply_fun]) ≠ func (anyref, i32) -> () then Trap {cycles_used = es.cycles_used;}
 
-  if reject_fun > |es.wasm_state.store.table| then Trap
-  if typeof(es.wasm_state.store.table[reject_fun]) ≠ func (anyref, i32) -> () then Trap
+  if reject_fun > |es.wasm_state.store.table| then Trap {cycles_used = es.cycles_used;}
+  if typeof(es.wasm_state.store.table[reject_fun]) ≠ func (anyref, i32) -> () then Trap {cycles_used = es.cycles_used;}
 
   es.pending_call = MethodCall {
     callee = callee;
@@ -4303,33 +4363,33 @@ ic0.call_new<es>(
   }
 
 ic0.call_data_append<es> (src : i32, size : i32) =
-  if es.pending_call = NoPendingCall then Trap
+  if es.pending_call = NoPendingCall then Trap {cycles_used = es.cycles_used;}
   es.pending_call.arg := es.pending_call.arg · copy_from_canister<es>(src, size)
 
 ic0.call_on_cleanup<es> (fun : i32, env : i32) =
-  if fun > |es.wasm_state.store.table| then Trap
-  if typeof(es.wasm_state.store.table[fun]) ≠ func (anyref, i32) -> () then Trap
-  if es.pending_call = NoPendingCall then Trap
-  if es.pending_call.callback.on_cleanup ≠ NoClosure then Trap
+  if fun > |es.wasm_state.store.table| then Trap {cycles_used = es.cycles_used;}
+  if typeof(es.wasm_state.store.table[fun]) ≠ func (anyref, i32) -> () then Trap {cycles_used = es.cycles_used;}
+  if es.pending_call = NoPendingCall then Trap {cycles_used = es.cycles_used;}
+  if es.pending_call.callback.on_cleanup ≠ NoClosure then Trap {cycles_used = es.cycles_used;}
   es.pending_call.callback.on_cleanup := Closure { fun = fun; env = env}
 
 ic0.call_cycles_add<es>(amount : i64) =
-  if es.pending_call = NoPendingCall then Trap
-  if es.balance < amount then Trap
+  if es.pending_call = NoPendingCall then Trap {cycles_used = es.cycles_used;}
+  if es.balance < amount then Trap {cycles_used = es.cycles_used;}
 
   es.balance := es.balance - amount
   es.pending_call.transferred_cycles := es.pending_call.transferred_cycles + amount
 
 ic0.call_cycles_add128<es>(amount_high : i64, amount_low : i64) =
   let amount = amount_high * 2^64^ + amount_low
-  if es.pending_call = NoPendingCall then Trap
-  if es.balance < amount then Trap
+  if es.pending_call = NoPendingCall then Trap {cycles_used = es.cycles_used;}
+  if es.balance < amount then Trap {cycles_used = es.cycles_used;}
 
   es.balance := es.balance - amount
   es.pending_call.transferred_cycles := es.pending_call.transferred_cycles + amount
 
 ic0.call_peform<es>() : ( err_code : i32 ) =
-  if es.pending_call = NoPendingCall then Trap
+  if es.pending_call = NoPendingCall then Trap {cycles_used = es.cycles_used;}
 
   // are we below the threezing threshold?
   // Or maybe the system has other reasons to not perform this
@@ -4349,12 +4409,12 @@ discard_pending_call<es>() =
     es.pending_call := NoPendingCall
 
 ic0.stable_size<es>() : (page_count : i32) =
-  if |es.wasm_state.store.mem| > 2^32^ then Trap
+  if |es.wasm_state.store.mem| > 2^32^ then Trap {cycles_used = es.cycles_used;}
   page_count := |es.wasm_state.stable_mem| / 64k
   return page_count
 
 ic0.stable_grow<es>(new_pages : i32) : (old_page_count : i32) =
-  if |es.wasm_state.store.mem| > 2^32^ then Trap
+  if |es.wasm_state.store.mem| > 2^32^ then Trap {cycles_used = es.cycles_used;}
   if arbitrary() then return -1
   else
     old_size := |es.wasm_state.stable_mem| / 64k
@@ -4364,16 +4424,16 @@ ic0.stable_grow<es>(new_pages : i32) : (old_page_count : i32) =
     return old_size
 
 ic0.stable_write<es>(offset : i32, src : i32, size : i32)
-  if |es.wasm_state.store.mem| > 2^32^ then Trap
-  if src+size > |es.wasm_state.store.mem| then Trap
-  if offset+size > |es.wasm_state.stable_mem| then Trap
+  if |es.wasm_state.store.mem| > 2^32^ then Trap {cycles_used = es.cycles_used;}
+  if src+size > |es.wasm_state.store.mem| then Trap {cycles_used = es.cycles_used;}
+  if offset+size > |es.wasm_state.stable_mem| then Trap {cycles_used = es.cycles_used;}
 
   es.wasm_state.stable_mem[offset..offset+size] := es.wasm_state.store.mem[src..src+size]
 
 ic0.stable_read<es>(dst : i32, offset : i32, size : i32)
-  if |es.wasm_state.store.mem| > 2^32^ then Trap
-  if offset+size > |es.wasm_state.stable_mem| then Trap
-  if dst+size > |es.wasm_state.store.mem| then Trap
+  if |es.wasm_state.store.mem| > 2^32^ then Trap {cycles_used = es.cycles_used;}
+  if offset+size > |es.wasm_state.stable_mem| then Trap {cycles_used = es.cycles_used;}
+  if dst+size > |es.wasm_state.store.mem| then Trap {cycles_used = es.cycles_used;}
 
   es.wasm_state.store.mem[offset..offset+size] := es.wasm_state.stable.mem[src..src+size]
 
@@ -4390,14 +4450,14 @@ ic0.stable64_grow<es>(new_pages : i64) : (old_page_count : i64) =
     return old_size
 
 ic0.stable64_write<es>(offset : i64, src : i64, size : i64)
-  if src+size > |es.wasm_state.store.mem| then Trap
-  if offset+size > |es.wasm_state.stable_mem| then Trap
+  if src+size > |es.wasm_state.store.mem| then Trap {cycles_used = es.cycles_used;}
+  if offset+size > |es.wasm_state.stable_mem| then Trap {cycles_used = es.cycles_used;}
 
   es.wasm_state.stable_mem[offset..offset+size] := es.wasm_state.store.mem[src..src+size]
 
 ic0.stable64_read<es>(dst : i64, offset : i64, size : i64)
-  if offset+size > |es.wasm_state.stable_mem| then Trap
-  if dst+size > |es.wasm_state.store.mem| then Trap
+  if offset+size > |es.wasm_state.stable_mem| then Trap {cycles_used = es.cycles_used;}
+  if dst+size > |es.wasm_state.store.mem| then Trap {cycles_used = es.cycles_used;}
 
   es.wasm_state.store.mem[offset..offset+size] := es.wasm_state.stable.mem[src..src+size]
 
@@ -4413,11 +4473,11 @@ ic0.data_certificate_present<es>() : i32 =
   else return 1
 
 ic0.data_certificate_size<es>() : i32 =
-  if es.params.sysenv.certificate = NoCertificate then Trap
+  if es.params.sysenv.certificate = NoCertificate then Trap {cycles_used = es.cycles_used;}
   return |es.params.sysenv.certificate|
 
 ic0.data_certificate_copy<es>(dst: i32, offset: i32, size: i32) =
-  if es.params.sysenv.certificate = NoCertificate then Trap
+  if es.params.sysenv.certificate = NoCertificate then Trap {cycles_used = es.cycles_used;}
   copy_to_canister<es>(dst, offset, size, es.params.sysenv.certificate)
 
 ic0.performance_counter<es>(counter_type : i32) : i64 =
@@ -4427,7 +4487,7 @@ ic0.debug_print<es>(src : i32, size : i32) =
   return
 
 ic0.trap<es>(src : i32, size : i32) =
-  Trap
+  Trap {cycles_used = es.cycles_used;}
 ....
 
 

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -149,7 +149,7 @@ We specify a _canonical textual format_ that is recommended whenever principals 
 
 The textual representation of a blob `b` is `Grouped(Base32(CRC32(b) · b))` where
 
- * `CRC32` is a four byte check sequence, calculated as defined by ISO 3309, ITU-T V.42 and https://www.w3.org/TR/2003/REC-PNG-20031110/#5CRC-algorithm[elsewhere]
+ * `CRC32` is a four byte check sequence, calculated as defined by ISO 3309, ITU-T V.42, and https://www.w3.org/TR/2003/REC-PNG-20031110/#5CRC-algorithm[elsewhere], and stored as big-endian, i.e., the most significant byte comes first and then the less significant bytes come in descending order of significance (MSB B2 B1 LSB).
  * `Base32` is the Base32 encoding as defined in https://tools.ietf.org/html/rfc4648#section-6[RFC 4648], with no padding character added.
  * The middle dot denotes concatenation.
  * `Grouped` takes an ASCII string and inserts the separator `-` (dash) every 5 characters. The last group may contain less than 5 characters. A separator never appears at the beginning or end.

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -544,8 +544,9 @@ The HTTP response to this request consists of a CBOR map with the following fiel
 * `certificate` (`blob`): A certificate (see <<certification>>).
 +
 If this `certificate` includes subnet delegations (possibly nested), then the `effective_canister_id` must be included in each delegation’s canister id range (see <<certification-delegation>>), unless
+
 - the `effective_canister_id` is that of the Management Canister (`aaaaa-aa`),
-- all requested paths have `/request_status/<request_id>` as prefix where the (single) original request referenced by `<request_id>` is an update call to the Management Canister (`aaaaa-aa`) and the method name is `provisional_create_canister_with_cycles`, and
+- all requested paths have `/time` or `/request_status/<request_id>` as prefix where the (single) original request referenced by `<request_id>` is an update call to the Management Canister (`aaaaa-aa`) and the method name is `provisional_create_canister_with_cycles`, and
 - whenever the certificate contains the path `/request_status/<request_id>/reply`, then its value is a Candid-encoded record with a `canister_id` field of type `principal` and the `canister_id` must be included in each delegation’s canister id range.
 
 The returned certificate reveals all values whose path is a suffix of the list of requested paths. It also always reveals `/time`, even if not explicitly requested.

--- a/spec/requests.cddl
+++ b/spec/requests.cddl
@@ -70,6 +70,7 @@ query-response = tagged<{
   status: "rejected"
   reject_code: unsigned
   reject_message: text
+  ? error_code: text
 }>
 
 call-reply = {

--- a/theories/IC.thy
+++ b/theories/IC.thy
@@ -1,0 +1,777 @@
+theory IC
+  imports "HOL-Library.AList"
+begin
+
+(* Partial maps *)
+
+typedef ('a, 'b) list_map = "{f :: ('a \<times> 'b) list. distinct (map fst f)}"
+  by (auto intro: exI[of _ "[]"])
+
+setup_lifting type_definition_list_map
+
+lift_definition list_map_dom :: "('a, 'b) list_map \<Rightarrow> 'a set" is
+  "set \<circ> map fst" .
+
+lift_definition list_map_vals :: "('a, 'b) list_map \<Rightarrow> 'b set" is
+  "set \<circ> map snd" .
+
+lift_definition list_map_sum_vals :: "('b \<Rightarrow> nat) \<Rightarrow> ('a, 'b) list_map \<Rightarrow> nat" is
+  "\<lambda>g. sum_list \<circ> (map (g \<circ> snd))" .
+
+lift_definition list_map_get :: "('a, 'b) list_map \<Rightarrow> 'a \<Rightarrow> 'b option" is
+  "map_of" .
+
+lift_definition list_map_set :: "('a, 'b) list_map \<Rightarrow> 'a \<Rightarrow> 'b \<Rightarrow> ('a, 'b) list_map" is
+  "\<lambda>f x y. AList.update x y f"
+  by (rule distinct_update)
+
+lift_definition list_map_del :: "('a, 'b) list_map \<Rightarrow> 'a \<Rightarrow> ('a, 'b) list_map" is
+  "\<lambda>f x. AList.delete x f"
+  by (rule distinct_delete)
+
+lift_definition list_map_empty :: "('a, 'b) list_map" is "[]"
+  by auto
+
+lemma list_map_empty_dom[simp]: "list_map_dom list_map_empty = {}"
+  by transfer auto
+
+lemma list_map_sum_in_ge_aux:
+  fixes g :: "'a \<Rightarrow> nat"
+  shows "distinct (map fst f) \<Longrightarrow> map_of f x = Some y \<Longrightarrow> g y \<le> sum_list (map g (map snd f))"
+  by (induction f) (auto split: if_splits)
+
+lemma list_map_sum_in_ge: "list_map_get f x = Some y \<Longrightarrow> list_map_sum_vals g f \<ge> g y"
+  apply transfer
+  using list_map_sum_in_ge_aux[OF _ map_of_is_SomeI]
+  by fastforce
+
+lemma list_map_sum_in_aux: fixes g :: "'a \<Rightarrow> nat"
+  shows "distinct (map fst f) \<Longrightarrow> map_of f x = Some y \<Longrightarrow>
+  sum_list (map (g \<circ> snd) (AList.update x y' f)) = sum_list (map (g \<circ> snd) f) + g y' - g y"
+  apply (induction f)
+   apply auto[1]
+  subgoal for a f
+    using list_map_sum_in_ge_aux[OF _ map_of_is_SomeI, of f x y g]
+    by auto
+  done
+
+lemma list_map_sum_in: "list_map_get f x = Some y \<Longrightarrow> list_map_sum_vals g (list_map_set f x y') = list_map_sum_vals g f + g y' - g y"
+  apply transfer
+  using list_map_sum_in_aux
+  by fastforce
+
+lemma list_map_sum_out_aux:
+  "x \<notin> set (map fst f) \<Longrightarrow> sum_list (map (g \<circ> snd) (AList.update x y f)) = sum_list (map (g \<circ> snd) f) + g y"
+  by (induction f) (auto simp: add.assoc)
+
+lemma list_map_sum_out: "x \<notin> list_map_dom f \<Longrightarrow> list_map_sum_vals g (list_map_set f x y) = list_map_sum_vals g f + g y"
+  apply transfer
+  using list_map_sum_out_aux
+  by fastforce
+
+lemma list_map_del_sum_aux:
+  fixes g :: "'a \<Rightarrow> nat"
+  shows "distinct (map fst f) \<Longrightarrow> map_of f x = Some y \<Longrightarrow> sum_list (map (g \<circ> snd) f) = sum_list (map (g \<circ> snd) (AList.delete x f)) + g y"
+  by (induction f) auto
+
+lemma list_map_del_sum: "list_map_get f x = Some y \<Longrightarrow> list_map_sum_vals g f = list_map_sum_vals g (list_map_del f x) + g y"
+  apply transfer
+  using list_map_del_sum_aux
+  by fastforce
+
+(* Abstract behaviour *)
+
+(* Abstract canisters *)
+
+record ('b, 'p) arg =
+  data :: 'b
+  caller :: 'p
+
+type_synonym timestamp = nat
+datatype status = Running | Stopping | Stopped
+record ('b) env =
+  env_time :: timestamp
+  balance :: nat
+  freezing_limit :: nat
+  certificate :: "'b option"
+  status :: status
+
+type_synonym reject_code = nat
+datatype ('b, 's) response =
+  Reply "'b"
+| Reject reject_code 's
+record ('p, 'canid, 's, 'b, 'c) method_call =
+  callee :: 'canid
+  method_name :: 's
+  arg :: 'b
+  transferred_cycles :: nat
+  callback :: 'c
+
+record ('w, 'p, 'canid, 's, 'b, 'c) update_return =
+  new_state :: 'w
+  new_calls :: "('p, 'canid, 's, 'b, 'c) method_call list"
+  new_certified_data :: "'b option"
+  response :: "('b, 's) response option"
+  cycles_accepted :: nat
+type_synonym ('w, 'p, 'canid, 's, 'b, 'c, 'tr) update_func = "'w \<Rightarrow> 'tr + ('w, 'p, 'canid, 's, 'b, 'c) update_return"
+type_synonym ('w, 'b, 's, 'tr) query_func = "'w \<Rightarrow> 'tr + ('b, 's) response"
+
+type_synonym available_cycles = nat
+type_synonym refunded_cycles = nat
+
+datatype inspect_method_result = Accept | Reject
+record ('p, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's) canister_module_rec =
+  init :: "'canid \<times> ('b, 'p) arg \<times> 'b env \<Rightarrow> 'tr + 'w"
+  pre_upgrade :: "'w \<times> 'p \<times> 'b env \<Rightarrow> 'tr + 'sm"
+  post_upgrade :: "'canid \<times> 'sm \<times> ('b, 'p) arg \<times> 'b env \<Rightarrow> 'tr + 'w"
+  update_methods :: "('s, (('b, 'p) arg \<times> 'b env \<times> available_cycles) \<Rightarrow> ('w, 'p, 'canid, 's, 'b, 'c, 'tr) update_func) list_map"
+  query_methods :: "('s, (('b, 'p) arg \<times> 'b env) \<Rightarrow> ('w, 'b, 's, 'tr) query_func) list_map"
+  heartbeat :: "'b env \<Rightarrow> 'w \<Rightarrow> 'tr + 'w"
+  callbacks :: "('c \<times> ('b, 's) response \<times> refunded_cycles \<times> 'b env \<times> available_cycles) \<Rightarrow> ('w, 'p, 'canid, 's, 'b, 'c, 'tr) update_func"
+  inspect_message :: "('s \<times> 'w \<times> ('b, 'p) arg \<times> 'b env) \<Rightarrow> 'tr + inspect_method_result"
+typedef ('p, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's) canister_module =
+  "{m :: ('p, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's) canister_module_rec. list_map_dom (update_methods m) \<inter> list_map_dom (query_methods m) = {}}"
+  by (auto intro: exI[of _ "\<lparr>init = undefined, pre_upgrade = undefined, post_upgrade = undefined,
+      update_methods = list_map_empty, query_methods = list_map_empty, heartbeat = undefined, callbacks = undefined,
+      inspect_message = undefined\<rparr>"])
+
+setup_lifting type_definition_canister_module
+
+lift_definition dispatch_method :: "'s \<Rightarrow> ('p, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's) canister_module \<Rightarrow>
+  (((('b, 'p) arg \<times> 'b env \<times> available_cycles) \<Rightarrow> ('w, 'p, 'canid, 's, 'b, 'c, 'tr) update_func) +
+   ((('b, 'p) arg \<times> 'b env) \<Rightarrow> ('w, 'b, 's, 'tr) query_func)) option" is
+  "\<lambda>f m. case list_map_get (update_methods m) f of Some f' \<Rightarrow> None | None \<Rightarrow> (case list_map_get (query_methods m) f of Some f' \<Rightarrow> None | None \<Rightarrow> None)" .
+
+lift_definition canister_module_callbacks :: "('p, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's) canister_module \<Rightarrow>
+  ('c \<times> ('b, 's) response \<times> refunded_cycles \<times> 'b env \<times> available_cycles) \<Rightarrow> ('w, 'p, 'canid, 's, 'b, 'c, 'tr) update_func" is
+  callbacks .
+
+lift_definition canister_module_heartbeat :: "('p, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's) canister_module \<Rightarrow> 'b env \<Rightarrow> 'w \<Rightarrow> 'tr + 'w" is
+  heartbeat .
+
+(* Call contexts *)
+
+record ('b, 'p, 'uid, 'canid, 's) request =
+  nonce :: 'b
+  ingress_expiry :: nat
+  sender :: 'uid
+  canister_id :: 'canid
+  method_name :: 's
+  data :: 'b
+datatype ('b, 'p, 'uid, 'canid, 's, 'c, 'cid) call_origin =
+  From_user "('b, 'p, 'uid, 'canid, 's) request"
+| From_canister "'cid" "'c"
+| From_heartbeat
+record ('p, 'uid, 'canid, 'b, 's, 'c, 'cid) call_ctxt_rep =
+  canister :: 'canid
+  origin :: "('b, 'p, 'uid, 'canid, 's, 'c, 'cid) call_origin"
+  needs_to_respond :: bool
+  deleted :: bool
+  available_cycles :: nat
+
+typedef ('p, 'uid, 'canid, 'b, 's, 'c, 'cid) call_ctxt = "{ctxt :: ('p, 'uid, 'canid, 'b, 's, 'c, 'cid) call_ctxt_rep.
+  (deleted ctxt \<longrightarrow> \<not>needs_to_respond ctxt) \<and> (\<not>needs_to_respond ctxt \<longrightarrow> available_cycles ctxt = 0)}"
+  by (auto intro: exI[of _ "\<lparr>canister = undefined, origin = undefined, needs_to_respond = True, deleted = False, available_cycles = 0\<rparr>"])
+
+setup_lifting type_definition_call_ctxt
+
+lift_definition call_ctxt_origin :: "('p, 'uid, 'canid, 'b, 's, 'c, 'cid) call_ctxt \<Rightarrow> ('b, 'p, 'uid, 'canid, 's, 'c, 'cid) call_origin" is
+  "\<lambda>ctxt. origin ctxt" .
+
+lift_definition call_ctxt_needs_to_respond :: "('p, 'uid, 'canid, 'b, 's, 'c, 'cid) call_ctxt \<Rightarrow> bool" is
+  "\<lambda>ctxt. needs_to_respond ctxt" .
+
+lift_definition call_ctxt_available_cycles :: "('p, 'uid, 'canid, 'b, 's, 'c, 'cid) call_ctxt \<Rightarrow> nat" is
+  "\<lambda>ctxt. available_cycles ctxt" .
+
+lemma call_ctxt_inv: "\<not>call_ctxt_needs_to_respond x2 \<Longrightarrow> call_ctxt_available_cycles x2 = 0"
+  by transfer auto
+
+lift_definition call_ctxt_respond :: "('p, 'uid, 'canid, 'b, 's, 'c, 'cid) call_ctxt \<Rightarrow> ('p, 'uid, 'canid, 'b, 's, 'c, 'cid) call_ctxt" is
+  "\<lambda>ctxt. ctxt\<lparr>available_cycles := 0, needs_to_respond := False\<rparr>"
+  by auto
+
+lemma call_ctxt_respond_available_cycles[simp]: "call_ctxt_available_cycles (call_ctxt_respond ctxt) = 0"
+  by transfer auto
+
+lemma call_ctxt_respond_needs_to_respond[dest]: "call_ctxt_needs_to_respond (call_ctxt_respond ctxt) \<Longrightarrow> False"
+  by transfer auto
+
+lift_definition call_ctxt_deduct_cycles :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 's, 'c, 'cid) call_ctxt \<Rightarrow> ('p, 'uid, 'canid, 'b, 's, 'c, 'cid) call_ctxt" is
+  "\<lambda>n ctxt. ctxt\<lparr>available_cycles := available_cycles ctxt - n\<rparr>"
+  by auto
+
+lemma call_ctxt_deduct_cycles_origin[simp]: "call_ctxt_origin (call_ctxt_deduct_cycles n ctxt) = call_ctxt_origin ctxt"
+  by transfer auto
+
+lemma call_ctxt_deduct_cycles_needs_to_respond[simp]: "call_ctxt_needs_to_respond (call_ctxt_deduct_cycles n ctxt) = call_ctxt_needs_to_respond ctxt"
+  by transfer auto
+
+lemma call_ctxt_deduct_cycles_available_cycles[simp]: "call_ctxt_available_cycles (call_ctxt_deduct_cycles n ctxt) = call_ctxt_available_cycles ctxt - n"
+  by transfer auto
+
+(* Calls and Messages *)
+
+datatype 'canid queue_origin = System | Canister 'canid
+datatype 'canid queue = Unordered | Queue "'canid queue_origin" 'canid
+datatype ('s, 'p, 'b, 'c) entry_point =
+  Public_method "'s" "'p" "'b"
+| Callback "'c" "('b, 's) response" "refunded_cycles"
+| Heartbeat
+
+datatype ('b, 'p, 'uid, 'canid, 's, 'c, 'cid) message =
+  Call_message "('b, 'p, 'uid, 'canid, 's, 'c, 'cid) call_origin" 'p 'canid 's 'b nat "'canid queue"
+| Func_message 'cid 'canid "('s, 'p, 'b, 'c) entry_point" "'canid queue"
+| Response_message "('b, 'p, 'uid, 'canid, 's, 'c, 'cid) call_origin" "('b, 's) response" nat
+
+(* API requests *)
+
+type_synonym 'b path = "'b list"
+record ('b, 'uid) StateRead =
+  nonce :: 'b
+  ingress_expiry :: nat
+  sender :: 'uid
+  paths :: "'b path list"
+record ('b, 'uid, 'canid, 's) CanisterQuery =
+  nonce :: 'b
+  ingress_expiry :: nat
+  sender :: 'uid
+  canister_id :: 'canid
+  method_name :: 's
+  data :: 'b
+type_synonym ('b, 'uid, 'canid, 's) APIReadRequest = "('b, 'uid) StateRead + ('b, 'uid, 'canid, 's) CanisterQuery"
+record ('b, 'p, 'uid, 'canid, 's, 'pk, 'sig, 'sd) envelope =
+  content :: "('b, 'p, 'uid, 'canid, 's) request + ('b, 'uid, 'canid, 's) APIReadRequest"
+  sender_pubkey :: "'pk option"
+  sender_sig :: "'sig option"
+  sender_delegation :: 'sd
+
+datatype ('b, 's) request_status = Received | Processing | Rejected reject_code 's | Replied 'b | Done
+
+(* The system state *)
+
+record ('p, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's) can_state_rec =
+  wasm_state :: 'w
+  module :: "('p, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's) canister_module"
+  raw_module :: 'b
+  public_custom_sections :: "('s, 'b) list_map"
+  private_custom_sections :: "('s, 'b) list_map"
+type_synonym ('p, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's) can_state = "('p, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's) can_state_rec option"
+datatype ('b, 'p, 'uid, 'canid, 's, 'c, 'cid) can_status = Running | Stopping "(('b, 'p, 'uid, 'canid, 's, 'c, 'cid) call_origin \<times> nat) list" | Stopped
+record ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic =
+  requests :: "(('b, 'p, 'uid, 'canid, 's) request, ('b, 's) request_status) list_map"
+  canisters :: "('canid, ('p, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's) can_state) list_map"
+  controllers :: "('canid,  'p set) list_map"
+  freezing_threshold :: "('canid,  nat) list_map"
+  canister_status :: "('canid,  ('b, 'p, 'uid, 'canid, 's, 'c, 'cid) can_status) list_map"
+  time :: "('canid,  timestamp) list_map"
+  balances :: "('canid,  nat) list_map"
+  certified_data :: "('canid,  'b) list_map"
+  system_time :: timestamp
+  call_contexts :: "('cid, ('p, 'uid, 'canid, 'b, 's, 'c, 'cid) call_ctxt) list_map"
+  messages :: "('b, 'p, 'uid, 'canid, 's, 'c, 'cid) message list"
+  root_key :: 'pk
+
+(* State transitions *)
+
+context fixes
+  CANISTER_ERROR :: reject_code
+  and SYS_FATAL :: reject_code
+  and SYS_TRANSIENT :: reject_code
+  and MAX_CYCLES_PER_MESSAGE :: nat
+  and MAX_CYCLES_PER_RESPONSE :: nat
+  and MAX_CANISTER_BALANCE :: nat
+  and ic_freezing_limit :: "('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> 'canid \<Rightarrow> nat"
+  and encode_string :: "string \<Rightarrow> 's"
+  and principal_of_uid :: "'uid \<Rightarrow> 'p"
+  and principal_of_canid :: "'canid \<Rightarrow> 'p"
+begin
+
+(* Cycles *)
+
+fun carried_cycles :: "('b, 'p, 'uid, 'canid, 's, 'c, 'cid) call_origin \<Rightarrow> nat" where
+  "carried_cycles (From_canister _ _) = MAX_CYCLES_PER_RESPONSE"
+| "carried_cycles _ = 0"
+
+fun cycles_reserved :: "('s, 'p, 'b, 'c) entry_point \<Rightarrow> nat" where
+  "cycles_reserved (entry_point.Public_method _ _ _) = MAX_CYCLES_PER_MESSAGE"
+| "cycles_reserved (entry_point.Callback _ _ _) = MAX_CYCLES_PER_RESPONSE"
+| "cycles_reserved (entry_point.Heartbeat) = MAX_CYCLES_PER_MESSAGE"
+
+fun message_cycles :: "('b, 'p, 'uid, 'canid, 's, 'c, 'cid) message \<Rightarrow> nat" where
+  "message_cycles (Call_message orig _ _ _ _ trans_cycles q) = carried_cycles orig + trans_cycles"
+| "message_cycles (Func_message _ _ ep _) = cycles_reserved ep"
+| "message_cycles (Response_message orig _ ref_cycles) = carried_cycles orig + ref_cycles"
+
+lift_definition call_ctxt_carried_cycles :: "('p, 'uid, 'canid, 'b, 's, 'c, 'cid) call_ctxt \<Rightarrow> nat" is
+  "\<lambda>ctxt. (if needs_to_respond ctxt
+    then available_cycles ctxt + carried_cycles (origin ctxt)
+    else 0)" .
+
+lemma call_ctxt_respond_carried_cycles[simp]: "call_ctxt_carried_cycles (call_ctxt_respond ctxt) = 0"
+  by transfer auto
+
+lemma call_ctxt_carried_cycles: "call_ctxt_carried_cycles ctxt = (if call_ctxt_needs_to_respond ctxt
+  then call_ctxt_available_cycles ctxt + carried_cycles (call_ctxt_origin ctxt) else 0)"
+  by transfer auto
+
+definition total_cycles :: "('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> nat" where
+  "total_cycles ic = (
+    let cycles_in_balances = list_map_sum_vals id (balances ic) in
+    let cycles_in_messages = sum_list (map message_cycles (messages ic)) in
+    let cycles_in_contexts = list_map_sum_vals call_ctxt_carried_cycles (call_contexts ic) in
+    cycles_in_balances + cycles_in_messages + cycles_in_contexts)"
+
+(* Accessor functions *)
+
+fun calling_context :: "('b, 'p, 'uid, 'canid, 's, 'c, 'cid) call_origin \<Rightarrow> 'cid option" where
+  "calling_context (From_canister c _) = Some c"
+| "calling_context _ = None"
+
+fun message_queue :: "('b, 'p, 'uid, 'canid, 's, 'c, 'cid) message \<Rightarrow> 'canid queue option" where
+  "message_queue (Call_message _ _ _ _ _ _ q) = Some q"
+| "message_queue (Func_message _ _ _ q) = Some q"
+| "message_queue _ = None"
+
+(* Type conversion functions *)
+
+fun to_status :: "('b, 'p, 'uid, 'canid, 's, 'c, 'cid) can_status \<Rightarrow> status" where
+  "to_status can_status.Running = status.Running"
+| "to_status (can_status.Stopping _) = status.Stopping"
+| "to_status can_status.Stopped = status.Stopped"
+
+
+
+(* System transition: API Request submission [DONE] *)
+
+definition request_submission_pre :: "('b, 'p, 'uid, 'canid, 's, 'pk, 'sig, 'sd) envelope \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  "request_submission_pre E S = (case content E of Inl req \<Rightarrow> req \<notin> list_map_dom (requests S) | _ \<Rightarrow> False)"
+
+definition request_submission_post :: "('b, 'p, 'uid, 'canid, 's, 'pk, 'sig, 'sd) envelope \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "request_submission_post E S = S\<lparr>requests := list_map_set (requests S) (projl (content E)) Received\<rparr>"
+
+lemma request_submission_cycles_inv:
+  "request_submission_pre E S \<Longrightarrow> total_cycles S = total_cycles (request_submission_post E S)"
+  by (auto simp: request_submission_pre_def request_submission_post_def total_cycles_def)
+
+
+
+(* System transition: Request rejection [DONE] *)
+
+definition request_rejection_pre :: "('b, 'p, 'uid, 'canid, 's, 'pk, 'sig, 'sd) envelope \<Rightarrow> ('b, 'p, 'uid, 'canid, 's) request \<Rightarrow> reject_code \<Rightarrow> 's \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  "request_rejection_pre E req code msg S = (list_map_get (requests S) req = Some Received \<and> (code = SYS_FATAL \<or> code = SYS_TRANSIENT))"
+
+definition request_rejection_post :: "('b, 'p, 'uid, 'canid, 's, 'pk, 'sig, 'sd) envelope \<Rightarrow> ('b, 'p, 'uid, 'canid, 's) request \<Rightarrow> reject_code \<Rightarrow> 's \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "request_rejection_post E req code msg S = S\<lparr>requests := list_map_set (requests S) req (Rejected code msg)\<rparr>"
+
+lemma request_rejection_cycles_inv:
+  "request_rejection_pre E req code msg S \<Longrightarrow> total_cycles S = total_cycles (request_rejection_post E req code msg S)"
+  by (auto simp: request_rejection_pre_def request_rejection_post_def total_cycles_def)
+
+
+
+(* System transition: Initiating canister calls [DONE] *)
+
+definition initiate_canister_call_pre :: "('b, 'p, 'uid, 'canid, 's) request \<Rightarrow>
+  ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  "initiate_canister_call_pre req S = (list_map_get (requests S) req = Some Received \<and>
+    system_time S \<le> request.ingress_expiry req \<and>
+    request.canister_id req \<in> list_map_dom (canisters S))"
+
+definition initiate_canister_call_post :: "('b, 'p, 'uid, 'canid, 's) request \<Rightarrow>
+  ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow>
+  ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "initiate_canister_call_post req S =
+    S\<lparr>requests := list_map_set (requests S) req Processing, messages :=
+      Call_message (From_user req) (principal_of_uid (request.sender req)) (request.canister_id req) (request.method_name req)
+      (request.data req) 0 Unordered # messages S\<rparr>"
+
+lemma initiate_canister_call_cycles_inv:
+  "initiate_canister_call_pre R S \<Longrightarrow>
+  total_cycles S = total_cycles (initiate_canister_call_post R S)"
+  by (auto simp: initiate_canister_call_pre_def initiate_canister_call_post_def total_cycles_def)
+
+
+
+(* System transition: Calls to stopped/stopping/frozen canisters are rejected [DONE] *)
+
+definition call_reject_pre :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  "call_reject_pre n S = (n < length (messages S) \<and> (case messages S ! n of
+    Call_message orig cer cee mn d trans_cycles q \<Rightarrow>
+      (q = Unordered \<or> (\<forall>j < n. message_queue (messages S ! j) \<noteq> Some q)) \<and>
+      (case list_map_get (canister_status S) cee of Some Stopped \<Rightarrow> True
+      | Some (Stopping l) \<Rightarrow> True
+      | _ \<Rightarrow> (case list_map_get (balances S) cee of Some bal \<Rightarrow> bal < ic_freezing_limit S cee | _ \<Rightarrow> False))
+    | _ \<Rightarrow> False))"
+
+definition call_reject_post :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "call_reject_post n S = (case messages S ! n of Call_message orig cer cee mn d trans_cycles q \<Rightarrow>
+    S\<lparr>messages := take n (messages S) @ drop (Suc n) (messages S) @ [Response_message orig (response.Reject CANISTER_ERROR (encode_string ''canister not running'')) trans_cycles]\<rparr>)"
+
+lemma call_reject_cycles_inv:
+  assumes "call_reject_pre n S"
+  shows "total_cycles S = total_cycles (call_reject_post n S)"
+proof -
+  obtain orig cer cee mn d trans_cycles q where msg: "messages S ! n = Call_message orig cer cee mn d trans_cycles q"
+    using assms
+    by (auto simp: call_reject_pre_def split: message.splits)
+  define older where "older = take n (messages S)"
+  define younger where "younger = drop (Suc n) (messages S)"
+  have msgs: "messages S = older @ Call_message orig cer cee mn d trans_cycles q # younger" "(older @ w # younger) ! n = w"
+    "take n older = older" "take (n - length older) ws = []" "drop (Suc n) older = []"
+    "drop (Suc n - length older) (w # ws) = ws" for w ws
+    using id_take_nth_drop[of n "messages S"] assms
+    by (auto simp: call_reject_pre_def msg younger_def older_def nth_append)
+  show ?thesis
+    using assms
+    by (auto simp: call_reject_pre_def call_reject_post_def total_cycles_def Let_def msgs split: message.splits option.splits)
+qed
+
+
+
+(* System transition: Call context creation: Public entry points [DONE] *)
+
+definition call_context_create_pre :: "nat \<Rightarrow> 'cid
+  \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  "call_context_create_pre n ctxt_id S = (n < length (messages S) \<and> (case messages S ! n of
+    Call_message orig cer cee mn d trans_cycles q \<Rightarrow>
+      (case list_map_get (canisters S) cee of Some (Some can) \<Rightarrow> True | _ \<Rightarrow> False) \<and>
+      list_map_get (canister_status S) cee = Some Running \<and>
+      (case list_map_get (balances S) cee of Some bal \<Rightarrow> bal \<ge> ic_freezing_limit S cee + MAX_CYCLES_PER_MESSAGE | None \<Rightarrow> False) \<and>
+      ctxt_id \<notin> list_map_dom (call_contexts S)
+    | _ \<Rightarrow> False))"
+
+lift_definition create_call_ctxt :: "'canid \<Rightarrow> ('b, 'p, 'uid, 'canid, 's, 'c, 'cid) call_origin \<Rightarrow> nat \<Rightarrow>
+  ('p, 'uid, 'canid, 'b, 's, 'c, 'cid) call_ctxt" is
+  "\<lambda>cee orig trans_cycles. \<lparr>canister = cee, origin = orig, needs_to_respond = True, deleted = False, available_cycles = trans_cycles\<rparr>"
+  by auto
+
+lemma create_call_ctxt_carried_cycles[simp]: "call_ctxt_carried_cycles (create_call_ctxt cee orig trans_cycles) = carried_cycles orig + trans_cycles"
+  by transfer auto
+
+definition call_context_create_post :: "nat \<Rightarrow> 'cid \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "call_context_create_post n ctxt_id S = (case messages S ! n of Call_message orig cer cee mn d trans_cycles q \<Rightarrow>
+    case list_map_get (balances S) cee of Some bal \<Rightarrow>
+    S\<lparr>messages := list_update (messages S) n (Func_message ctxt_id cee (Public_method mn cer d) q),
+      call_contexts := list_map_set (call_contexts S) ctxt_id (create_call_ctxt cee orig trans_cycles),
+      balances := list_map_set (balances S) cee (bal - MAX_CYCLES_PER_MESSAGE)\<rparr>)"
+
+lemma call_context_create_cycles_inv:
+  assumes "call_context_create_pre n ctxt_id S"
+  shows "total_cycles S = total_cycles (call_context_create_post n ctxt_id S)"
+proof -
+  obtain orig cer cee mn d trans_cycles q where msg: "messages S ! n = Call_message orig cer cee mn d trans_cycles q"
+    using assms
+    by (auto simp: call_context_create_pre_def split: message.splits)
+  define xs where "xs = take n (messages S)"
+  define older where "older = drop (Suc n) (messages S)"
+  have msgs: "messages S = xs @ Call_message orig cer cee mn d trans_cycles q # older" "(xs @ m # older) ! n = m"
+    and msgs_upd: "(xs @ Call_message orig cer cee mn d trans_cycles q # older)[n := m] = xs @ m # older" for m
+    using id_take_nth_drop[of n "messages S"] upd_conv_take_nth_drop[of n "messages S"] assms
+    by (auto simp: call_context_create_pre_def msg xs_def older_def nth_append)
+  show ?thesis
+    using assms list_map_sum_in_ge[of "balances S" cee, where ?g=id]
+    by (auto simp: call_context_create_pre_def call_context_create_post_def total_cycles_def
+        list_map_sum_in[where ?g=id, simplified] list_map_sum_out msgs msgs_upd split: option.splits)
+qed
+
+
+
+(* System transition: Call context creation: Heartbeat [DONE] *)
+
+definition call_context_heartbeat_pre :: "'canid \<Rightarrow> 'cid \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  "call_context_heartbeat_pre cee ctxt_id S = (
+    (case list_map_get (canisters S) cee of Some (Some can) \<Rightarrow> True | _ \<Rightarrow> False) \<and>
+    list_map_get (canister_status S) cee = Some Running \<and>
+    (case list_map_get (balances S) cee of Some bal \<Rightarrow> bal \<ge> ic_freezing_limit S cee + MAX_CYCLES_PER_MESSAGE | _ \<Rightarrow> False) \<and>
+    ctxt_id \<notin> list_map_dom (call_contexts S))"
+
+lift_definition create_call_ctxt_heartbeat :: "'canid \<Rightarrow> ('p, 'uid, 'canid, 'b, 's, 'c, 'cid) call_ctxt" is
+  "\<lambda>cee. \<lparr>canister = cee, origin = From_heartbeat, needs_to_respond = False, deleted = False, available_cycles = 0\<rparr>"
+  by auto
+
+lemma create_call_ctxt_heartbeat_carried_cycles[simp]: "call_ctxt_carried_cycles (create_call_ctxt_heartbeat cee) = 0"
+  by transfer auto
+
+definition call_context_heartbeat_post :: "'canid \<Rightarrow> 'cid \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "call_context_heartbeat_post cee ctxt_id S =
+  (case list_map_get (balances S) cee of Some bal \<Rightarrow>
+    S\<lparr>messages := Func_message ctxt_id cee Heartbeat (Queue System cee) # messages S,
+    call_contexts := list_map_set (call_contexts S) ctxt_id (create_call_ctxt_heartbeat cee),
+    balances := list_map_set (balances S) cee (bal - MAX_CYCLES_PER_MESSAGE)\<rparr>)"
+
+lemma call_context_heartbeat_cycles_inv:
+  "call_context_heartbeat_pre cee ctxt_id S \<Longrightarrow>
+    total_cycles S = total_cycles (call_context_heartbeat_post cee ctxt_id S)"
+  using list_map_sum_in_ge[of "balances S" cee, where ?g=id, simplified]
+  by (auto simp: call_context_heartbeat_pre_def call_context_heartbeat_post_def total_cycles_def
+      list_map_sum_in[where ?g=id, simplified] list_map_sum_out split: option.splits)
+
+
+
+(* System transition: Message execution [DONE] *)
+
+fun query_as_update :: "((('b, 'p) arg \<times> 'b env) \<Rightarrow> ('w, 'b, 's, 'tr) query_func) \<times> ('b, 'p) arg \<times> 'b env \<Rightarrow> ('w, 'p, 'canid, 's, 'b, 'c, 'tr) update_func" where
+  "query_as_update (f, a, e) = (\<lambda>w. case f (a, e) w of Inl t \<Rightarrow> Inl t |
+    Inr res \<Rightarrow> Inr \<lparr>new_state = w, new_calls = [], new_certified_data = None, response = Some res, cycles_accepted = 0\<rparr>)"
+
+fun heartbeat_as_update :: "('b env \<Rightarrow> 'w \<Rightarrow> 'tr + 'w) \<times> 'b env \<Rightarrow> ('w, 'p, 'canid, 's, 'b, 'c, 'tr) update_func" where
+  "heartbeat_as_update (f, e) w = (case f e w of Inl t \<Rightarrow> Inl t |
+    Inr w' \<Rightarrow> Inr \<lparr>update_return.new_state = w', update_return.new_calls = [], update_return.new_certified_data = None,
+      update_return.response = None, update_return.cycles_accepted = 0\<rparr>)"
+
+fun exec_function :: "('s, 'p, 'b, 'c) entry_point \<Rightarrow> 'b env \<Rightarrow> nat \<Rightarrow> ('p, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's) canister_module \<Rightarrow> ('w, 'p, 'canid, 's, 'b, 'c, 'tr) update_func" where
+  "exec_function (entry_point.Public_method mn c d) e bal m = (
+    let arg = \<lparr>arg.data = d, arg.caller = c\<rparr> in
+    case dispatch_method mn m of Some (Inl upd) \<Rightarrow> upd (arg, e, bal)
+    | Some (Inr query) \<Rightarrow> query_as_update (query, arg, e) | None \<Rightarrow>
+    undefined)"
+| "exec_function (entry_point.Callback cb resp ref_cycles) e bal m =
+    canister_module_callbacks m (cb, resp, ref_cycles, e, bal)"
+| "exec_function (entry_point.Heartbeat) e bal m = heartbeat_as_update ((canister_module_heartbeat m), e)"
+
+definition message_execution_pre :: "nat \<Rightarrow> nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  "message_execution_pre n cycles_used S =
+    (n < length (messages S) \<and> (case messages S ! n of Func_message ctxt_id recv ep q \<Rightarrow>
+    (q = Unordered \<or> (\<forall>j < n. message_queue (messages S ! j) \<noteq> Some q)) \<and>
+    (case (list_map_get (canisters S) recv, list_map_get (balances S) recv, list_map_get (canister_status S) recv,
+      list_map_get (time S) recv, list_map_get (call_contexts S) ctxt_id) of
+      (Some (Some can), Some bal, Some can_status, Some t, Some ctxt) \<Rightarrow> True | _ \<Rightarrow> False)
+    | _ \<Rightarrow> False))"
+
+definition message_execution_post :: "nat \<Rightarrow> nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "message_execution_post n cycles_used S = (case messages S ! n of Func_message ctxt_id recv ep q \<Rightarrow>
+    (case (list_map_get (canisters S) recv, list_map_get (balances S) recv, list_map_get (canister_status S) recv,
+      list_map_get (time S) recv, list_map_get (call_contexts S) ctxt_id) of
+      (Some (Some can), Some bal, Some can_status, Some t, Some ctxt) \<Rightarrow> (
+        let Mod = module can;
+        Is_response = (case ep of Callback _ _ _ \<Rightarrow> True | _ \<Rightarrow> False);
+        Env = \<lparr>env_time = t, balance = bal, freezing_limit = ic_freezing_limit S recv, certificate = None, status = to_status can_status\<rparr>;
+        Available = call_ctxt_available_cycles ctxt;
+        F = exec_function ep Env Available Mod;
+        R = F (wasm_state can);
+        (cycles_accepted_res, new_calls_res) = (case R of Inr res \<Rightarrow> (cycles_accepted res, new_calls res));
+        New_balance = bal + cycles_accepted_res + (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE)
+          - (cycles_used + sum_list (map (\<lambda>x. MAX_CYCLES_PER_RESPONSE + transferred_cycles x) new_calls_res));
+        no_response = (case R of Inr result \<Rightarrow> update_return.response result = None) in
+        if \<not>isl R \<and> cycles_used \<le> (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE) \<and>
+          cycles_accepted_res \<le> Available \<and>
+          cycles_used + sum_list (map (\<lambda>x. MAX_CYCLES_PER_RESPONSE + transferred_cycles x) new_calls_res) \<le>
+            bal + cycles_accepted_res + (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE) \<and>
+          New_balance > (if Is_response then 0 else ic_freezing_limit S recv) \<and>
+          (no_response \<or> call_ctxt_needs_to_respond ctxt) then
+          (let result = projr R;
+            new_call_to_message = (\<lambda>call. Call_message (From_canister ctxt_id (callback call)) (principal_of_canid recv)
+              (callee call) (method_call.method_name call) (arg call) (transferred_cycles call) (Queue (Canister recv) (callee call)));
+            response_messages = (case response result of None \<Rightarrow> []
+              | Some resp \<Rightarrow> [Response_message (call_ctxt_origin ctxt) resp (Available - cycles_accepted_res)]);
+            messages = take n (messages S) @ drop (Suc n) (messages S) @ map new_call_to_message new_calls_res @ response_messages;
+            new_ctxt = (case response result of
+              None \<Rightarrow> call_ctxt_deduct_cycles cycles_accepted_res ctxt
+            | Some _ \<Rightarrow> call_ctxt_respond ctxt);
+            certified_data = (case new_certified_data result of None \<Rightarrow> certified_data S
+              | Some cd \<Rightarrow> list_map_set (certified_data S) recv cd)
+            in S\<lparr>canisters := list_map_set (canisters S) recv (Some (can\<lparr>wasm_state := new_state result\<rparr>)),
+              messages := messages, call_contexts := list_map_set (call_contexts S) ctxt_id new_ctxt,
+              balances := list_map_set (balances S) recv New_balance, certified_data := certified_data\<rparr>)
+        else S\<lparr>messages := take n (messages S) @ drop (Suc n) (messages S),
+            balances := list_map_set (balances S) recv (bal + ((if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE) - cycles_used))\<rparr>))
+    | _ \<Rightarrow> undefined)"
+
+definition message_execution_lost_cycles :: "nat \<Rightarrow> nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> nat" where
+  "message_execution_lost_cycles n cycles_used S = (case messages S ! n of Func_message ctxt_id recv ep q \<Rightarrow>
+    let Is_response = (case ep of Callback _ _ _ \<Rightarrow> True | _ \<Rightarrow> False) in
+    min cycles_used (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE))"
+
+lemma message_execution_cycles_monotonic:
+  assumes pre: "message_execution_pre n cycles_used S"
+  shows "total_cycles S = total_cycles (message_execution_post n cycles_used S) + message_execution_lost_cycles n cycles_used S"
+proof -
+  obtain ctxt_id recv ep q can bal can_status t ctxt where msg: "messages S ! n = Func_message ctxt_id recv ep q"
+    and prod: "list_map_get (canisters S) recv = Some (Some can)"
+    "list_map_get (balances S) recv = Some bal"
+    "list_map_get (canister_status S) recv = Some can_status"
+    "list_map_get (time S) recv = Some t"
+    "list_map_get (call_contexts S) ctxt_id = Some ctxt"
+    using pre
+    by (auto simp: message_execution_pre_def split: message.splits option.splits)
+  define Mod where "Mod = can_state_rec.module can"
+  define Is_response where "Is_response = (case ep of Callback _ _ _ \<Rightarrow> True | _ \<Rightarrow> False)"
+  define Env :: "'b env" where "Env = \<lparr>env_time = t, balance = bal, freezing_limit = ic_freezing_limit S recv, certificate = None, status = to_status can_status\<rparr>"
+  define Available where "Available = call_ctxt_available_cycles ctxt"
+  define F where "F = exec_function ep Env Available Mod"
+  define R where "R = F (wasm_state can)"
+  obtain cycles_accepted_res new_calls_res where res: "(cycles_accepted_res, new_calls_res) = (case R of Inr res \<Rightarrow> (cycles_accepted res, new_calls res))"
+    by (cases "(case R of Inr res \<Rightarrow> (cycles_accepted res, new_calls res))") auto
+  define New_balance where "New_balance = bal + cycles_accepted_res + (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE)
+    - (cycles_used + sum_list (map (\<lambda>x. MAX_CYCLES_PER_RESPONSE + transferred_cycles x) new_calls_res))"
+  define no_response where "no_response = (case R of Inr result \<Rightarrow> update_return.response result = None)"
+  define older where "older = take n (messages S)"
+  define younger where "younger = drop (Suc n) (messages S)"
+  have msgs: "messages S = older @ Func_message ctxt_id recv ep q # younger"
+    "take n older = older" "drop (Suc n) older = []"
+    "take (n - length older) ws = []" "drop (Suc n - length older) (w # ws) = ws"
+    for w and ws :: "('b, 'p, 'uid, 'canid, 's, 'c, 'cid) message list"
+    using id_take_nth_drop[of n "messages S"] pre
+    by (auto simp: message_execution_pre_def msg older_def younger_def)
+  note lm = list_map_sum_in[OF prod(2), where ?g=id, simplified] list_map_sum_in_ge[OF prod(2), where ?g=id, simplified]
+    list_map_sum_in[OF prod(5), where ?g=call_ctxt_carried_cycles] list_map_sum_in_ge[OF prod(5), where ?g=call_ctxt_carried_cycles]
+  define S'' where "S'' = S\<lparr>messages := take n (messages S) @ drop (Suc n) (messages S),
+    balances := list_map_set (balances S) recv (bal + ((if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE) - cycles_used))\<rparr>"
+  define cond where "cond = (\<not>isl R \<and> cycles_used \<le> (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE) \<and>
+    cycles_accepted_res \<le> Available \<and>
+    cycles_used + sum_list (map (\<lambda>x. MAX_CYCLES_PER_RESPONSE + transferred_cycles x) new_calls_res) \<le>
+      bal + cycles_accepted_res + (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE) \<and>
+    New_balance > (if Is_response then 0 else ic_freezing_limit S recv) \<and>
+    (no_response \<or> call_ctxt_needs_to_respond ctxt))"
+  have reserved: "(if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE) = cycles_reserved ep"
+    by (auto simp: Is_response_def split: entry_point.splits)
+  show ?thesis
+  proof (cases cond)
+    case False
+    have "message_execution_post n cycles_used S = S''"
+      "message_execution_lost_cycles n cycles_used S = min cycles_used (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE)"
+      using False
+      by (simp_all add: message_execution_post_def message_execution_lost_cycles_def Let_def msg prod
+          Mod_def[symmetric] Is_response_def[symmetric] Env_def[symmetric] Available_def[symmetric] F_def[symmetric] R_def[symmetric] res[symmetric]
+          New_balance_def[symmetric] no_response_def[symmetric] S''_def[symmetric] cond_def[symmetric] del: min_less_iff_conj split del: if_split)
+    then show ?thesis
+      using lm(2)
+      by (auto simp: total_cycles_def S''_def msgs lm(1) reserved)
+  next
+    case True
+    define result where "result = projr R"
+    have R_Inr: "R = Inr result"
+      using True
+      by (auto simp: cond_def result_def)
+    define response_messages where "response_messages = (case response result of None \<Rightarrow> []
+      | Some resp \<Rightarrow> [Response_message (call_ctxt_origin ctxt) resp (Available - cycles_accepted_res)])"
+    define new_call_to_message :: "(?'p, 'canid, 's, 'b, 'c) method_call \<Rightarrow> ('b, 'p, 'uid, 'canid, 's, 'c, 'cid) message" where
+      "new_call_to_message = (\<lambda>call. Call_message (From_canister ctxt_id (callback call)) (principal_of_canid recv)
+        (callee call) (method_call.method_name call) (arg call) (transferred_cycles call) (Queue (Canister recv) (callee call)))"
+    define messages where "messages = take n (ic.messages S) @ drop (Suc n) (ic.messages S) @ map new_call_to_message new_calls_res @ response_messages"
+    define new_ctxt where "new_ctxt = (case response result of
+        None \<Rightarrow> call_ctxt_deduct_cycles cycles_accepted_res ctxt
+      | Some _ \<Rightarrow> call_ctxt_respond ctxt)"
+    define certified_data where "certified_data = (case new_certified_data result of None \<Rightarrow> ic.certified_data S
+      | Some cd \<Rightarrow> list_map_set (ic.certified_data S) recv cd)"
+    define S' where "S' = S\<lparr>canisters := list_map_set (canisters S) recv (Some (can\<lparr>wasm_state := new_state result\<rparr>)),
+      messages := messages, call_contexts := list_map_set (call_contexts S) ctxt_id new_ctxt,
+      balances := list_map_set (balances S) recv New_balance, certified_data := certified_data\<rparr>"
+    have cycles_accepted_res_def: "cycles_accepted_res = cycles_accepted result"
+      and new_calls_res_def: "new_calls_res = new_calls result"
+      using res
+      by (auto simp: R_Inr)
+    have no_response: "no_response = (response result = None)"
+      by (auto simp: no_response_def R_Inr)
+    have msg_exec: "message_execution_post n cycles_used S = S'"
+      and lost: "message_execution_lost_cycles n cycles_used S = min cycles_used (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE)"
+      using True
+      by (simp_all add: message_execution_post_def message_execution_lost_cycles_def Let_def msg prod
+          Mod_def[symmetric] Is_response_def[symmetric] Env_def[symmetric] Available_def[symmetric] F_def[symmetric] R_def[symmetric] res[symmetric]
+          New_balance_def[symmetric] no_response_def[symmetric] S''_def[symmetric] cond_def[symmetric]
+          messages_def[symmetric] new_ctxt_def[symmetric] certified_data_def[symmetric] S'_def[symmetric]
+          result_def[symmetric] response_messages_def[symmetric] new_call_to_message_def[symmetric]
+          del: min_less_iff_conj split del: if_split)
+    have "message_cycles \<circ> new_call_to_message = (\<lambda>c. MAX_CYCLES_PER_RESPONSE + transferred_cycles c)" for c :: "(?'p, 'canid, 's, 'b, 'c) method_call"
+      by (auto simp: new_call_to_message_def)
+    then have A1: "sum_list (map (message_cycles \<circ> new_call_to_message) new_calls_res) = (\<Sum>x\<leftarrow>new_calls_res. MAX_CYCLES_PER_RESPONSE + transferred_cycles x)"
+      by auto
+    have A2: "sum_list (map local.message_cycles response_messages) = (case response result of None \<Rightarrow> 0
+      | _ \<Rightarrow> carried_cycles (call_ctxt_origin ctxt) + (call_ctxt_available_cycles ctxt - cycles_accepted result))"
+      by (auto simp: response_messages_def Available_def cycles_accepted_res_def split: option.splits)
+    have A3: "call_ctxt_carried_cycles new_ctxt = (case response result of Some _ \<Rightarrow> 0
+      | _ \<Rightarrow> if call_ctxt_needs_to_respond ctxt then carried_cycles (call_ctxt_origin ctxt) + (call_ctxt_available_cycles ctxt - cycles_accepted result) else 0)"
+      by (auto simp: new_ctxt_def Available_def cycles_accepted_res_def call_ctxt_carried_cycles split: option.splits)
+    have A4: "call_ctxt_carried_cycles ctxt = (if call_ctxt_needs_to_respond ctxt then carried_cycles (call_ctxt_origin ctxt) + call_ctxt_available_cycles ctxt else 0)"
+      using call_ctxt_carried_cycles
+      by auto
+    have reserve: "cycles_reserved ep = (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE)"
+      by (auto simp: Is_response_def split: entry_point.splits)
+    have messages_msgs: "messages = older @ younger @ map new_call_to_message new_calls_res @ response_messages"
+      by (auto simp: messages_def older_def younger_def)
+    show ?thesis
+      using lm(2,4) True call_ctxt_inv[of ctxt]
+      by (auto simp: cond_def msg_exec S'_def total_cycles_def lm(1,3) msgs messages_msgs A1 A2 A3 A4 New_balance_def
+          reserve cycles_accepted_res_def no_response_def R_Inr lost Available_def split: option.splits)
+  qed
+qed
+
+
+
+(* System transition: Call context starvation [DONE] *)
+
+definition call_context_starvation_pre :: "'cid \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  "call_context_starvation_pre ctxt_id S =
+  (case list_map_get (call_contexts S) ctxt_id of Some call_context \<Rightarrow> call_ctxt_needs_to_respond call_context \<and>
+    call_ctxt_origin call_context \<noteq> From_heartbeat \<and>
+    (\<forall>msg \<in> set (messages S). case msg of
+        Call_message orig _ _ _ _ _ _ \<Rightarrow> calling_context orig \<noteq> Some ctxt_id
+      | Response_message orig _ _ \<Rightarrow> calling_context orig \<noteq> Some ctxt_id
+      | _ \<Rightarrow> True) \<and>
+    (\<forall>other_call_context \<in> list_map_vals (call_contexts S).
+      call_ctxt_needs_to_respond other_call_context \<longrightarrow>
+      calling_context (call_ctxt_origin other_call_context) \<noteq> Some ctxt_id)
+  | None \<Rightarrow> False)"
+
+definition call_context_starvation_post :: "'cid \<Rightarrow>
+  ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "call_context_starvation_post ctxt_id S = (
+    case list_map_get (call_contexts S) ctxt_id of Some call_context \<Rightarrow>
+    let msg = Response_message (call_ctxt_origin call_context) (response.Reject CANISTER_ERROR (encode_string ''starvation'')) (call_ctxt_available_cycles call_context)
+    in S\<lparr>call_contexts := list_map_set (call_contexts S) ctxt_id (call_ctxt_respond call_context),
+        messages := messages S @ [msg]\<rparr>)"
+
+lemma call_context_starvation_cycles_inv:
+  "call_context_starvation_pre ctxt_id S \<Longrightarrow>
+  total_cycles S = total_cycles (call_context_starvation_post ctxt_id S)"
+  using list_map_sum_in_ge[where ?f="call_contexts S" and ?x=ctxt_id and ?g=call_ctxt_carried_cycles]
+  by (auto simp: call_context_starvation_pre_def call_context_starvation_post_def total_cycles_def
+      call_ctxt_carried_cycles list_map_sum_in[where ?g=call_ctxt_carried_cycles] split: option.splits)
+
+
+
+(* System transition: Call context removal [DONE] *)
+
+definition call_context_removal_pre :: "'cid \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  "call_context_removal_pre ctxt_id S = (
+    (case list_map_get (call_contexts S) ctxt_id of Some call_context \<Rightarrow>
+      (\<not>call_ctxt_needs_to_respond call_context \<or>
+        (call_ctxt_origin call_context = From_heartbeat \<and>
+          (\<forall>msg \<in> set (messages S). case msg of
+            Func_message other_ctxt_id _ _ _ \<Rightarrow> other_ctxt_id \<noteq> ctxt_id
+          | _ \<Rightarrow> True))) \<and>
+      (\<forall>msg \<in> set (messages S). case msg of
+          Call_message ctxt _ _ _ _ _ _ \<Rightarrow> calling_context ctxt \<noteq> Some ctxt_id
+        | Response_message ctxt _ _ \<Rightarrow> calling_context ctxt \<noteq> Some ctxt_id
+        | _ \<Rightarrow> True) \<and>
+      (\<forall>other_call_context \<in> list_map_vals (call_contexts S).
+        call_ctxt_needs_to_respond other_call_context \<longrightarrow>
+        calling_context (call_ctxt_origin other_call_context) \<noteq> Some ctxt_id)
+    | None \<Rightarrow> False))"
+
+definition call_context_removal_post :: "'cid \<Rightarrow>
+  ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "call_context_removal_post ctxt_id S = S\<lparr>call_contexts := list_map_del (call_contexts S) ctxt_id\<rparr>"
+
+lemma call_context_removal_cycles_inv:
+  "call_context_removal_pre ctxt_id S \<Longrightarrow>
+  total_cycles S = total_cycles (call_context_removal_post ctxt_id S) +
+    (case list_map_get (call_contexts S) ctxt_id of Some call_context \<Rightarrow> call_ctxt_available_cycles call_context)"
+  using call_ctxt_inv
+  by (auto simp: call_context_removal_pre_def call_context_removal_post_def total_cycles_def call_ctxt_carried_cycles list_map_del_sum split: option.splits)
+
+end
+
+export_code request_submission_pre request_submission_post
+  request_rejection_pre request_rejection_post
+  initiate_canister_call_pre initiate_canister_call_post
+  call_reject_pre call_reject_post
+  call_context_create_pre call_context_create_post
+  call_context_heartbeat_pre call_context_heartbeat_post
+  message_execution_pre message_execution_post
+  call_context_starvation_pre call_context_starvation_post
+  call_context_removal_pre call_context_removal_post
+in Haskell module_name IC file_prefix code
+
+end

--- a/theories/IC.thy
+++ b/theories/IC.thy
@@ -2,6 +2,11 @@ theory IC
   imports "HOL-Library.AList"
 begin
 
+(* General helper lemmas *)
+
+lemma in_set_updD: "x \<in> set (xs[n := z]) \<Longrightarrow> x \<in> set xs \<or> x = z"
+  by (meson insert_iff set_update_subset_insert subsetD)
+
 (* Partial maps *)
 
 typedef ('a, 'b) list_map = "{f :: ('a \<times> 'b) list. distinct (map fst f)}"
@@ -9,11 +14,22 @@ typedef ('a, 'b) list_map = "{f :: ('a \<times> 'b) list. distinct (map fst f)}"
 
 setup_lifting type_definition_list_map
 
+lift_bnf (dead 'k, set: 'v) list_map [wits: "[] :: ('k \<times> 'v) list"] for map: map rel: rel
+  by auto
+
+hide_const (open) map set rel
+
 lift_definition list_map_dom :: "('a, 'b) list_map \<Rightarrow> 'a set" is
   "set \<circ> map fst" .
 
-lift_definition list_map_vals :: "('a, 'b) list_map \<Rightarrow> 'b set" is
+lift_definition list_map_vals :: "('a, 'b) list_map \<Rightarrow> 'b list" is
+  "map snd" .
+
+lift_definition list_map_range :: "('a, 'b) list_map \<Rightarrow> 'b set" is
   "set \<circ> map snd" .
+
+lemma in_set_map_filter_vals: "z \<in> set (List.map_filter g (list_map_vals f)) \<Longrightarrow> \<exists>w \<in> list_map_range f. g w = Some z"
+  by transfer (force simp: List.map_filter_def)
 
 lift_definition list_map_sum_vals :: "('b \<Rightarrow> nat) \<Rightarrow> ('a, 'b) list_map \<Rightarrow> nat" is
   "\<lambda>g. sum_list \<circ> (map (g \<circ> snd))" .
@@ -21,19 +37,89 @@ lift_definition list_map_sum_vals :: "('b \<Rightarrow> nat) \<Rightarrow> ('a, 
 lift_definition list_map_get :: "('a, 'b) list_map \<Rightarrow> 'a \<Rightarrow> 'b option" is
   "map_of" .
 
+lemma list_map_get_dom[dest]: "x \<in> list_map_dom f \<Longrightarrow> list_map_get f x = None \<Longrightarrow> False"
+  by transfer auto
+
+lemma list_map_get_range: "list_map_get f x = Some y \<Longrightarrow> y \<in> list_map_range f"
+  by transfer force
+
 lift_definition list_map_set :: "('a, 'b) list_map \<Rightarrow> 'a \<Rightarrow> 'b \<Rightarrow> ('a, 'b) list_map" is
   "\<lambda>f x y. AList.update x y f"
   by (rule distinct_update)
+
+lemma list_map_get_set: "list_map_get (list_map_set f x y) z = (if x = z then Some y else list_map_get f z)"
+  by transfer (auto simp add: update_Some_unfold update_conv)
+
+lemma list_map_dom_set[simp]: "list_map_dom (list_map_set f x y) = list_map_dom f \<union> {x}"
+  by transfer (auto simp add: dom_update)
+
+lemma list_map_range_setD: "z \<in> list_map_range (list_map_set f x y) \<Longrightarrow> z \<in> list_map_range f \<or> z = y"
+  apply transfer
+  apply auto
+  apply (metis distinct_update image_iff map_of_eq_Some_iff snd_eqD update_Some_unfold)
+  done
 
 lift_definition list_map_del :: "('a, 'b) list_map \<Rightarrow> 'a \<Rightarrow> ('a, 'b) list_map" is
   "\<lambda>f x. AList.delete x f"
   by (rule distinct_delete)
 
+lemma list_map_get_del: "list_map_get (list_map_del f x) z = (if x = z then None else list_map_get f z)"
+  by transfer (auto simp add: delete_conv')
+
+lemma list_map_dom_del[simp]: "list_map_dom (list_map_del f x) = list_map_dom f - {x}"
+  by transfer (simp add: delete_keys)
+
+lemma list_map_range_del: "z \<in> list_map_range (list_map_del f x) \<Longrightarrow> z \<in> list_map_range f"
+  apply transfer
+  apply auto
+  apply (metis Some_eq_map_of_iff delete_notin_dom distinct_delete fst_eqD imageI map_of_delete snd_eqD)
+  done
+
 lift_definition list_map_empty :: "('a, 'b) list_map" is "[]"
   by auto
 
+lemma list_map_get_empty[simp]: "list_map_get list_map_empty x = None"
+  by transfer auto
+
 lemma list_map_empty_dom[simp]: "list_map_dom list_map_empty = {}"
   by transfer auto
+
+lemma list_map_empty_range[simp]: "list_map_range list_map_empty = {}"
+  by transfer auto
+
+lift_definition list_map_init :: "('a \<times> 'b) list \<Rightarrow> ('a, 'b) list_map" is
+  "\<lambda>xys. AList.updates (map fst xys) (map snd xys) []"
+  using distinct_updates
+  by force
+
+lift_definition list_map_map :: "('b \<Rightarrow> 'c) \<Rightarrow> ('a, 'b) list_map \<Rightarrow> ('a, 'c) list_map" is
+  "\<lambda>f xs. map (\<lambda>(k, v). (k, f v)) xs"
+  by (auto simp: comp_def case_prod_beta)
+
+lemma list_map_dom_map_map[simp]: "list_map_dom (list_map_map g f) = list_map_dom f"
+  by transfer force
+
+lemma list_map_range_map_map[simp]: "list_map_range (list_map_map g f) = g ` list_map_range f"
+  by transfer force
+
+lemma list_map_sum_vals_split: "(\<And>ctxt. ctxt \<in> list_map_range xs \<Longrightarrow> f (g ctxt) \<le> f ctxt) \<Longrightarrow> list_map_sum_vals f xs =
+  list_map_sum_vals id
+    (list_map_map (\<lambda>ctxt. if P ctxt then f ctxt - f (g ctxt) else 0) xs) +
+  list_map_sum_vals f
+    (list_map_map (\<lambda>ctxt. if P ctxt then g ctxt else ctxt) xs)"
+  apply (transfer fixing: f g P)
+  subgoal for xs
+    by (induction xs) auto
+  done
+
+lemma list_map_sum_vals_filter:
+  assumes "\<And>b. b \<in> list_map_range xs \<Longrightarrow> P b = None \<Longrightarrow> f b = 0" "\<And>b y. b \<in> list_map_range xs \<Longrightarrow> P b = Some y \<Longrightarrow> f b = g y"
+  shows "list_map_sum_vals id (list_map_map f xs) = sum_list (map g (List.map_filter P (list_map_vals xs)))"
+  using assms
+  apply (transfer fixing: f g P)
+  subgoal for xs
+    by (induction xs) (auto simp: List.map_filter_def)
+  done
 
 lemma list_map_sum_in_ge_aux:
   fixes g :: "'a \<Rightarrow> nat"
@@ -83,12 +169,15 @@ lemma list_map_del_sum: "list_map_get f x = Some y \<Longrightarrow> list_map_su
 
 (* Abstract canisters *)
 
+type_synonym 's method_name = 's
+
 type_synonym 'b arg = 'b
+type_synonym 'p caller_id = 'p
 
 type_synonym timestamp = nat
 datatype status = Running | Stopping | Stopped
 record ('b) env =
-  env_time :: timestamp
+  time :: timestamp
   balance :: nat
   freezing_limit :: nat
   certificate :: "'b option"
@@ -100,52 +189,65 @@ datatype ('b, 's) response =
 | Reject reject_code 's
 record ('p, 'canid, 's, 'b, 'c) method_call =
   callee :: 'canid
-  method_name :: 's
+  method_name :: "'s method_name"
   arg :: 'b
   transferred_cycles :: nat
   callback :: 'c
 
+record 'x cycles_return =
+  return :: 'x
+  cycles_used :: nat
+type_synonym trap_return = "unit cycles_return"
 record ('w, 'p, 'canid, 's, 'b, 'c) update_return =
   new_state :: 'w
   new_calls :: "('p, 'canid, 's, 'b, 'c) method_call list"
   new_certified_data :: "'b option"
   response :: "('b, 's) response option"
   cycles_accepted :: nat
-type_synonym ('w, 'p, 'canid, 's, 'b, 'c, 'tr) update_func = "'w \<Rightarrow> 'tr + ('w, 'p, 'canid, 's, 'b, 'c) update_return"
-type_synonym ('w, 'b, 's, 'tr) query_func = "'w \<Rightarrow> 'tr + ('b, 's) response"
+  cycles_used :: nat
+record ('b, 's) query_return =
+  response :: "('b, 's) response"
+  cycles_used :: nat
+record 'w heartbeat_return =
+  new_state :: 'w
+  cycles_used :: nat
+type_synonym ('w, 'p, 'canid, 's, 'b, 'c) update_func = "'w \<Rightarrow> trap_return + ('w, 'p, 'canid, 's, 'b, 'c) update_return"
+type_synonym ('w, 'b, 's) query_func = "'w \<Rightarrow> trap_return + ('b, 's) query_return"
+type_synonym 'w heartbeat_func = "'w \<Rightarrow> trap_return + 'w heartbeat_return"
 
 type_synonym available_cycles = nat
 type_synonym refunded_cycles = nat
 
 datatype inspect_method_result = Accept | Reject
-record ('p, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's) canister_module_rec =
-  init :: "'canid \<times> 'b arg \<times> 'p \<times> 'b env \<Rightarrow> 'tr + 'w"
-  pre_upgrade :: "'w \<times> 'p \<times> 'b env \<Rightarrow> 'tr + 'sm"
-  post_upgrade :: "'canid \<times> 'sm \<times> 'b arg \<times> 'p \<times> 'b env \<Rightarrow> 'tr + 'w"
-  update_methods :: "('s, ('b arg \<times> 'p \<times> 'b env \<times> available_cycles) \<Rightarrow> ('w, 'p, 'canid, 's, 'b, 'c, 'tr) update_func) list_map"
-  query_methods :: "('s, ('b arg \<times> 'p \<times> 'b env) \<Rightarrow> ('w, 'b, 's, 'tr) query_func) list_map"
-  heartbeat :: "'b env \<Rightarrow> 'w \<Rightarrow> 'tr + 'w"
-  callbacks :: "('c \<times> ('b, 's) response \<times> refunded_cycles \<times> 'b env \<times> available_cycles) \<Rightarrow> ('w, 'p, 'canid, 's, 'b, 'c, 'tr) update_func"
-  inspect_message :: "('s \<times> 'w \<times> 'b arg \<times> 'p \<times> 'b env) \<Rightarrow> 'tr + inspect_method_result"
-typedef ('p, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's) canister_module =
-  "{m :: ('p, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's) canister_module_rec. list_map_dom (update_methods m) \<inter> list_map_dom (query_methods m) = {}}"
+record ('p, 'canid, 'b, 'w, 'sm, 'c, 's) canister_module_rec =
+  init :: "'canid \<times> 'b arg \<times> 'p caller_id \<times> 'b env \<Rightarrow> trap_return + 'w cycles_return"
+  pre_upgrade :: "'w \<times> 'p \<times> 'b env \<Rightarrow> trap_return + 'sm cycles_return"
+  post_upgrade :: "'canid \<times> 'sm \<times> 'b arg \<times> 'p caller_id \<times> 'b env \<Rightarrow> trap_return + 'w cycles_return"
+  update_methods :: "('s method_name, ('b arg \<times> 'p caller_id \<times> 'b env \<times> available_cycles) \<Rightarrow> ('w, 'p, 'canid, 's, 'b, 'c) update_func) list_map"
+  query_methods :: "('s method_name, ('b arg \<times> 'p caller_id \<times> 'b env) \<Rightarrow> ('w, 'b, 's) query_func) list_map"
+  heartbeat :: "'b env \<Rightarrow> 'w heartbeat_func"
+  callbacks :: "('c \<times> ('b, 's) response \<times> refunded_cycles \<times> 'b env \<times> available_cycles) \<Rightarrow> ('w, 'p, 'canid, 's, 'b, 'c) update_func"
+  inspect_message :: "('s method_name \<times> 'w \<times> 'b arg \<times> 'p caller_id \<times> 'b env) \<Rightarrow> trap_return + inspect_method_result cycles_return"
+typedef ('p, 'canid, 'b, 'w, 'sm, 'c, 's) canister_module =
+  "{m :: ('p, 'canid, 'b, 'w, 'sm, 'c, 's) canister_module_rec. list_map_dom (update_methods m) \<inter> list_map_dom (query_methods m) = {}}"
   by (auto intro: exI[of _ "\<lparr>init = undefined, pre_upgrade = undefined, post_upgrade = undefined,
       update_methods = list_map_empty, query_methods = list_map_empty, heartbeat = undefined, callbacks = undefined,
       inspect_message = undefined\<rparr>"])
 
 setup_lifting type_definition_canister_module
 
-lift_definition dispatch_method :: "'s \<Rightarrow> ('p, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's) canister_module \<Rightarrow>
-  ((('b arg \<times> 'p \<times> 'b env \<times> available_cycles) \<Rightarrow> ('w, 'p, 'canid, 's, 'b, 'c, 'tr) update_func) +
-   (('b arg \<times> 'p \<times> 'b env) \<Rightarrow> ('w, 'b, 's, 'tr) query_func)) option" is
-  "\<lambda>f m. case list_map_get (update_methods m) f of Some f' \<Rightarrow> None | None \<Rightarrow> (case list_map_get (query_methods m) f of Some f' \<Rightarrow> None | None \<Rightarrow> None)" .
+lift_definition canister_module_init :: "('p, 'canid, 'b, 'w, 'sm, 'c, 's) canister_module \<Rightarrow> 'canid \<times> 'b arg \<times> 'p \<times> 'b env \<Rightarrow> trap_return + 'w cycles_return" is "init" .
+lift_definition canister_module_pre_upgrade :: "('p, 'canid, 'b, 'w, 'sm, 'c, 's) canister_module \<Rightarrow> 'w \<times> 'p \<times> 'b env \<Rightarrow> trap_return + 'sm cycles_return" is pre_upgrade .
+lift_definition canister_module_post_upgrade :: "('p, 'canid, 'b, 'w, 'sm, 'c, 's) canister_module \<Rightarrow> 'canid \<times> 'sm \<times> 'b arg \<times> 'p \<times> 'b env \<Rightarrow> trap_return + 'w cycles_return" is post_upgrade .
+lift_definition canister_module_update_methods :: "('p, 'canid, 'b, 'w, 'sm, 'c, 's) canister_module \<Rightarrow> ('s, ('b arg \<times> 'p \<times> 'b env \<times> available_cycles) \<Rightarrow> ('w, 'p, 'canid, 's, 'b, 'c) update_func) list_map" is update_methods .
+lift_definition canister_module_query_methods :: "('p, 'canid, 'b, 'w, 'sm, 'c, 's) canister_module \<Rightarrow> ('s, ('b arg \<times> 'p \<times> 'b env) \<Rightarrow> ('w, 'b, 's) query_func) list_map" is query_methods .
+lift_definition canister_module_heartbeat :: "('p, 'canid, 'b, 'w, 'sm, 'c, 's) canister_module \<Rightarrow> 'b env \<Rightarrow> 'w heartbeat_func" is heartbeat .
+lift_definition canister_module_callbacks :: "('p, 'canid, 'b, 'w, 'sm, 'c, 's) canister_module \<Rightarrow> ('c \<times> ('b, 's) response \<times> refunded_cycles \<times> 'b env \<times> available_cycles) \<Rightarrow> ('w, 'p, 'canid, 's, 'b, 'c) update_func" is callbacks .
+lift_definition canister_module_inspect_message :: "('p, 'canid, 'b, 'w, 'sm, 'c, 's) canister_module \<Rightarrow> ('s \<times> 'w \<times> 'b arg \<times> 'p \<times> 'b env) \<Rightarrow> trap_return + inspect_method_result cycles_return" is inspect_message .
 
-lift_definition canister_module_callbacks :: "('p, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's) canister_module \<Rightarrow>
-  ('c \<times> ('b, 's) response \<times> refunded_cycles \<times> 'b env \<times> available_cycles) \<Rightarrow> ('w, 'p, 'canid, 's, 'b, 'c, 'tr) update_func" is
-  callbacks .
-
-lift_definition canister_module_heartbeat :: "('p, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's) canister_module \<Rightarrow> 'b env \<Rightarrow> 'w \<Rightarrow> 'tr + 'w" is
-  heartbeat .
+lift_definition dispatch_method :: "'s \<Rightarrow> ('p, 'canid, 'b, 'w, 'sm, 'c, 's) canister_module \<Rightarrow>
+  ((('b arg \<times> 'p \<times> 'b env \<times> available_cycles) \<Rightarrow> ('w, 'p, 'canid, 's, 'b, 'c) update_func) + (('b arg \<times> 'p \<times> 'b env) \<Rightarrow> ('w, 'b, 's) query_func)) option" is
+  "\<lambda>f m. case list_map_get (update_methods m) f of Some f' \<Rightarrow> Some (Inl f') | None \<Rightarrow> (case list_map_get (query_methods m) f of Some f' \<Rightarrow> Some (Inr f') | None \<Rightarrow> None)" .
 
 (* Call contexts *)
 
@@ -173,26 +275,26 @@ typedef ('p, 'uid, 'canid, 'b, 's, 'c, 'cid) call_ctxt = "{ctxt :: ('p, 'uid, 'c
 
 setup_lifting type_definition_call_ctxt
 
-lift_definition call_ctxt_origin :: "('p, 'uid, 'canid, 'b, 's, 'c, 'cid) call_ctxt \<Rightarrow> ('b, 'p, 'uid, 'canid, 's, 'c, 'cid) call_origin" is
-  "\<lambda>ctxt. origin ctxt" .
+lift_definition call_ctxt_canister :: "('p, 'uid, 'canid, 'b, 's, 'c, 'cid) call_ctxt \<Rightarrow> 'canid" is "canister" .
+lift_definition call_ctxt_origin :: "('p, 'uid, 'canid, 'b, 's, 'c, 'cid) call_ctxt \<Rightarrow> ('b, 'p, 'uid, 'canid, 's, 'c, 'cid) call_origin" is "origin" .
+lift_definition call_ctxt_needs_to_respond :: "('p, 'uid, 'canid, 'b, 's, 'c, 'cid) call_ctxt \<Rightarrow> bool" is needs_to_respond .
+lift_definition call_ctxt_deleted :: "('p, 'uid, 'canid, 'b, 's, 'c, 'cid) call_ctxt \<Rightarrow> bool" is deleted .
+lift_definition call_ctxt_available_cycles :: "('p, 'uid, 'canid, 'b, 's, 'c, 'cid) call_ctxt \<Rightarrow> nat" is available_cycles .
 
-lift_definition call_ctxt_needs_to_respond :: "('p, 'uid, 'canid, 'b, 's, 'c, 'cid) call_ctxt \<Rightarrow> bool" is
-  "\<lambda>ctxt. needs_to_respond ctxt" .
-
-lift_definition call_ctxt_available_cycles :: "('p, 'uid, 'canid, 'b, 's, 'c, 'cid) call_ctxt \<Rightarrow> nat" is
-  "\<lambda>ctxt. available_cycles ctxt" .
-
-lemma call_ctxt_inv: "\<not>call_ctxt_needs_to_respond x2 \<Longrightarrow> call_ctxt_available_cycles x2 = 0"
+lemma call_ctxt_not_needs_to_respond_available_cycles: "\<not>call_ctxt_needs_to_respond x2 \<Longrightarrow> call_ctxt_available_cycles x2 = 0"
   by transfer auto
 
 lift_definition call_ctxt_respond :: "('p, 'uid, 'canid, 'b, 's, 'c, 'cid) call_ctxt \<Rightarrow> ('p, 'uid, 'canid, 'b, 's, 'c, 'cid) call_ctxt" is
-  "\<lambda>ctxt. ctxt\<lparr>available_cycles := 0, needs_to_respond := False\<rparr>"
+  "\<lambda>ctxt. ctxt\<lparr>needs_to_respond := False, available_cycles := 0\<rparr>"
   by auto
 
-lemma call_ctxt_respond_available_cycles[simp]: "call_ctxt_available_cycles (call_ctxt_respond ctxt) = 0"
+lemma call_ctxt_respond_origin[simp]: "call_ctxt_origin (call_ctxt_respond ctxt) = call_ctxt_origin ctxt"
   by transfer auto
 
 lemma call_ctxt_respond_needs_to_respond[dest]: "call_ctxt_needs_to_respond (call_ctxt_respond ctxt) \<Longrightarrow> False"
+  by transfer auto
+
+lemma call_ctxt_respond_available_cycles[simp]: "call_ctxt_available_cycles (call_ctxt_respond ctxt) = 0"
   by transfer auto
 
 lift_definition call_ctxt_deduct_cycles :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 's, 'c, 'cid) call_ctxt \<Rightarrow> ('p, 'uid, 'canid, 'b, 's, 'c, 'cid) call_ctxt" is
@@ -208,12 +310,19 @@ lemma call_ctxt_deduct_cycles_needs_to_respond[simp]: "call_ctxt_needs_to_respon
 lemma call_ctxt_deduct_cycles_available_cycles[simp]: "call_ctxt_available_cycles (call_ctxt_deduct_cycles n ctxt) = call_ctxt_available_cycles ctxt - n"
   by transfer auto
 
+lift_definition call_ctxt_delete :: "('p, 'uid, 'canid, 'b, 's, 'c, 'cid) call_ctxt \<Rightarrow> ('p, 'uid, 'canid, 'b, 's, 'c, 'cid) call_ctxt" is
+  "\<lambda>ctxt. ctxt\<lparr>deleted := True, needs_to_respond := False, available_cycles := 0\<rparr>"
+  by auto
+
+lemma call_ctxt_delete_needs_to_respond[simp]: "call_ctxt_needs_to_respond (call_ctxt_delete ctxt) = False"
+  by transfer auto
+
 (* Calls and Messages *)
 
 datatype 'canid queue_origin = System | Canister 'canid
 datatype 'canid queue = Unordered | Queue "'canid queue_origin" 'canid
 datatype ('s, 'p, 'b, 'c) entry_point =
-  Public_method "'s" "'p" "'b"
+  Public_method "'s method_name" "'p" "'b"
 | Callback "'c" "('b, 's) response" "refunded_cycles"
 | Heartbeat
 
@@ -238,27 +347,37 @@ record ('b, 'uid, 'canid, 's) CanisterQuery =
   method_name :: 's
   arg :: 'b
 type_synonym ('b, 'uid, 'canid, 's) APIReadRequest = "('b, 'uid) StateRead + ('b, 'uid, 'canid, 's) CanisterQuery"
-record ('b, 'p, 'uid, 'canid, 's, 'pk, 'sig, 'sd) envelope =
+
+record ('p, 'canid, 'pk, 'sig) delegation =
+  pubkey :: 'pk
+  targets :: "'canid list option"
+  senders :: "'p list option"
+  expiration :: timestamp
+record ('p, 'canid, 'pk, 'sig) signed_delegation =
+  delegation :: "('p, 'canid, 'pk, 'sig) delegation"
+  signature :: "'sig"
+
+record ('b, 'p, 'uid, 'canid, 's, 'pk, 'sig) envelope =
   content :: "('b, 'p, 'uid, 'canid, 's) request + ('b, 'uid, 'canid, 's) APIReadRequest"
   sender_pubkey :: "'pk option"
   sender_sig :: "'sig option"
-  sender_delegation :: 'sd
+  sender_delegation :: "('p, 'canid, 'pk, 'sig) delegation list"
 
 datatype ('b, 's) request_status = Received | Processing | Rejected reject_code 's | Replied 'b | Done
 
 (* The system state *)
 
-record ('p, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's) can_state_rec =
+record ('p, 'canid, 'b, 'w, 'sm, 'c, 's) can_state_rec =
   wasm_state :: 'w
-  module :: "('p, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's) canister_module"
+  module :: "('p, 'canid, 'b, 'w, 'sm, 'c, 's) canister_module"
   raw_module :: 'b
   public_custom_sections :: "('s, 'b) list_map"
   private_custom_sections :: "('s, 'b) list_map"
-type_synonym ('p, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's) can_state = "('p, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's) can_state_rec option"
+type_synonym ('p, 'canid, 'b, 'w, 'sm, 'c, 's) can_state = "('p, 'canid, 'b, 'w, 'sm, 'c, 's) can_state_rec option"
 datatype ('b, 'p, 'uid, 'canid, 's, 'c, 'cid) can_status = Running | Stopping "(('b, 'p, 'uid, 'canid, 's, 'c, 'cid) call_origin \<times> nat) list" | Stopped
-record ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic =
+record ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic =
   requests :: "(('b, 'p, 'uid, 'canid, 's) request, ('b, 's) request_status) list_map"
-  canisters :: "('canid, ('p, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's) can_state) list_map"
+  canisters :: "('canid, ('p, 'canid, 'b, 'w, 'sm, 'c, 's) can_state) list_map"
   controllers :: "('canid,  'p set) list_map"
   freezing_threshold :: "('canid,  nat) list_map"
   canister_status :: "('canid,  ('b, 'p, 'uid, 'canid, 's, 'c, 'cid) can_status) list_map"
@@ -270,20 +389,163 @@ record ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic =
   messages :: "('b, 'p, 'uid, 'canid, 's, 'c, 'cid) message list"
   root_key :: 'pk
 
+fun simple_status :: "('b, 'p, 'uid, 'canid, 's, 'c, 'cid) can_status \<Rightarrow> status" where
+  "simple_status can_status.Running = status.Running"
+| "simple_status (can_status.Stopping _) = status.Stopping"
+| "simple_status can_status.Stopped = status.Stopped"
+
+(* Initial state *)
+
+definition initial_ic :: "nat \<Rightarrow> 'pk \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "initial_ic t pk = \<lparr>requests = list_map_empty,
+    canisters = list_map_empty,
+    controllers = list_map_empty,
+    freezing_threshold = list_map_empty,
+    canister_status = list_map_empty,
+    time = list_map_empty,
+    balances = list_map_empty,
+    certified_data = list_map_empty,
+    system_time = t,
+    call_contexts = list_map_empty,
+    messages = [],
+    root_key = pk\<rparr>"
+
+(* Invariants *)
+
+definition ic_can_status_inv :: "('b, 'p, 'uid, 'canid, 's, 'c, 'cid) can_status set \<Rightarrow> 'cid set \<Rightarrow> bool" where
+  "ic_can_status_inv st c = (\<forall>can_status \<in> st.
+    case can_status of Stopping os \<Rightarrow> \<forall>(orig, cycles) \<in> set os. (case orig of
+      From_canister ctxt_id _ \<Rightarrow> ctxt_id \<in> c
+      | _ \<Rightarrow> True)
+    | _ \<Rightarrow> True)"
+
+lemma ic_can_status_inv_mono1: "ic_can_status_inv x y \<Longrightarrow>
+  z \<subseteq> x \<union> {can_status.Running, can_status.Stopped} \<Longrightarrow>
+  ic_can_status_inv z y"
+  by (fastforce simp: ic_can_status_inv_def split: can_status.splits call_origin.splits)
+
+lemma ic_can_status_inv_mono2: "ic_can_status_inv x y \<Longrightarrow>
+  y \<subseteq> z \<Longrightarrow>
+  ic_can_status_inv x z"
+  by (force simp: ic_can_status_inv_def split: can_status.splits call_origin.splits)
+
+lemma ic_can_status_inv_stopping: "ic_can_status_inv x y \<Longrightarrow>
+  (\<And>ctxt_id c. os = From_canister ctxt_id c \<Longrightarrow> ctxt_id \<in> y) \<Longrightarrow>
+  z \<subseteq> x \<union> {can_status.Stopping [(os, cyc)]} \<Longrightarrow>
+  ic_can_status_inv z y"
+  by (fastforce simp: ic_can_status_inv_def split: can_status.splits call_origin.splits)
+
+lemma ic_can_status_inv_stopping_app: "ic_can_status_inv x y \<Longrightarrow>
+  can_status.Stopping w \<in> x \<Longrightarrow>
+  (\<And>ctxt_id c. os = From_canister ctxt_id c \<Longrightarrow> ctxt_id \<in> y) \<Longrightarrow>
+  z \<subseteq> x \<union> {can_status.Stopping (w @ [(os, cyc)])} \<Longrightarrow>
+  ic_can_status_inv z y"
+  by (force simp: ic_can_status_inv_def split: can_status.splits call_origin.splits dest!: subsetD[where ?A=z])
+
+lemma ic_can_status_inv_del: "ic_can_status_inv x z \<Longrightarrow>
+  (\<And>os other_ctxt_id c cyc. Stopping os \<in> x \<Longrightarrow> (From_canister other_ctxt_id c, cyc) \<in> set os \<Longrightarrow> ctxt_id \<noteq> other_ctxt_id) \<Longrightarrow>
+  ic_can_status_inv x (z - {ctxt_id})"
+  by (fastforce simp: ic_can_status_inv_def split: can_status.splits call_origin.splits)
+
+definition ic_inv :: "('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  "ic_inv S = ((\<forall>msg \<in> set (messages S). case msg of
+    Call_message (From_canister ctxt_id _) _ _ _ _ _ _ \<Rightarrow> ctxt_id \<in> list_map_dom (call_contexts S)
+  | Response_message (From_canister ctxt_id _) _ _ \<Rightarrow> ctxt_id \<in> list_map_dom (call_contexts S)
+  | _ \<Rightarrow> True) \<and>
+  (\<forall>ctxt \<in> list_map_range (call_contexts S). call_ctxt_needs_to_respond ctxt \<longrightarrow>
+    (case call_ctxt_origin ctxt of From_canister ctxt_id _ \<Rightarrow> ctxt_id \<in> list_map_dom (call_contexts S)
+    | _ \<Rightarrow> True)) \<and>
+  ic_can_status_inv (list_map_range (canister_status S)) (list_map_dom (call_contexts S)))"
+
+lemma ic_initial_inv: "ic_inv (initial_ic t pk)"
+  by (auto simp: ic_inv_def ic_can_status_inv_def initial_ic_def split: call_origin.splits)
+
+(* Candid *)
+
+datatype ('s, 'b, 'p) candid =
+    Candid_nat nat
+  | Candid_text 's
+  | Candid_blob (candid_unwrap_blob: 'b)
+  | Candid_opt "('s, 'b, 'p) candid"
+  | Candid_vec "('s, 'b, 'p) candid list"
+  | Candid_record "('s, ('s, 'b, 'p) candid) list_map"
+  | Candid_null
+  | Candid_empty
+
+fun candid_is_blob :: "('s, 'b, 'p) candid \<Rightarrow> bool" where
+  "candid_is_blob (Candid_blob b) = True"
+| "candid_is_blob _ = False"
+
+fun candid_lookup :: "('s, 'b, 'p) candid \<Rightarrow> 's \<Rightarrow> ('s, 'b, 'p) candid option" where
+  "candid_lookup (Candid_record m) s = list_map_get m s"
+| "candid_lookup _ _ = None"
+
 (* State transitions *)
 
 context fixes
   CANISTER_ERROR :: reject_code
+  and CANISTER_REJECT :: reject_code
   and SYS_FATAL :: reject_code
   and SYS_TRANSIENT :: reject_code
   and MAX_CYCLES_PER_MESSAGE :: nat
   and MAX_CYCLES_PER_RESPONSE :: nat
   and MAX_CANISTER_BALANCE :: nat
-  and ic_freezing_limit :: "('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> 'canid \<Rightarrow> nat"
+  and ic_idle_cycles_burned_rate :: "('p :: linorder, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> 'canid \<Rightarrow> nat"
+  and blob_length :: "'b \<Rightarrow> nat"
+  and sha_256 :: "'b \<Rightarrow> 'b"
+  and ic_principal :: 'canid
+  and blob_of_candid :: "('s, 'b, 'p) candid \<Rightarrow> 'b"
+  and parse_candid :: "'b \<Rightarrow> ('s, 'b, 'p) candid option"
+  and parse_principal :: "'b \<Rightarrow> 'p option"
+  and blob_of_principal :: "'p \<Rightarrow> 'b"
+  and empty_blob :: 'b
+  and is_system_assigned :: "'p \<Rightarrow> bool"
   and encode_string :: "string \<Rightarrow> 's"
   and principal_of_uid :: "'uid \<Rightarrow> 'p"
   and principal_of_canid :: "'canid \<Rightarrow> 'p"
+  and canid_of_principal :: "'p \<Rightarrow> 'canid option"
+  and parse_wasm_mod :: "'b \<Rightarrow> ('p, 'canid, 'b, 'w, 'sm, 'c, 's) canister_module option"
+  and parse_public_custom_sections :: "'b \<Rightarrow> ('s, 'b) list_map option"
+  and parse_private_custom_sections :: "'b \<Rightarrow> ('s, 'b) list_map option"
+  and verify_envelope :: "('b, 'p, 'uid, 'canid, 's, 'pk, 'sig) envelope \<Rightarrow> 'p \<Rightarrow> nat \<Rightarrow> 'p set" (* TODO *)
+  and principal_list_of_set :: "'p set \<Rightarrow> 'p list"
 begin
+
+(* Type conversion functions *)
+
+definition canid_of_blob :: "'b \<Rightarrow> 'canid option" where
+  "canid_of_blob b = (case parse_principal b of Some p \<Rightarrow> canid_of_principal p | _ \<Rightarrow> None)"
+
+definition blob_of_canid :: "'canid \<Rightarrow> 'b" where
+  "blob_of_canid = blob_of_principal \<circ> principal_of_canid"
+
+(* Candid helper functions *)
+
+definition candid_nested_lookup :: "'b \<Rightarrow> 's list \<Rightarrow> ('s, 'b, 'p) candid option" where
+  "candid_nested_lookup b = foldl (\<lambda>c s. case c of Some c' \<Rightarrow> candid_lookup c' s | _ \<Rightarrow> None) (parse_candid b)"
+
+definition candid_parse_nat :: "'b \<Rightarrow> 's list \<Rightarrow> nat option" where
+  "candid_parse_nat b s = (case candid_nested_lookup b s of Some (Candid_nat n') \<Rightarrow> Some n' | _ \<Rightarrow> None)"
+
+definition candid_parse_text :: "'b \<Rightarrow> 's list \<Rightarrow> 's option" where
+  "candid_parse_text b s = (case candid_nested_lookup b s of Some (Candid_text t') \<Rightarrow> Some t' | _ \<Rightarrow> None)"
+
+definition candid_parse_blob :: "'b \<Rightarrow> 's list \<Rightarrow> 'b option" where
+  "candid_parse_blob b s = (case candid_nested_lookup b s of Some (Candid_blob b') \<Rightarrow> Some b' | _ \<Rightarrow> None)"
+
+definition candid_parse_cid :: "'b \<Rightarrow> 'canid option" where
+  "candid_parse_cid b = (case candid_parse_blob b [encode_string ''canister_id''] of Some b' \<Rightarrow> canid_of_blob b' | _ \<Rightarrow> None)"
+
+definition candid_parse_controllers :: "'b \<Rightarrow> 'p set option" where
+  "candid_parse_controllers b = (case candid_nested_lookup b [encode_string ''settings'', encode_string ''controllers''] of Some (Candid_vec xs) \<Rightarrow>
+    if (\<forall>c'' \<in> set xs. candid_is_blob c'' \<and> parse_principal (candid_unwrap_blob c'') \<noteq> None) then
+      Some (the ` parse_principal ` candid_unwrap_blob ` set xs)
+    else None | _ \<Rightarrow> None)"
+
+fun candid_of_status :: "status \<Rightarrow> ('s, 'b, 'p) candid" where
+  "candid_of_status status.Running = Candid_text (encode_string ''Running'')"
+| "candid_of_status status.Stopping = Candid_text (encode_string ''Stopping'')"
+| "candid_of_status status.Stopped = Candid_text (encode_string ''Stopped'')"
 
 (* Cycles *)
 
@@ -301,6 +563,10 @@ fun message_cycles :: "('b, 'p, 'uid, 'canid, 's, 'c, 'cid) message \<Rightarrow
 | "message_cycles (Func_message _ _ ep _) = cycles_reserved ep"
 | "message_cycles (Response_message orig _ ref_cycles) = carried_cycles orig + ref_cycles"
 
+fun status_cycles :: "('b, 'p, 'uid, 'canid, 's, 'c, 'cid) can_status \<Rightarrow> nat" where
+  "status_cycles (Stopping os) = sum_list (map (carried_cycles \<circ> fst) os) + sum_list (map snd os)"
+| "status_cycles _ = 0"
+
 lift_definition call_ctxt_carried_cycles :: "('p, 'uid, 'canid, 'b, 's, 'c, 'cid) call_ctxt \<Rightarrow> nat" is
   "\<lambda>ctxt. (if needs_to_respond ctxt
     then available_cycles ctxt + carried_cycles (origin ctxt)
@@ -313,12 +579,16 @@ lemma call_ctxt_carried_cycles: "call_ctxt_carried_cycles ctxt = (if call_ctxt_n
   then call_ctxt_available_cycles ctxt + carried_cycles (call_ctxt_origin ctxt) else 0)"
   by transfer auto
 
-definition total_cycles :: "('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> nat" where
+lemma call_ctxt_delete_carried_cycles[simp]: "call_ctxt_carried_cycles (call_ctxt_delete ctxt) = 0"
+  by transfer auto
+
+definition total_cycles :: "('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> nat" where
   "total_cycles ic = (
     let cycles_in_balances = list_map_sum_vals id (balances ic) in
     let cycles_in_messages = sum_list (map message_cycles (messages ic)) in
     let cycles_in_contexts = list_map_sum_vals call_ctxt_carried_cycles (call_contexts ic) in
-    cycles_in_balances + cycles_in_messages + cycles_in_contexts)"
+    let cycles_in_statuses = list_map_sum_vals status_cycles (canister_status ic) in
+    cycles_in_balances + cycles_in_messages + cycles_in_contexts + cycles_in_statuses)"
 
 (* Accessor functions *)
 
@@ -331,91 +601,199 @@ fun message_queue :: "('b, 'p, 'uid, 'canid, 's, 'c, 'cid) message \<Rightarrow>
 | "message_queue (Func_message _ _ _ q) = Some q"
 | "message_queue _ = None"
 
-(* Type conversion functions *)
+(* Effective canister IDs *)
 
-fun simple_status :: "('b, 'p, 'uid, 'canid, 's, 'c, 'cid) can_status \<Rightarrow> status" where
-  "simple_status can_status.Running = status.Running"
-| "simple_status (can_status.Stopping _) = status.Stopping"
-| "simple_status can_status.Stopped = status.Stopped"
+definition is_effective_canister_id :: "('b, 'p, 'uid, 'canid, 's) request \<Rightarrow> 'p \<Rightarrow> bool" where
+  "is_effective_canister_id r p = (if request.canister_id r = ic_principal then
+      (case candid_parse_cid (request.arg r) of Some cid \<Rightarrow> principal_of_canid cid = p
+      | _ \<Rightarrow> request.method_name r = encode_string ''provisional_create_canister_with_cycles'')
+    else principal_of_canid (request.canister_id r) = p)"
+
+lemma is_effective_canister_id_code[code_unfold]:
+  "(\<exists>p. is_effective_canister_id r p) = (if request.canister_id r = ic_principal then
+      (case candid_parse_cid (request.arg r) of Some cid \<Rightarrow> True
+      | _ \<Rightarrow> request.method_name r = encode_string ''provisional_create_canister_with_cycles'')
+    else True)"
+  by (auto simp: is_effective_canister_id_def split: option.splits)
 
 
 
 (* System transition: API Request submission [DONE] *)
 
-definition request_submission_pre :: "('b, 'p, 'uid, 'canid, 's, 'pk, 'sig, 'sd) envelope \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
-  "request_submission_pre E S = (case content E of Inl req \<Rightarrow> req \<notin> list_map_dom (requests S) | _ \<Rightarrow> False)"
+definition ic_freezing_limit :: "('p :: linorder, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> 'canid \<Rightarrow> nat" where
+  "ic_freezing_limit S cid = ic_idle_cycles_burned_rate S cid * (the (list_map_get (freezing_threshold S) cid)) div (24 * 60 * 60)"
 
-definition request_submission_post :: "('b, 'p, 'uid, 'canid, 's, 'pk, 'sig, 'sd) envelope \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
-  "request_submission_post E S = S\<lparr>requests := list_map_set (requests S) (projl (content E)) Received\<rparr>"
+definition request_submission_pre :: "('b, 'p, 'uid, 'canid, 's, 'pk, 'sig) envelope \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  "request_submission_pre E S = (case content E of Inl req \<Rightarrow>
+    principal_of_canid (request.canister_id req) \<in> verify_envelope E (principal_of_uid (request.sender req)) (system_time S) \<and>
+    req \<notin> list_map_dom (requests S) \<and>
+    system_time S \<le> request.ingress_expiry req \<and>
+    (\<exists>ECID. is_effective_canister_id req ECID) \<and>
+    (
+      (
+        request.canister_id req = ic_principal \<and>
+        (case candid_parse_cid (request.arg req) of Some cid \<Rightarrow>
+          (case list_map_get (controllers S) cid of Some ctrls \<Rightarrow>
+            principal_of_uid (request.sender req) \<in> ctrls \<and>
+            request.method_name req \<in> {encode_string ''install_code'', encode_string ''uninstall_code'', encode_string ''update_settings'',
+              encode_string ''start_canister'', encode_string ''stop_canister'',
+              encode_string ''canister_status'', encode_string ''delete_canister'',
+              encode_string ''provisional_create_canister_with_cycles'', encode_string ''provisional_top_up_canister''}
+          | _ \<Rightarrow> False)
+        | _ \<Rightarrow> False)
+      )
+    \<or>
+      (
+        request.canister_id req \<noteq> ic_principal \<and>
+        (case (list_map_get (canisters S) (request.canister_id req), list_map_get (time S) (request.canister_id req), list_map_get (balances S) (request.canister_id req), list_map_get (canister_status S) (request.canister_id req)) of
+          (Some (Some can), Some t, Some bal, Some can_status) \<Rightarrow>
+          let env = \<lparr>env.time = t, balance = bal, freezing_limit = ic_freezing_limit S (request.canister_id req), certificate = None, status = simple_status can_status\<rparr> in
+          (case canister_module_inspect_message (module can) (request.method_name req, wasm_state can, request.arg req, principal_of_uid (request.sender req), env) of Inr ret \<Rightarrow>
+            cycles_return.return ret = Accept \<and> cycles_return.cycles_used ret \<le> bal
+          | _ \<Rightarrow> False)
+        | _ \<Rightarrow> False)
+      )
+    )
+  | _ \<Rightarrow> False)"
+
+definition request_submission_post :: "('b, 'p, 'uid, 'canid, 's, 'pk, 'sig) envelope \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "request_submission_post E S = (
+    let req = projl (content E);
+    cid = request.canister_id req;
+    balances = (if cid \<noteq> ic_principal then
+      (case (list_map_get (canisters S) cid, list_map_get (time S) cid, list_map_get (balances S) cid, list_map_get (canister_status S) cid) of
+        (Some (Some can), Some t, Some bal, Some can_status) \<Rightarrow>
+        let env = \<lparr>env.time = t, balance = bal, freezing_limit = ic_freezing_limit S cid, certificate = None, status = simple_status can_status\<rparr> in
+        (case canister_module_inspect_message (module can) (request.method_name req, wasm_state can, request.arg req, principal_of_uid (request.sender req), env) of Inr ret \<Rightarrow>
+          list_map_set (balances S) cid (bal - cycles_return.cycles_used ret)))
+      else balances S) in
+    S\<lparr>requests := list_map_set (requests S) req Received, balances := balances\<rparr>)"
+
+definition request_submission_burned_cycles :: "('b, 'p, 'uid, 'canid, 's, 'pk, 'sig) envelope \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> nat" where
+  "request_submission_burned_cycles E S = (
+    let req = projl (content E);
+    cid = request.canister_id req in
+    (if request.canister_id req \<noteq> ic_principal then
+      (case (list_map_get (canisters S) (request.canister_id req), list_map_get (time S) (request.canister_id req), list_map_get (balances S) (request.canister_id req), list_map_get (canister_status S) (request.canister_id req)) of
+        (Some (Some can), Some t, Some bal, Some can_status) \<Rightarrow>
+        let env = \<lparr>env.time = t, balance = bal, freezing_limit = ic_freezing_limit S (request.canister_id req), certificate = None, status = simple_status can_status\<rparr> in
+        (case canister_module_inspect_message (module can) (request.method_name req, wasm_state can, request.arg req, principal_of_uid (request.sender req), env) of Inr ret \<Rightarrow>
+          cycles_return.cycles_used ret))
+      else 0))"
 
 lemma request_submission_cycles_inv:
-  "request_submission_pre E S \<Longrightarrow> total_cycles S = total_cycles (request_submission_post E S)"
-  by (auto simp: request_submission_pre_def request_submission_post_def total_cycles_def)
+  assumes "request_submission_pre E S"
+  shows "total_cycles S = total_cycles (request_submission_post E S) + request_submission_burned_cycles E S"
+proof -
+  obtain req where req_def: "content E = Inl req"
+    using assms
+    by (auto simp: request_submission_pre_def split: sum.splits)
+  {
+    assume "request.canister_id req \<noteq> ic_principal"
+    then have "(case (list_map_get (canisters S) (request.canister_id req), list_map_get (time S) (request.canister_id req), list_map_get (balances S) (request.canister_id req), list_map_get (canister_status S) (request.canister_id req)) of
+      (Some (Some can), Some t, Some bal, Some can_status) \<Rightarrow>
+      let env = \<lparr>env.time = t, balance = bal, freezing_limit = ic_freezing_limit S (request.canister_id req), certificate = None, status = simple_status can_status\<rparr> in
+      (case canister_module_inspect_message (module can) (request.method_name req, wasm_state can, request.arg req, principal_of_uid (request.sender req), env) of Inr ret \<Rightarrow>
+        cycles_return.return ret = Accept \<and> cycles_return.cycles_used ret \<le> bal
+      | _ \<Rightarrow> False)
+    | _ \<Rightarrow> False)"
+      using assms
+      by (auto simp: request_submission_pre_def req_def split: option.splits sum.splits prod.splits)
+    then have ?thesis
+      using list_map_sum_in_ge[where ?f="balances S" and ?g=id and ?x="request.canister_id req"]
+      by (auto simp: request_submission_pre_def request_submission_post_def request_submission_burned_cycles_def total_cycles_def req_def list_map_sum_in[where ?f="balances S"]
+          split: option.splits sum.splits)
+  }
+  then show ?thesis
+    by (auto simp: request_submission_pre_def request_submission_post_def request_submission_burned_cycles_def total_cycles_def req_def)
+qed
+
+lemma request_submission_ic_inv:
+  assumes "request_submission_pre E S" "ic_inv S"
+  shows "ic_inv (request_submission_post E S)"
+  using assms
+  by (auto simp: ic_inv_def request_submission_pre_def request_submission_post_def Let_def
+      split: sum.splits message.splits call_origin.splits)
 
 
 
 (* System transition: Request rejection [DONE] *)
 
-definition request_rejection_pre :: "('b, 'p, 'uid, 'canid, 's, 'pk, 'sig, 'sd) envelope \<Rightarrow> ('b, 'p, 'uid, 'canid, 's) request \<Rightarrow> reject_code \<Rightarrow> 's \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+definition request_rejection_pre :: "('b, 'p, 'uid, 'canid, 's, 'pk, 'sig) envelope \<Rightarrow> ('b, 'p, 'uid, 'canid, 's) request \<Rightarrow> reject_code \<Rightarrow> 's \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
   "request_rejection_pre E req code msg S = (list_map_get (requests S) req = Some Received \<and> (code = SYS_FATAL \<or> code = SYS_TRANSIENT))"
 
-definition request_rejection_post :: "('b, 'p, 'uid, 'canid, 's, 'pk, 'sig, 'sd) envelope \<Rightarrow> ('b, 'p, 'uid, 'canid, 's) request \<Rightarrow> reject_code \<Rightarrow> 's \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+definition request_rejection_post :: "('b, 'p, 'uid, 'canid, 's, 'pk, 'sig) envelope \<Rightarrow> ('b, 'p, 'uid, 'canid, 's) request \<Rightarrow> reject_code \<Rightarrow> 's \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
   "request_rejection_post E req code msg S = S\<lparr>requests := list_map_set (requests S) req (Rejected code msg)\<rparr>"
 
 lemma request_rejection_cycles_inv:
-  "request_rejection_pre E req code msg S \<Longrightarrow> total_cycles S = total_cycles (request_rejection_post E req code msg S)"
+  assumes "request_rejection_pre E req code msg S"
+  shows "total_cycles S = total_cycles (request_rejection_post E req code msg S)"
   by (auto simp: request_rejection_pre_def request_rejection_post_def total_cycles_def)
+
+lemma request_rejection_ic_inv:
+  assumes "request_rejection_pre E req code msg S" "ic_inv S"
+  shows "ic_inv (request_rejection_post E req code msg S)"
+  using assms
+  by (auto simp: ic_inv_def request_rejection_pre_def request_rejection_post_def Let_def
+      split: sum.splits message.splits call_origin.splits)
 
 
 
 (* System transition: Initiating canister calls [DONE] *)
 
 definition initiate_canister_call_pre :: "('b, 'p, 'uid, 'canid, 's) request \<Rightarrow>
-  ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
   "initiate_canister_call_pre req S = (list_map_get (requests S) req = Some Received \<and>
     system_time S \<le> request.ingress_expiry req \<and>
     request.canister_id req \<in> list_map_dom (canisters S))"
 
 definition initiate_canister_call_post :: "('b, 'p, 'uid, 'canid, 's) request \<Rightarrow>
-  ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow>
-  ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow>
+  ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
   "initiate_canister_call_post req S =
     S\<lparr>requests := list_map_set (requests S) req Processing, messages :=
       Call_message (From_user req) (principal_of_uid (request.sender req)) (request.canister_id req) (request.method_name req)
       (request.arg req) 0 Unordered # messages S\<rparr>"
 
 lemma initiate_canister_call_cycles_inv:
-  "initiate_canister_call_pre R S \<Longrightarrow>
-  total_cycles S = total_cycles (initiate_canister_call_post R S)"
+  assumes "initiate_canister_call_pre R S"
+  shows "total_cycles S = total_cycles (initiate_canister_call_post R S)"
   by (auto simp: initiate_canister_call_pre_def initiate_canister_call_post_def total_cycles_def)
+
+lemma initiate_canister_call_ic_inv:
+  assumes "initiate_canister_call_pre R S" "ic_inv S"
+  shows "ic_inv (initiate_canister_call_post R S)"
+  using assms
+  by (auto simp: ic_inv_def initiate_canister_call_pre_def initiate_canister_call_post_def Let_def
+      split: sum.splits message.splits call_origin.splits)
 
 
 
 (* System transition: Calls to stopped/stopping/frozen canisters are rejected [DONE] *)
 
-definition call_reject_pre :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+definition call_reject_pre :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
   "call_reject_pre n S = (n < length (messages S) \<and> (case messages S ! n of
-    Call_message orig cer cee mn d trans_cycles q \<Rightarrow>
+    Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
       (q = Unordered \<or> (\<forall>j < n. message_queue (messages S ! j) \<noteq> Some q)) \<and>
       (case list_map_get (canister_status S) cee of Some Stopped \<Rightarrow> True
       | Some (Stopping l) \<Rightarrow> True
       | _ \<Rightarrow> (case list_map_get (balances S) cee of Some bal \<Rightarrow> bal < ic_freezing_limit S cee | _ \<Rightarrow> False))
     | _ \<Rightarrow> False))"
 
-definition call_reject_post :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
-  "call_reject_post n S = (case messages S ! n of Call_message orig cer cee mn d trans_cycles q \<Rightarrow>
+definition call_reject_post :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "call_reject_post n S = (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
     S\<lparr>messages := take n (messages S) @ drop (Suc n) (messages S) @ [Response_message orig (response.Reject CANISTER_ERROR (encode_string ''canister not running'')) trans_cycles]\<rparr>)"
 
 lemma call_reject_cycles_inv:
   assumes "call_reject_pre n S"
   shows "total_cycles S = total_cycles (call_reject_post n S)"
 proof -
-  obtain orig cer cee mn d trans_cycles q where msg: "messages S ! n = Call_message orig cer cee mn d trans_cycles q"
+  obtain orig cer cee mn a trans_cycles q where msg: "messages S ! n = Call_message orig cer cee mn a trans_cycles q"
     using assms
     by (auto simp: call_reject_pre_def split: message.splits)
   define older where "older = take n (messages S)"
   define younger where "younger = drop (Suc n) (messages S)"
-  have msgs: "messages S = older @ Call_message orig cer cee mn d trans_cycles q # younger" "(older @ w # younger) ! n = w"
+  have msgs: "messages S = older @ Call_message orig cer cee mn a trans_cycles q # younger" "(older @ w # younger) ! n = w"
     "take n older = older" "take (n - length older) ws = []" "drop (Suc n) older = []"
     "drop (Suc n - length older) (w # ws) = ws" for w ws
     using id_take_nth_drop[of n "messages S"] assms
@@ -425,14 +803,22 @@ proof -
     by (auto simp: call_reject_pre_def call_reject_post_def total_cycles_def Let_def msgs split: message.splits option.splits)
 qed
 
+lemma call_reject_ic_inv:
+  assumes "call_reject_pre n S" "ic_inv S"
+  shows "ic_inv (call_reject_post n S)"
+  using assms
+  by (auto simp: ic_inv_def call_reject_pre_def call_reject_post_def Let_def
+      split: sum.splits message.splits call_origin.splits
+      dest!: in_set_takeD in_set_dropD nth_mem[of n "messages S"])
+
 
 
 (* System transition: Call context creation: Public entry points [DONE] *)
 
 definition call_context_create_pre :: "nat \<Rightarrow> 'cid
-  \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
   "call_context_create_pre n ctxt_id S = (n < length (messages S) \<and> (case messages S ! n of
-    Call_message orig cer cee mn d trans_cycles q \<Rightarrow>
+    Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
       (case list_map_get (canisters S) cee of Some (Some can) \<Rightarrow> True | _ \<Rightarrow> False) \<and>
       list_map_get (canister_status S) cee = Some Running \<and>
       (case list_map_get (balances S) cee of Some bal \<Rightarrow> bal \<ge> ic_freezing_limit S cee + MAX_CYCLES_PER_MESSAGE | None \<Rightarrow> False) \<and>
@@ -444,13 +830,16 @@ lift_definition create_call_ctxt :: "'canid \<Rightarrow> ('b, 'p, 'uid, 'canid,
   "\<lambda>cee orig trans_cycles. \<lparr>canister = cee, origin = orig, needs_to_respond = True, deleted = False, available_cycles = trans_cycles\<rparr>"
   by auto
 
+lemma create_call_ctxt_origin[simp]: "call_ctxt_origin (create_call_ctxt cee orig trans_cycles) = orig"
+  by transfer auto
+
 lemma create_call_ctxt_carried_cycles[simp]: "call_ctxt_carried_cycles (create_call_ctxt cee orig trans_cycles) = carried_cycles orig + trans_cycles"
   by transfer auto
 
-definition call_context_create_post :: "nat \<Rightarrow> 'cid \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
-  "call_context_create_post n ctxt_id S = (case messages S ! n of Call_message orig cer cee mn d trans_cycles q \<Rightarrow>
+definition call_context_create_post :: "nat \<Rightarrow> 'cid \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "call_context_create_post n ctxt_id S = (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
     case list_map_get (balances S) cee of Some bal \<Rightarrow>
-    S\<lparr>messages := list_update (messages S) n (Func_message ctxt_id cee (Public_method mn cer d) q),
+    S\<lparr>messages := list_update (messages S) n (Func_message ctxt_id cee (Public_method mn cer a) q),
       call_contexts := list_map_set (call_contexts S) ctxt_id (create_call_ctxt cee orig trans_cycles),
       balances := list_map_set (balances S) cee (bal - MAX_CYCLES_PER_MESSAGE)\<rparr>)"
 
@@ -458,26 +847,35 @@ lemma call_context_create_cycles_inv:
   assumes "call_context_create_pre n ctxt_id S"
   shows "total_cycles S = total_cycles (call_context_create_post n ctxt_id S)"
 proof -
-  obtain orig cer cee mn d trans_cycles q where msg: "messages S ! n = Call_message orig cer cee mn d trans_cycles q"
+  obtain orig cer cee mn a trans_cycles q where msg: "messages S ! n = Call_message orig cer cee mn a trans_cycles q"
     using assms
     by (auto simp: call_context_create_pre_def split: message.splits)
-  define xs where "xs = take n (messages S)"
-  define older where "older = drop (Suc n) (messages S)"
-  have msgs: "messages S = xs @ Call_message orig cer cee mn d trans_cycles q # older" "(xs @ m # older) ! n = m"
-    and msgs_upd: "(xs @ Call_message orig cer cee mn d trans_cycles q # older)[n := m] = xs @ m # older" for m
+  define older where "older = take n (messages S)"
+  define younger where "younger = drop (Suc n) (messages S)"
+  have msgs: "messages S = older @ Call_message orig cer cee mn a trans_cycles q # younger" "(older @ m # younger) ! n = m"
+    and msgs_upd: "(older @ Call_message orig cer cee mn a trans_cycles q # younger)[n := m] = older @ m # younger" for m
     using id_take_nth_drop[of n "messages S"] upd_conv_take_nth_drop[of n "messages S"] assms
-    by (auto simp: call_context_create_pre_def msg xs_def older_def nth_append)
+    by (auto simp: call_context_create_pre_def msg older_def younger_def nth_append)
   show ?thesis
     using assms list_map_sum_in_ge[of "balances S" cee, where ?g=id]
     by (auto simp: call_context_create_pre_def call_context_create_post_def total_cycles_def
         list_map_sum_in[where ?g=id, simplified] list_map_sum_out msgs msgs_upd split: option.splits)
 qed
 
+lemma call_context_create_ic_inv:
+  assumes "call_context_create_pre n ctxt_id S" "ic_inv S"
+  shows "ic_inv (call_context_create_post n ctxt_id S)"
+  using assms
+  by (auto simp: ic_inv_def call_context_create_pre_def call_context_create_post_def Let_def
+      split: sum.splits message.splits call_origin.splits option.splits
+      dest!: in_set_takeD in_set_dropD nth_mem[of n "messages S"] in_set_updD list_map_range_setD
+      intro: ic_can_status_inv_mono2)
+
 
 
 (* System transition: Call context creation: Heartbeat [DONE] *)
 
-definition call_context_heartbeat_pre :: "'canid \<Rightarrow> 'cid \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+definition call_context_heartbeat_pre :: "'canid \<Rightarrow> 'cid \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
   "call_context_heartbeat_pre cee ctxt_id S = (
     (case list_map_get (canisters S) cee of Some (Some can) \<Rightarrow> True | _ \<Rightarrow> False) \<and>
     list_map_get (canister_status S) cee = Some Running \<and>
@@ -488,10 +886,13 @@ lift_definition create_call_ctxt_heartbeat :: "'canid \<Rightarrow> ('p, 'uid, '
   "\<lambda>cee. \<lparr>canister = cee, origin = From_heartbeat, needs_to_respond = False, deleted = False, available_cycles = 0\<rparr>"
   by auto
 
+lemma create_call_ctxt_heartbeat_needs_to_respond[simp]: "call_ctxt_needs_to_respond (create_call_ctxt_heartbeat cee) = False"
+  by transfer auto
+
 lemma create_call_ctxt_heartbeat_carried_cycles[simp]: "call_ctxt_carried_cycles (create_call_ctxt_heartbeat cee) = 0"
   by transfer auto
 
-definition call_context_heartbeat_post :: "'canid \<Rightarrow> 'cid \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+definition call_context_heartbeat_post :: "'canid \<Rightarrow> 'cid \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
   "call_context_heartbeat_post cee ctxt_id S =
   (case list_map_get (balances S) cee of Some bal \<Rightarrow>
     S\<lparr>messages := Func_message ctxt_id cee Heartbeat (Queue System cee) # messages S,
@@ -499,36 +900,47 @@ definition call_context_heartbeat_post :: "'canid \<Rightarrow> 'cid \<Rightarro
     balances := list_map_set (balances S) cee (bal - MAX_CYCLES_PER_MESSAGE)\<rparr>)"
 
 lemma call_context_heartbeat_cycles_inv:
-  "call_context_heartbeat_pre cee ctxt_id S \<Longrightarrow>
-    total_cycles S = total_cycles (call_context_heartbeat_post cee ctxt_id S)"
-  using list_map_sum_in_ge[of "balances S" cee, where ?g=id, simplified]
+  assumes "call_context_heartbeat_pre cee ctxt_id S"
+  shows "total_cycles S = total_cycles (call_context_heartbeat_post cee ctxt_id S)"
+  using assms list_map_sum_in_ge[of "balances S" cee, where ?g=id, simplified]
   by (auto simp: call_context_heartbeat_pre_def call_context_heartbeat_post_def total_cycles_def
       list_map_sum_in[where ?g=id, simplified] list_map_sum_out split: option.splits)
+
+lemma call_context_heartbeat_ic_inv:
+  assumes "call_context_heartbeat_pre cee ctxt_id S" "ic_inv S"
+  shows "ic_inv (call_context_heartbeat_post cee ctxt_id S)"
+  using assms
+  by (auto simp: ic_inv_def call_context_heartbeat_pre_def call_context_heartbeat_post_def Let_def
+      split: sum.splits message.splits call_origin.splits option.splits
+      dest!: in_set_takeD in_set_dropD in_set_updD list_map_range_setD
+      intro: ic_can_status_inv_mono2)
 
 
 
 (* System transition: Message execution [DONE] *)
 
-fun query_as_update :: "(('b arg \<times> 'p \<times> 'b env) \<Rightarrow> ('w, 'b, 's, 'tr) query_func) \<times> 'b arg \<times> 'p \<times> 'b env \<Rightarrow> ('w, 'p, 'canid, 's, 'b, 'c, 'tr) update_func" where
+fun query_as_update :: "(('b arg \<times> 'p \<times> 'b env) \<Rightarrow> ('w, 'b, 's) query_func) \<times> 'b arg \<times> 'p \<times> 'b env \<Rightarrow> ('w, 'p, 'canid, 's, 'b, 'c) update_func" where
   "query_as_update (f, a, e) = (\<lambda>w. case f (a, e) w of Inl t \<Rightarrow> Inl t |
-    Inr res \<Rightarrow> Inr \<lparr>new_state = w, new_calls = [], new_certified_data = None, response = Some res, cycles_accepted = 0\<rparr>)"
+    Inr res \<Rightarrow> Inr \<lparr>update_return.new_state = w, update_return.new_calls = [], update_return.new_certified_data = None,
+      update_return.response = Some (query_return.response res), update_return.cycles_accepted = 0, update_return.cycles_used = query_return.cycles_used res\<rparr>)"
 
-fun heartbeat_as_update :: "('b env \<Rightarrow> 'w \<Rightarrow> 'tr + 'w) \<times> 'b env \<Rightarrow> ('w, 'p, 'canid, 's, 'b, 'c, 'tr) update_func" where
-  "heartbeat_as_update (f, e) w = (case f e w of Inl t \<Rightarrow> Inl t |
-    Inr w' \<Rightarrow> Inr \<lparr>update_return.new_state = w', update_return.new_calls = [], update_return.new_certified_data = None,
-      update_return.response = None, update_return.cycles_accepted = 0\<rparr>)"
+fun heartbeat_as_update :: "('b env \<Rightarrow> 'w heartbeat_func) \<times> 'b env \<Rightarrow> ('w, 'p, 'canid, 's, 'b, 'c) update_func" where
+  "heartbeat_as_update (f, e) = (\<lambda>w. case f e w of Inl t \<Rightarrow> Inl t |
+    Inr res \<Rightarrow> Inr \<lparr>update_return.new_state = heartbeat_return.new_state res, update_return.new_calls = [], update_return.new_certified_data = None,
+      update_return.response = None, update_return.cycles_accepted = 0, update_return.cycles_used = heartbeat_return.cycles_used res\<rparr>)"
 
-fun exec_function :: "('s, 'p, 'b, 'c) entry_point \<Rightarrow> 'b env \<Rightarrow> nat \<Rightarrow> ('p, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's) canister_module \<Rightarrow> ('w, 'p, 'canid, 's, 'b, 'c, 'tr) update_func" where
-  "exec_function (entry_point.Public_method mn c d) e bal m = (
-    case dispatch_method mn m of Some (Inl upd) \<Rightarrow> upd (d, c, e, bal)
-    | Some (Inr query) \<Rightarrow> query_as_update (query, d, c, e) | None \<Rightarrow>
-    undefined)"
-| "exec_function (entry_point.Callback cb resp ref_cycles) e bal m =
-    canister_module_callbacks m (cb, resp, ref_cycles, e, bal)"
+fun exec_function :: "('s, 'p, 'b, 'c) entry_point \<Rightarrow> 'b env \<Rightarrow> nat \<Rightarrow> ('p, 'canid, 'b, 'w, 'sm, 'c, 's) canister_module \<Rightarrow> ('w, 'p, 'canid, 's, 'b, 'c) update_func" where
+  "exec_function (entry_point.Public_method mn c a) e bal m = (
+    case dispatch_method mn m of Some (Inl upd) \<Rightarrow> upd (a, c, e, bal)
+    | Some (Inr query) \<Rightarrow> query_as_update (query, a, c, e)
+    | None \<Rightarrow> undefined
+  )"
+| "exec_function (entry_point.Callback c resp ref_cycles) e bal m =
+    canister_module_callbacks m (c, resp, ref_cycles, e, bal)"
 | "exec_function (entry_point.Heartbeat) e bal m = heartbeat_as_update ((canister_module_heartbeat m), e)"
 
-definition message_execution_pre :: "nat \<Rightarrow> nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
-  "message_execution_pre n cycles_used S =
+definition message_execution_pre :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  "message_execution_pre n S =
     (n < length (messages S) \<and> (case messages S ! n of Func_message ctxt_id recv ep q \<Rightarrow>
     (q = Unordered \<or> (\<forall>j < n. message_queue (messages S ! j) \<noteq> Some q)) \<and>
     (case (list_map_get (canisters S) recv, list_map_get (balances S) recv, list_map_get (canister_status S) recv,
@@ -536,53 +948,65 @@ definition message_execution_pre :: "nat \<Rightarrow> nat \<Rightarrow> ('p, 'u
       (Some (Some can), Some bal, Some can_status, Some t, Some ctxt) \<Rightarrow> True | _ \<Rightarrow> False)
     | _ \<Rightarrow> False))"
 
-definition message_execution_post :: "nat \<Rightarrow> nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
-  "message_execution_post n cycles_used S = (case messages S ! n of Func_message ctxt_id recv ep q \<Rightarrow>
+definition message_execution_post :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "message_execution_post n S = (case messages S ! n of Func_message ctxt_id recv ep q \<Rightarrow>
     (case (list_map_get (canisters S) recv, list_map_get (balances S) recv, list_map_get (canister_status S) recv,
       list_map_get (time S) recv, list_map_get (call_contexts S) ctxt_id) of
       (Some (Some can), Some bal, Some can_status, Some t, Some ctxt) \<Rightarrow> (
         let Mod = module can;
         Is_response = (case ep of Callback _ _ _ \<Rightarrow> True | _ \<Rightarrow> False);
-        Env = \<lparr>env_time = t, balance = bal, freezing_limit = ic_freezing_limit S recv, certificate = None, status = simple_status can_status\<rparr>;
+        Env = \<lparr>env.time = t, balance = bal, freezing_limit = ic_freezing_limit S recv, certificate = None, status = simple_status can_status\<rparr>;
         Available = call_ctxt_available_cycles ctxt;
         F = exec_function ep Env Available Mod;
         R = F (wasm_state can);
-        (cycles_accepted_res, new_calls_res) = (case R of Inr res \<Rightarrow> (cycles_accepted res, new_calls res));
+        cyc_used = (case R of Inr res \<Rightarrow> update_return.cycles_used res | Inl trap \<Rightarrow> cycles_return.cycles_used trap);
+        (cycles_accepted_res, new_calls_res) = (case R of Inr res \<Rightarrow> (update_return.cycles_accepted res, update_return.new_calls res));
         New_balance = bal + cycles_accepted_res + (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE)
-          - (cycles_used + sum_list (map (\<lambda>x. MAX_CYCLES_PER_RESPONSE + transferred_cycles x) new_calls_res));
+          - (cyc_used + sum_list (map (\<lambda>x. MAX_CYCLES_PER_RESPONSE + transferred_cycles x) new_calls_res));
         no_response = (case R of Inr result \<Rightarrow> update_return.response result = None) in
-        if \<not>isl R \<and> cycles_used \<le> (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE) \<and>
+        if \<not>isl R \<and> cyc_used \<le> (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE) \<and>
           cycles_accepted_res \<le> Available \<and>
-          cycles_used + sum_list (map (\<lambda>x. MAX_CYCLES_PER_RESPONSE + transferred_cycles x) new_calls_res) \<le>
+          cyc_used + sum_list (map (\<lambda>x. MAX_CYCLES_PER_RESPONSE + transferred_cycles x) new_calls_res) \<le>
             bal + cycles_accepted_res + (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE) \<and>
-          New_balance > (if Is_response then 0 else ic_freezing_limit S recv) \<and>
+          New_balance \<ge> (if Is_response then 0 else ic_freezing_limit S recv) \<and>
           (no_response \<or> call_ctxt_needs_to_respond ctxt) then
           (let result = projr R;
-            new_call_to_message = (\<lambda>call. Call_message (From_canister ctxt_id (callback call)) (principal_of_canid recv)
-              (callee call) (method_call.method_name call) (method_call.arg call) (transferred_cycles call) (Queue (Canister recv) (callee call)));
-            response_messages = (case response result of None \<Rightarrow> []
+            new_call_to_message = (\<lambda>call. Call_message (From_canister ctxt_id (method_call.callback call)) (principal_of_canid recv)
+              (method_call.callee call) (method_call.method_name call) (method_call.arg call) (method_call.transferred_cycles call) (Queue (Canister recv) (method_call.callee call)));
+            response_messages = (case update_return.response result of None \<Rightarrow> []
               | Some resp \<Rightarrow> [Response_message (call_ctxt_origin ctxt) resp (Available - cycles_accepted_res)]);
             messages = take n (messages S) @ drop (Suc n) (messages S) @ map new_call_to_message new_calls_res @ response_messages;
-            new_ctxt = (case response result of
+            new_ctxt = (case update_return.response result of
               None \<Rightarrow> call_ctxt_deduct_cycles cycles_accepted_res ctxt
             | Some _ \<Rightarrow> call_ctxt_respond ctxt);
             certified_data = (case new_certified_data result of None \<Rightarrow> certified_data S
               | Some cd \<Rightarrow> list_map_set (certified_data S) recv cd)
-            in S\<lparr>canisters := list_map_set (canisters S) recv (Some (can\<lparr>wasm_state := new_state result\<rparr>)),
+            in S\<lparr>canisters := list_map_set (canisters S) recv (Some (can\<lparr>wasm_state := update_return.new_state result\<rparr>)),
               messages := messages, call_contexts := list_map_set (call_contexts S) ctxt_id new_ctxt,
-              balances := list_map_set (balances S) recv New_balance, certified_data := certified_data\<rparr>)
+              certified_data := certified_data, balances := list_map_set (balances S) recv New_balance\<rparr>)
         else S\<lparr>messages := take n (messages S) @ drop (Suc n) (messages S),
-            balances := list_map_set (balances S) recv (bal + ((if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE) - cycles_used))\<rparr>))
+          balances := list_map_set (balances S) recv ((bal + (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE))
+            - min cyc_used (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE))\<rparr>))
     | _ \<Rightarrow> undefined)"
 
-definition message_execution_lost_cycles :: "nat \<Rightarrow> nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> nat" where
-  "message_execution_lost_cycles n cycles_used S = (case messages S ! n of Func_message ctxt_id recv ep q \<Rightarrow>
-    let Is_response = (case ep of Callback _ _ _ \<Rightarrow> True | _ \<Rightarrow> False) in
-    min cycles_used (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE))"
+definition message_execution_burned_cycles :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> nat" where
+  "message_execution_burned_cycles n S = (case messages S ! n of Func_message ctxt_id recv ep q \<Rightarrow>
+    (case (list_map_get (canisters S) recv, list_map_get (balances S) recv, list_map_get (canister_status S) recv,
+      list_map_get (time S) recv, list_map_get (call_contexts S) ctxt_id) of
+      (Some (Some can), Some bal, Some can_status, Some t, Some ctxt) \<Rightarrow> (
+        let Mod = module can;
+        Is_response = (case ep of Callback _ _ _ \<Rightarrow> True | _ \<Rightarrow> False);
+        Env = \<lparr>env.time = t, balance = bal, freezing_limit = ic_freezing_limit S recv, certificate = None, status = simple_status can_status\<rparr>;
+        Available = call_ctxt_available_cycles ctxt;
+        F = exec_function ep Env Available Mod;
+        R = F (wasm_state can);
+        cyc_used = (case R of Inr res \<Rightarrow> update_return.cycles_used res | Inl trap \<Rightarrow> cycles_return.cycles_used trap) in
+        min cyc_used (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE)
+      )))"
 
 lemma message_execution_cycles_monotonic:
-  assumes pre: "message_execution_pre n cycles_used S"
-  shows "total_cycles S = total_cycles (message_execution_post n cycles_used S) + message_execution_lost_cycles n cycles_used S"
+  assumes pre: "message_execution_pre n S"
+  shows "total_cycles S = total_cycles (message_execution_post n S) + message_execution_burned_cycles n S"
 proof -
   obtain ctxt_id recv ep q can bal can_status t ctxt where msg: "messages S ! n = Func_message ctxt_id recv ep q"
     and prod: "list_map_get (canisters S) recv = Some (Some can)"
@@ -594,14 +1018,15 @@ proof -
     by (auto simp: message_execution_pre_def split: message.splits option.splits)
   define Mod where "Mod = can_state_rec.module can"
   define Is_response where "Is_response = (case ep of Callback _ _ _ \<Rightarrow> True | _ \<Rightarrow> False)"
-  define Env :: "'b env" where "Env = \<lparr>env_time = t, balance = bal, freezing_limit = ic_freezing_limit S recv, certificate = None, status = simple_status can_status\<rparr>"
+  define Env :: "'b env" where "Env = \<lparr>env.time = t, balance = bal, freezing_limit = ic_freezing_limit S recv, certificate = None, status = simple_status can_status\<rparr>"
   define Available where "Available = call_ctxt_available_cycles ctxt"
   define F where "F = exec_function ep Env Available Mod"
   define R where "R = F (wasm_state can)"
-  obtain cycles_accepted_res new_calls_res where res: "(cycles_accepted_res, new_calls_res) = (case R of Inr res \<Rightarrow> (cycles_accepted res, new_calls res))"
-    by (cases "(case R of Inr res \<Rightarrow> (cycles_accepted res, new_calls res))") auto
+  define cyc_used where "cyc_used = (case R of Inr res \<Rightarrow> update_return.cycles_used res | Inl trap \<Rightarrow> cycles_return.cycles_used trap)"
+  obtain cycles_accepted_res new_calls_res where res: "(cycles_accepted_res, new_calls_res) = (case R of Inr res \<Rightarrow> (update_return.cycles_accepted res, new_calls res))"
+    by (cases "(case R of Inr res \<Rightarrow> (update_return.cycles_accepted res, new_calls res))") auto
   define New_balance where "New_balance = bal + cycles_accepted_res + (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE)
-    - (cycles_used + sum_list (map (\<lambda>x. MAX_CYCLES_PER_RESPONSE + transferred_cycles x) new_calls_res))"
+    - (cyc_used + sum_list (map (\<lambda>x. MAX_CYCLES_PER_RESPONSE + transferred_cycles x) new_calls_res))"
   define no_response where "no_response = (case R of Inr result \<Rightarrow> update_return.response result = None)"
   define older where "older = take n (messages S)"
   define younger where "younger = drop (Suc n) (messages S)"
@@ -614,23 +1039,23 @@ proof -
   note lm = list_map_sum_in[OF prod(2), where ?g=id, simplified] list_map_sum_in_ge[OF prod(2), where ?g=id, simplified]
     list_map_sum_in[OF prod(5), where ?g=call_ctxt_carried_cycles] list_map_sum_in_ge[OF prod(5), where ?g=call_ctxt_carried_cycles]
   define S'' where "S'' = S\<lparr>messages := take n (messages S) @ drop (Suc n) (messages S),
-    balances := list_map_set (balances S) recv (bal + ((if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE) - cycles_used))\<rparr>"
-  define cond where "cond = (\<not>isl R \<and> cycles_used \<le> (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE) \<and>
+    balances := list_map_set (balances S) recv ((bal + (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE)) - min cyc_used (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE))\<rparr>"
+  define cond where "cond = (\<not>isl R \<and> cyc_used \<le> (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE) \<and>
     cycles_accepted_res \<le> Available \<and>
-    cycles_used + sum_list (map (\<lambda>x. MAX_CYCLES_PER_RESPONSE + transferred_cycles x) new_calls_res) \<le>
+    cyc_used + sum_list (map (\<lambda>x. MAX_CYCLES_PER_RESPONSE + transferred_cycles x) new_calls_res) \<le>
       bal + cycles_accepted_res + (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE) \<and>
-    New_balance > (if Is_response then 0 else ic_freezing_limit S recv) \<and>
+    New_balance \<ge> (if Is_response then 0 else ic_freezing_limit S recv) \<and>
     (no_response \<or> call_ctxt_needs_to_respond ctxt))"
   have reserved: "(if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE) = cycles_reserved ep"
     by (auto simp: Is_response_def split: entry_point.splits)
   show ?thesis
   proof (cases cond)
     case False
-    have "message_execution_post n cycles_used S = S''"
-      "message_execution_lost_cycles n cycles_used S = min cycles_used (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE)"
+    have "message_execution_post n S = S''"
+      "message_execution_burned_cycles n S = min cyc_used (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE)"
       using False
-      by (simp_all add: message_execution_post_def message_execution_lost_cycles_def Let_def msg prod
-          Mod_def[symmetric] Is_response_def[symmetric] Env_def[symmetric] Available_def[symmetric] F_def[symmetric] R_def[symmetric] res[symmetric]
+      by (simp_all add: message_execution_post_def message_execution_burned_cycles_def Let_def msg prod
+          Mod_def[symmetric] Is_response_def[symmetric] Env_def[symmetric] Available_def[symmetric] F_def[symmetric] R_def[symmetric] cyc_used_def[symmetric] res[symmetric]
           New_balance_def[symmetric] no_response_def[symmetric] S''_def[symmetric] cond_def[symmetric] del: min_less_iff_conj split del: if_split)
     then show ?thesis
       using lm(2)
@@ -640,32 +1065,32 @@ proof -
     define result where "result = projr R"
     have R_Inr: "R = Inr result"
       using True
-      by (auto simp: cond_def result_def)
-    define response_messages where "response_messages = (case response result of None \<Rightarrow> []
+      by (auto simp: cond_def result_def split: option.splits)
+    define response_messages where "response_messages = (case update_return.response result of None \<Rightarrow> []
       | Some resp \<Rightarrow> [Response_message (call_ctxt_origin ctxt) resp (Available - cycles_accepted_res)])"
     define new_call_to_message :: "(?'p, 'canid, 's, 'b, 'c) method_call \<Rightarrow> ('b, 'p, 'uid, 'canid, 's, 'c, 'cid) message" where
       "new_call_to_message = (\<lambda>call. Call_message (From_canister ctxt_id (callback call)) (principal_of_canid recv)
         (callee call) (method_call.method_name call) (method_call.arg call) (transferred_cycles call) (Queue (Canister recv) (callee call)))"
     define messages where "messages = take n (ic.messages S) @ drop (Suc n) (ic.messages S) @ map new_call_to_message new_calls_res @ response_messages"
-    define new_ctxt where "new_ctxt = (case response result of
+    define new_ctxt where "new_ctxt = (case update_return.response result of
         None \<Rightarrow> call_ctxt_deduct_cycles cycles_accepted_res ctxt
       | Some _ \<Rightarrow> call_ctxt_respond ctxt)"
     define certified_data where "certified_data = (case new_certified_data result of None \<Rightarrow> ic.certified_data S
       | Some cd \<Rightarrow> list_map_set (ic.certified_data S) recv cd)"
-    define S' where "S' = S\<lparr>canisters := list_map_set (canisters S) recv (Some (can\<lparr>wasm_state := new_state result\<rparr>)),
+    define S' where "S' = S\<lparr>canisters := list_map_set (canisters S) recv (Some (can\<lparr>wasm_state := update_return.new_state result\<rparr>)),
       messages := messages, call_contexts := list_map_set (call_contexts S) ctxt_id new_ctxt,
-      balances := list_map_set (balances S) recv New_balance, certified_data := certified_data\<rparr>"
-    have cycles_accepted_res_def: "cycles_accepted_res = cycles_accepted result"
+      certified_data := certified_data, balances := list_map_set (balances S) recv New_balance\<rparr>"
+    have cycles_accepted_res_def: "cycles_accepted_res = update_return.cycles_accepted result"
       and new_calls_res_def: "new_calls_res = new_calls result"
       using res
       by (auto simp: R_Inr)
-    have no_response: "no_response = (response result = None)"
+    have no_response: "no_response = (update_return.response result = None)"
       by (auto simp: no_response_def R_Inr)
-    have msg_exec: "message_execution_post n cycles_used S = S'"
-      and lost: "message_execution_lost_cycles n cycles_used S = min cycles_used (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE)"
+    have msg_exec: "message_execution_post n S = S'"
+      and lost: "message_execution_burned_cycles n S = min cyc_used (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE)"
       using True
-      by (simp_all add: message_execution_post_def message_execution_lost_cycles_def Let_def msg prod
-          Mod_def[symmetric] Is_response_def[symmetric] Env_def[symmetric] Available_def[symmetric] F_def[symmetric] R_def[symmetric] res[symmetric]
+      by (simp_all add: message_execution_post_def message_execution_burned_cycles_def Let_def msg prod
+          Mod_def[symmetric] Is_response_def[symmetric] Env_def[symmetric] Available_def[symmetric] F_def[symmetric] R_def[symmetric] cyc_used_def[symmetric] res[symmetric]
           New_balance_def[symmetric] no_response_def[symmetric] S''_def[symmetric] cond_def[symmetric]
           messages_def[symmetric] new_ctxt_def[symmetric] certified_data_def[symmetric] S'_def[symmetric]
           result_def[symmetric] response_messages_def[symmetric] new_call_to_message_def[symmetric]
@@ -674,11 +1099,11 @@ proof -
       by (auto simp: new_call_to_message_def)
     then have A1: "sum_list (map (message_cycles \<circ> new_call_to_message) new_calls_res) = (\<Sum>x\<leftarrow>new_calls_res. MAX_CYCLES_PER_RESPONSE + transferred_cycles x)"
       by auto
-    have A2: "sum_list (map local.message_cycles response_messages) = (case response result of None \<Rightarrow> 0
-      | _ \<Rightarrow> carried_cycles (call_ctxt_origin ctxt) + (call_ctxt_available_cycles ctxt - cycles_accepted result))"
+    have A2: "sum_list (map local.message_cycles response_messages) = (case update_return.response result of None \<Rightarrow> 0
+      | _ \<Rightarrow> carried_cycles (call_ctxt_origin ctxt) + (call_ctxt_available_cycles ctxt - update_return.cycles_accepted result))"
       by (auto simp: response_messages_def Available_def cycles_accepted_res_def split: option.splits)
-    have A3: "call_ctxt_carried_cycles new_ctxt = (case response result of Some _ \<Rightarrow> 0
-      | _ \<Rightarrow> if call_ctxt_needs_to_respond ctxt then carried_cycles (call_ctxt_origin ctxt) + (call_ctxt_available_cycles ctxt - cycles_accepted result) else 0)"
+    have A3: "call_ctxt_carried_cycles new_ctxt = (case update_return.response result of Some _ \<Rightarrow> 0
+      | _ \<Rightarrow> if call_ctxt_needs_to_respond ctxt then carried_cycles (call_ctxt_origin ctxt) + (call_ctxt_available_cycles ctxt - update_return.cycles_accepted result) else 0)"
       by (auto simp: new_ctxt_def Available_def cycles_accepted_res_def call_ctxt_carried_cycles split: option.splits)
     have A4: "call_ctxt_carried_cycles ctxt = (if call_ctxt_needs_to_respond ctxt then carried_cycles (call_ctxt_origin ctxt) + call_ctxt_available_cycles ctxt else 0)"
       using call_ctxt_carried_cycles
@@ -688,9 +1113,129 @@ proof -
     have messages_msgs: "messages = older @ younger @ map new_call_to_message new_calls_res @ response_messages"
       by (auto simp: messages_def older_def younger_def)
     show ?thesis
-      using lm(2,4) True call_ctxt_inv[of ctxt]
+      using lm(2,4) True call_ctxt_not_needs_to_respond_available_cycles[of ctxt]
       by (auto simp: cond_def msg_exec S'_def total_cycles_def lm(1,3) msgs messages_msgs A1 A2 A3 A4 New_balance_def
           reserve cycles_accepted_res_def no_response_def R_Inr lost Available_def split: option.splits)
+  qed
+qed
+
+lemma message_execution_ic_inv:
+  assumes "message_execution_pre n S" "ic_inv S"
+  shows "ic_inv (message_execution_post n S)"
+proof -
+  obtain ctxt_id recv ep q can bal can_status t ctxt where msg: "messages S ! n = Func_message ctxt_id recv ep q"
+    and prod: "list_map_get (canisters S) recv = Some (Some can)"
+    "list_map_get (balances S) recv = Some bal"
+    "list_map_get (canister_status S) recv = Some can_status"
+    "list_map_get (time S) recv = Some t"
+    "list_map_get (call_contexts S) ctxt_id = Some ctxt"
+    using assms
+    by (auto simp: message_execution_pre_def split: message.splits option.splits)
+  define Mod where "Mod = can_state_rec.module can"
+  define Is_response where "Is_response = (case ep of Callback _ _ _ \<Rightarrow> True | _ \<Rightarrow> False)"
+  define Env :: "'b env" where "Env = \<lparr>env.time = t, balance = bal, freezing_limit = ic_freezing_limit S recv, certificate = None, status = simple_status can_status\<rparr>"
+  define Available where "Available = call_ctxt_available_cycles ctxt"
+  define F where "F = exec_function ep Env Available Mod"
+  define R where "R = F (wasm_state can)"
+  define cyc_used where "cyc_used = (case R of Inr res \<Rightarrow> update_return.cycles_used res | Inl trap \<Rightarrow> cycles_return.cycles_used trap)"
+  obtain cycles_accepted_res new_calls_res where res: "(cycles_accepted_res, new_calls_res) = (case R of Inr res \<Rightarrow> (update_return.cycles_accepted res, new_calls res))"
+    by (cases "(case R of Inr res \<Rightarrow> (update_return.cycles_accepted res, new_calls res))") auto
+  define New_balance where "New_balance = bal + cycles_accepted_res + (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE)
+    - (cyc_used + sum_list (map (\<lambda>x. MAX_CYCLES_PER_RESPONSE + transferred_cycles x) new_calls_res))"
+  define no_response where "no_response = (case R of Inr result \<Rightarrow> update_return.response result = None)"
+  define older where "older = take n (messages S)"
+  define younger where "younger = drop (Suc n) (messages S)"
+  have msgs: "messages S = older @ Func_message ctxt_id recv ep q # younger"
+    "take n older = older" "drop (Suc n) older = []"
+    "take (n - length older) ws = []" "drop (Suc n - length older) (w # ws) = ws"
+    for w and ws :: "('b, 'p, 'uid, 'canid, 's, 'c, 'cid) message list"
+    using id_take_nth_drop[of n "messages S"] assms
+    by (auto simp: message_execution_pre_def msg older_def younger_def)
+  define S'' where "S'' = S\<lparr>messages := take n (messages S) @ drop (Suc n) (messages S),
+    balances := list_map_set (balances S) recv ((bal + (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE)) - min cyc_used (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE))\<rparr>"
+  define cond where "cond = (\<not>isl R \<and> cyc_used \<le> (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE) \<and>
+    cycles_accepted_res \<le> Available \<and>
+    cyc_used + sum_list (map (\<lambda>x. MAX_CYCLES_PER_RESPONSE + transferred_cycles x) new_calls_res) \<le>
+      bal + cycles_accepted_res + (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE) \<and>
+    New_balance \<ge> (if Is_response then 0 else ic_freezing_limit S recv) \<and>
+    (no_response \<or> call_ctxt_needs_to_respond ctxt))"
+  show ?thesis
+  proof (cases cond)
+    case False
+    have "message_execution_post n S = S''"
+      using False
+      by (simp_all add: message_execution_post_def Let_def msg prod
+          Mod_def[symmetric] Is_response_def[symmetric] Env_def[symmetric] Available_def[symmetric] F_def[symmetric] R_def[symmetric] cyc_used_def[symmetric] res[symmetric]
+          New_balance_def[symmetric] no_response_def[symmetric] S''_def[symmetric] cond_def[symmetric])
+    then show ?thesis
+      using assms(2)
+      apply (auto simp: ic_inv_def S''_def msgs split: message.splits call_origin.splits)
+         apply force
+        apply fast
+       apply force
+      apply fast
+      done
+  next
+    case True
+    define result where "result = projr R"
+    have R_Inr: "R = Inr result"
+      using True
+      by (auto simp: cond_def result_def split: option.splits)
+    define response_messages where "response_messages = (case update_return.response result of None \<Rightarrow> []
+      | Some resp \<Rightarrow> [Response_message (call_ctxt_origin ctxt) resp (Available - cycles_accepted_res)])"
+    define new_call_to_message :: "(?'p, 'canid, 's, 'b, 'c) method_call \<Rightarrow> ('b, 'p, 'uid, 'canid, 's, 'c, 'cid) message" where
+      "new_call_to_message = (\<lambda>call. Call_message (From_canister ctxt_id (callback call)) (principal_of_canid recv)
+        (callee call) (method_call.method_name call) (method_call.arg call) (transferred_cycles call) (Queue (Canister recv) (callee call)))"
+    define messages where "messages = take n (ic.messages S) @ drop (Suc n) (ic.messages S) @ map new_call_to_message new_calls_res @ response_messages"
+    define new_ctxt where "new_ctxt = (case update_return.response result of
+        None \<Rightarrow> call_ctxt_deduct_cycles cycles_accepted_res ctxt
+      | Some _ \<Rightarrow> call_ctxt_respond ctxt)"
+    define certified_data where "certified_data = (case new_certified_data result of None \<Rightarrow> ic.certified_data S
+      | Some cd \<Rightarrow> list_map_set (ic.certified_data S) recv cd)"
+    define S' where "S' = S\<lparr>canisters := list_map_set (canisters S) recv (Some (can\<lparr>wasm_state := update_return.new_state result\<rparr>)),
+      messages := messages, call_contexts := list_map_set (call_contexts S) ctxt_id new_ctxt,
+      certified_data := certified_data, balances := list_map_set (balances S) recv New_balance\<rparr>"
+    have cycles_accepted_res_def: "cycles_accepted_res = update_return.cycles_accepted result"
+      and new_calls_res_def: "new_calls_res = new_calls result"
+      using res
+      by (auto simp: R_Inr)
+    have no_response: "no_response = (update_return.response result = None)"
+      by (auto simp: no_response_def R_Inr)
+    have msg_exec: "message_execution_post n S = S'"
+      using True
+      by (simp_all add: message_execution_post_def Let_def msg prod
+          Mod_def[symmetric] Is_response_def[symmetric] Env_def[symmetric] Available_def[symmetric] F_def[symmetric] R_def[symmetric] cyc_used_def[symmetric] res[symmetric]
+          New_balance_def[symmetric] no_response_def[symmetric] S''_def[symmetric] cond_def[symmetric]
+          messages_def[symmetric] new_ctxt_def[symmetric] certified_data_def[symmetric] S'_def[symmetric]
+          result_def[symmetric] response_messages_def[symmetric] new_call_to_message_def[symmetric])
+    have messages_msgs: "messages = older @ younger @ map new_call_to_message new_calls_res @ response_messages"
+      by (auto simp: messages_def older_def younger_def)
+    have ctxt_in_range: "ctxt \<in> list_map_range (call_contexts S)"
+      using prod(5)
+      by (simp add: list_map_get_range)
+    have response_msgsD: "msg \<in> set response_messages \<Longrightarrow> update_return.response result \<noteq> None \<and>
+      (\<exists>resp. msg = Response_message (call_ctxt_origin ctxt) resp (Available - cycles_accepted_res))" for msg
+      by (auto simp: response_messages_def) metis
+    have call_ctxt_origin_new_ctxt: "call_ctxt_origin new_ctxt = call_ctxt_origin ctxt"
+      by (auto simp: new_ctxt_def split: option.splits)
+    have call_ctxt_needs_to_respond_new_ctxtD: "call_ctxt_needs_to_respond new_ctxt \<Longrightarrow> call_ctxt_needs_to_respond ctxt"
+      by (auto simp: new_ctxt_def split: option.splits)
+    show ?thesis
+      using assms(2) ctxt_in_range True call_ctxt_not_needs_to_respond_available_cycles[of ctxt]
+      apply (auto simp: cond_def msg_exec S'_def ic_inv_def msgs messages_msgs new_call_to_message_def
+          no_response_def R_Inr call_ctxt_origin_new_ctxt
+          split: option.splits message.splits call_origin.splits
+          dest!: list_map_range_setD response_msgsD call_ctxt_needs_to_respond_new_ctxtD
+          intro: ic_can_status_inv_mono2)
+             apply blast
+            apply fast
+           apply blast
+          apply fast
+         apply blast
+        apply fast
+       apply blast
+      apply fast
+      done
   qed
 qed
 
@@ -698,21 +1243,22 @@ qed
 
 (* System transition: Call context starvation [DONE] *)
 
-definition call_context_starvation_pre :: "'cid \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+definition call_context_starvation_pre :: "'cid \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
   "call_context_starvation_pre ctxt_id S =
-  (case list_map_get (call_contexts S) ctxt_id of Some call_context \<Rightarrow> call_ctxt_needs_to_respond call_context \<and>
+  (case list_map_get (call_contexts S) ctxt_id of Some call_context \<Rightarrow>
+    call_ctxt_needs_to_respond call_context \<and>
     call_ctxt_origin call_context \<noteq> From_heartbeat \<and>
     (\<forall>msg \<in> set (messages S). case msg of
         Call_message orig _ _ _ _ _ _ \<Rightarrow> calling_context orig \<noteq> Some ctxt_id
       | Response_message orig _ _ \<Rightarrow> calling_context orig \<noteq> Some ctxt_id
       | _ \<Rightarrow> True) \<and>
-    (\<forall>other_call_context \<in> list_map_vals (call_contexts S).
+    (\<forall>other_call_context \<in> list_map_range (call_contexts S).
       call_ctxt_needs_to_respond other_call_context \<longrightarrow>
       calling_context (call_ctxt_origin other_call_context) \<noteq> Some ctxt_id)
   | None \<Rightarrow> False)"
 
 definition call_context_starvation_post :: "'cid \<Rightarrow>
-  ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
   "call_context_starvation_post ctxt_id S = (
     case list_map_get (call_contexts S) ctxt_id of Some call_context \<Rightarrow>
     let msg = Response_message (call_ctxt_origin call_context) (response.Reject CANISTER_ERROR (encode_string ''starvation'')) (call_ctxt_available_cycles call_context)
@@ -720,17 +1266,26 @@ definition call_context_starvation_post :: "'cid \<Rightarrow>
         messages := messages S @ [msg]\<rparr>)"
 
 lemma call_context_starvation_cycles_inv:
-  "call_context_starvation_pre ctxt_id S \<Longrightarrow>
-  total_cycles S = total_cycles (call_context_starvation_post ctxt_id S)"
-  using list_map_sum_in_ge[where ?f="call_contexts S" and ?x=ctxt_id and ?g=call_ctxt_carried_cycles]
+  assumes "call_context_starvation_pre ctxt_id S"
+  shows "total_cycles S = total_cycles (call_context_starvation_post ctxt_id S)"
+  using assms list_map_sum_in_ge[where ?f="call_contexts S" and ?x=ctxt_id and ?g=call_ctxt_carried_cycles]
   by (auto simp: call_context_starvation_pre_def call_context_starvation_post_def total_cycles_def
       call_ctxt_carried_cycles list_map_sum_in[where ?g=call_ctxt_carried_cycles] split: option.splits)
+
+lemma call_context_starvation_ic_inv:
+  assumes "call_context_starvation_pre ctxt_id S" "ic_inv S"
+  shows "ic_inv (call_context_starvation_post ctxt_id S)"
+  using assms
+  by (auto simp: ic_inv_def call_context_starvation_pre_def call_context_starvation_post_def Let_def
+      split: sum.splits message.splits call_origin.splits option.splits
+      dest!: in_set_takeD in_set_dropD in_set_updD list_map_range_setD list_map_get_range
+      intro: ic_can_status_inv_mono2)
 
 
 
 (* System transition: Call context removal [DONE] *)
 
-definition call_context_removal_pre :: "'cid \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+definition call_context_removal_pre :: "'cid \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
   "call_context_removal_pre ctxt_id S = (
     (case list_map_get (call_contexts S) ctxt_id of Some call_context \<Rightarrow>
       (\<not>call_ctxt_needs_to_respond call_context \<or>
@@ -742,21 +1297,1517 @@ definition call_context_removal_pre :: "'cid \<Rightarrow> ('p, 'uid, 'canid, 'b
           Call_message ctxt _ _ _ _ _ _ \<Rightarrow> calling_context ctxt \<noteq> Some ctxt_id
         | Response_message ctxt _ _ \<Rightarrow> calling_context ctxt \<noteq> Some ctxt_id
         | _ \<Rightarrow> True) \<and>
-      (\<forall>other_call_context \<in> list_map_vals (call_contexts S).
+      (\<forall>other_call_context \<in> list_map_range (call_contexts S).
         call_ctxt_needs_to_respond other_call_context \<longrightarrow>
-        calling_context (call_ctxt_origin other_call_context) \<noteq> Some ctxt_id)
+        calling_context (call_ctxt_origin other_call_context) \<noteq> Some ctxt_id) \<and>
+      (\<forall>can_status \<in> list_map_range (canister_status S). case can_status of Stopping os \<Rightarrow>
+        \<forall>(orig, cyc) \<in> set os. (case orig of From_canister other_ctxt_id _ \<Rightarrow> ctxt_id \<noteq> other_ctxt_id | _ \<Rightarrow> True)
+      | _ \<Rightarrow> True)
     | None \<Rightarrow> False))"
 
 definition call_context_removal_post :: "'cid \<Rightarrow>
-  ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'tr, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
   "call_context_removal_post ctxt_id S = S\<lparr>call_contexts := list_map_del (call_contexts S) ctxt_id\<rparr>"
 
-lemma call_context_removal_cycles_inv:
-  "call_context_removal_pre ctxt_id S \<Longrightarrow>
-  total_cycles S = total_cycles (call_context_removal_post ctxt_id S) +
-    (case list_map_get (call_contexts S) ctxt_id of Some call_context \<Rightarrow> call_ctxt_available_cycles call_context)"
-  using call_ctxt_inv
-  by (auto simp: call_context_removal_pre_def call_context_removal_post_def total_cycles_def call_ctxt_carried_cycles list_map_del_sum split: option.splits)
+definition call_context_removal_burned_cycles :: "'cid \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> nat" where
+  "call_context_removal_burned_cycles ctxt_id S = call_ctxt_available_cycles (the (list_map_get (call_contexts S) ctxt_id))"
+
+lemma call_context_removal_cycles_monotonic:
+  assumes "call_context_removal_pre ctxt_id S"
+  shows "total_cycles S = total_cycles (call_context_removal_post ctxt_id S) + call_context_removal_burned_cycles ctxt_id S"
+  using assms call_ctxt_not_needs_to_respond_available_cycles
+  by (auto simp: call_context_removal_pre_def call_context_removal_post_def call_context_removal_burned_cycles_def total_cycles_def call_ctxt_carried_cycles list_map_del_sum split: option.splits)
+
+lemma call_context_removal_ic_inv:
+  assumes "call_context_removal_pre ctxt_id S" "ic_inv S"
+  shows "ic_inv (call_context_removal_post ctxt_id S)"
+  using assms
+  by (force simp: ic_inv_def call_context_removal_pre_def call_context_removal_post_def Let_def
+      split: sum.splits message.splits call_origin.splits option.splits
+      dest!: in_set_takeD in_set_dropD in_set_updD list_map_range_setD list_map_get_range list_map_range_del
+      intro!: ic_can_status_inv_del[where ?z="list_map_dom (call_contexts S)"])
+
+
+
+(* System transition: IC Management Canister: Canister creation [DONE] *)
+
+definition ic_canister_creation_pre :: "nat \<Rightarrow> 'canid \<Rightarrow> nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  "ic_canister_creation_pre n cid t S = (n < length (messages S) \<and> (case messages S ! n of
+    Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
+      (q = Unordered \<or> (\<forall>j < n. message_queue (messages S ! j) \<noteq> Some q)) \<and>
+      cee = ic_principal \<and>
+      mn = encode_string ''create_canister'' \<and>
+      parse_candid a \<noteq> None \<and>
+      is_system_assigned (principal_of_canid cid) \<and>
+      cid \<notin> list_map_dom (canisters S) \<and>
+      cid \<notin> list_map_dom (time S) \<and>
+      cid \<notin> list_map_dom (controllers S) \<and>
+      cid \<notin> list_map_dom (balances S) \<and>
+      cid \<notin> list_map_dom (certified_data S) \<and>
+      cid \<notin> list_map_dom (canister_status S)
+    | _ \<Rightarrow> False))"
+
+definition ic_canister_creation_post :: "nat \<Rightarrow> 'canid \<Rightarrow> nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "ic_canister_creation_post n cid t S = (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
+    let ctrls = (case candid_parse_controllers a of Some ctrls \<Rightarrow> ctrls | _ \<Rightarrow> {cer}) in
+    S\<lparr>canisters := list_map_set (canisters S) cid None,
+      time := list_map_set (time S) cid t,
+      controllers := list_map_set (controllers S) cid ctrls,
+      freezing_threshold := list_map_set (freezing_threshold S) cid 2592000,
+      balances := list_map_set (balances S) cid trans_cycles,
+      certified_data := list_map_set (certified_data S) cid empty_blob,
+      messages := take n (messages S) @ drop (Suc n) (messages S) @ [Response_message orig (Reply (blob_of_candid
+        (Candid_record (list_map_init [(encode_string ''canister_id'', Candid_blob (blob_of_canid cid))])))) 0],
+      canister_status := list_map_set (canister_status S) cid Running\<rparr>)"
+
+lemma ic_canister_creation_cycles_inv:
+  assumes "ic_canister_creation_pre n cid t S"
+  shows "total_cycles S = total_cycles (ic_canister_creation_post n cid t S)"
+proof -
+  obtain orig cer cee mn a trans_cycles q where msg: "messages S ! n = Call_message orig cer cee mn a trans_cycles q"
+    using assms
+    by (auto simp: ic_canister_creation_pre_def split: message.splits)
+  define older where "older = take n (messages S)"
+  define younger where "younger = drop (Suc n) (messages S)"
+  have msgs: "messages S = older @ Call_message orig cer cee mn a trans_cycles q # younger" "(older @ w # younger) ! n = w"
+    "take n older = older" "take (n - length older) ws = []" "drop (Suc n) older = []"
+    "drop (Suc n - length older) (w # ws) = ws" for w ws
+    using id_take_nth_drop[of n "messages S"] assms
+    by (auto simp: ic_canister_creation_pre_def msg younger_def older_def nth_append)
+  show ?thesis
+    using assms
+    by (auto simp: ic_canister_creation_pre_def ic_canister_creation_post_def total_cycles_def Let_def msgs
+        list_map_sum_out[where ?g=id] list_map_sum_out[where ?g=status_cycles] split: message.splits option.splits)
+qed
+
+lemma ic_canister_creation_ic_inv:
+  assumes "ic_canister_creation_pre n cid t S" "ic_inv S"
+  shows "ic_inv (ic_canister_creation_post n cid t S)"
+  using assms
+  by (auto simp: ic_inv_def ic_canister_creation_pre_def ic_canister_creation_post_def Let_def
+      split: sum.splits message.splits call_origin.splits option.splits
+      dest!: in_set_takeD in_set_dropD nth_mem[of n "messages S"] in_set_updD list_map_range_setD list_map_get_range list_map_range_del
+      intro: ic_can_status_inv_mono1)
+
+
+
+(* System transition: IC Management Canister: Changing settings [DONE] *)
+
+definition ic_update_settings_pre :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  "ic_update_settings_pre n S = (n < length (messages S) \<and> (case messages S ! n of
+    Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
+      (q = Unordered \<or> (\<forall>j < n. message_queue (messages S ! j) \<noteq> Some q)) \<and>
+      cee = ic_principal \<and>
+      mn = encode_string ''update_settings'' \<and>
+      (case candid_parse_cid a of Some cid \<Rightarrow>
+      (case list_map_get (controllers S) cid of Some ctrls \<Rightarrow> cer \<in> ctrls
+      | _ \<Rightarrow> False) | _ \<Rightarrow> False)
+    | _ \<Rightarrow> False))"
+
+definition ic_update_settings_post :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "ic_update_settings_post n S = (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
+    let cid = the (candid_parse_cid a);
+    ctrls = (case candid_parse_controllers a of Some ctrls \<Rightarrow> list_map_set (controllers S) cid ctrls | _ \<Rightarrow> controllers S);
+    freezing_thres = (case candid_nested_lookup a [encode_string '''settings'', encode_string ''freezing_threshold''] of Some (Candid_nat freeze) \<Rightarrow>
+      list_map_set (freezing_threshold S) cid freeze | _ \<Rightarrow> freezing_threshold S) in
+    S\<lparr>controllers := ctrls, freezing_threshold := freezing_thres, messages := take n (messages S) @ drop (Suc n) (messages S) @
+        [Response_message orig (Reply (blob_of_candid Candid_empty)) trans_cycles]\<rparr>)"
+
+lemma ic_update_settings_cycles_inv:
+  assumes "ic_update_settings_pre n S"
+  shows "total_cycles S = total_cycles (ic_update_settings_post n S)"
+proof -
+  obtain orig cer cee mn a trans_cycles q where msg: "messages S ! n = Call_message orig cer cee mn a trans_cycles q"
+    using assms
+    by (auto simp: ic_update_settings_pre_def split: message.splits)
+  define older where "older = take n (messages S)"
+  define younger where "younger = drop (Suc n) (messages S)"
+  have msgs: "messages S = older @ Call_message orig cer cee mn a trans_cycles q # younger" "(older @ w # younger) ! n = w"
+    "take n older = older" "take (n - length older) ws = []" "drop (Suc n) older = []"
+    "drop (Suc n - length older) (w # ws) = ws" for w ws
+    using id_take_nth_drop[of n "messages S"] assms
+    by (auto simp: ic_update_settings_pre_def msg younger_def older_def nth_append)
+  show ?thesis
+    using assms
+    by (auto simp: ic_update_settings_pre_def ic_update_settings_post_def total_cycles_def Let_def msgs split: message.splits option.splits)
+qed
+
+lemma ic_update_settings_ic_inv:
+  assumes "ic_update_settings_pre n S" "ic_inv S"
+  shows "ic_inv (ic_update_settings_post n S)"
+  using assms
+  by (auto simp: ic_inv_def ic_update_settings_pre_def ic_update_settings_post_def Let_def
+      split: sum.splits message.splits call_origin.splits option.splits
+      dest!: in_set_takeD in_set_dropD nth_mem[of n "messages S"] in_set_updD list_map_range_setD list_map_get_range list_map_range_del)
+
+
+
+(* System transition: IC Management Canister: Canister status [DONE] *)
+
+definition ic_canister_status_pre :: "nat \<Rightarrow> nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  "ic_canister_status_pre n m S = (n < length (messages S) \<and> (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
+    (q = Unordered \<or> (\<forall>j < n. message_queue (messages S ! j) \<noteq> Some q)) \<and>
+    cee = ic_principal \<and>
+    mn = encode_string ''canister_status'' \<and>
+    (case candid_parse_cid a of Some cid \<Rightarrow>
+      cid \<in> list_map_dom (canisters S) \<and>
+      cid \<in> list_map_dom (canister_status S) \<and>
+      cid \<in> list_map_dom (balances S) \<and>
+      cid \<in> list_map_dom (freezing_threshold S) \<and>
+    (case list_map_get (controllers S) cid of Some ctrls \<Rightarrow> cer \<in> ctrls | _ \<Rightarrow> False) | _ \<Rightarrow> False)
+  | _ \<Rightarrow> False))"
+
+definition ic_canister_status_post :: "nat \<Rightarrow> nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "ic_canister_status_post n m S = (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
+    let cid = the (candid_parse_cid a);
+    hash = (case the (list_map_get (canisters S) cid) of None \<Rightarrow> Candid_null
+      | Some can \<Rightarrow> Candid_opt (Candid_blob (sha_256 (raw_module can)))) in
+    S\<lparr>messages := take n (messages S) @ drop (Suc n) (messages S) @ [Response_message orig (Reply (blob_of_candid
+      (Candid_record (list_map_init [(encode_string ''status'', candid_of_status (simple_status (the (list_map_get (canister_status S) cid)))),
+        (encode_string ''module_hash'', hash),
+        (encode_string ''controllers'', Candid_vec (map (Candid_blob \<circ> blob_of_principal) (principal_list_of_set (the (list_map_get (controllers S) cid))))),
+        (encode_string ''memory_size'', Candid_nat m),
+        (encode_string ''cycles'', Candid_nat (the (list_map_get (balances S) cid))),
+        (encode_string ''freezing_threshold'', Candid_nat (the (list_map_get (freezing_threshold S) cid))),
+        (encode_string ''idle_cycles_burned_per_day'', Candid_nat (ic_idle_cycles_burned_rate S cid))])))) trans_cycles]\<rparr>)"
+
+lemma ic_canister_status_cycles_inv:
+  assumes "ic_canister_status_pre n m S"
+  shows "total_cycles S = total_cycles (ic_canister_status_post n m S)"
+proof -
+  obtain orig cer cee mn a trans_cycles q where msg: "messages S ! n = Call_message orig cer cee mn a trans_cycles q"
+    using assms
+    by (auto simp: ic_canister_status_pre_def split: message.splits)
+  define older where "older = take n (messages S)"
+  define younger where "younger = drop (Suc n) (messages S)"
+  have msgs: "messages S = older @ Call_message orig cer cee mn a trans_cycles q # younger" "(older @ w # younger) ! n = w"
+    "take n older = older" "take (n - length older) ws = []" "drop (Suc n) older = []"
+    "drop (Suc n - length older) (w # ws) = ws" for w ws
+    using id_take_nth_drop[of n "messages S"] assms
+    by (auto simp: ic_canister_status_pre_def msg younger_def older_def nth_append)
+  show ?thesis
+    using assms
+    by (auto simp: ic_canister_status_pre_def ic_canister_status_post_def total_cycles_def Let_def msgs split: message.splits option.splits)
+qed
+
+lemma ic_canister_status_ic_inv:
+  assumes "ic_canister_status_pre n m S" "ic_inv S"
+  shows "ic_inv (ic_canister_status_post n m S)"
+  using assms
+  by (auto simp: ic_inv_def ic_canister_status_pre_def ic_canister_status_post_def Let_def
+      split: sum.splits message.splits call_origin.splits option.splits
+      dest!: in_set_takeD in_set_dropD nth_mem[of n "messages S"] in_set_updD list_map_range_setD list_map_get_range list_map_range_del)
+
+
+
+(* System transition: IC Management Canister: Code installation [DONE] *)
+
+definition ic_code_installation_pre :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  "ic_code_installation_pre n S = (n < length (messages S) \<and> (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
+    (q = Unordered \<or> (\<forall>j < n. message_queue (messages S ! j) \<noteq> Some q)) \<and>
+    cee = ic_principal \<and>
+    mn = encode_string ''install_code'' \<and>
+    (case candid_parse_cid a of Some cid \<Rightarrow>
+    (case (candid_parse_text a [encode_string ''mode''], candid_parse_blob a [encode_string ''wasm_module''], candid_parse_blob a [encode_string ''arg'']) of
+      (Some mode, Some w, Some ar) \<Rightarrow>
+    (case parse_wasm_mod w of Some m \<Rightarrow>
+      parse_public_custom_sections w \<noteq> None \<and>
+      parse_private_custom_sections w \<noteq> None \<and>
+    (case (list_map_get (controllers S) cid, list_map_get (time S) cid, list_map_get (balances S) cid, list_map_get (canister_status S) cid) of
+      (Some ctrls, Some t, Some bal, Some can_status) \<Rightarrow>
+      let env = \<lparr>env.time = t, balance = bal, freezing_limit = ic_freezing_limit S cid, certificate = None, status = simple_status can_status\<rparr> in
+      ((mode = encode_string ''install'' \<and> (case list_map_get (canisters S) cid of Some None \<Rightarrow> True | _ \<Rightarrow> False)) \<or> mode = encode_string ''reinstall'') \<and>
+      cer \<in> ctrls \<and>
+      (case canister_module_init m (cid, ar, cer, env) of Inl _ \<Rightarrow> False
+      | Inr ret \<Rightarrow> cycles_return.cycles_used ret \<le> bal) \<and>
+      list_map_dom (canister_module_update_methods m) \<inter> list_map_dom (canister_module_query_methods m) = {}
+    | _ \<Rightarrow> False) | _ \<Rightarrow> False) | _ \<Rightarrow> False) | _ \<Rightarrow> False)
+  | _ \<Rightarrow> False))"
+
+definition ic_code_installation_post :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "ic_code_installation_post n S = (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
+    (case candid_parse_cid a of Some cid \<Rightarrow>
+    (case (candid_parse_text a [encode_string ''mode''], candid_parse_blob a [encode_string ''wasm_module''], candid_parse_blob a [encode_string ''arg'']) of
+      (Some mode, Some w, Some a) \<Rightarrow>
+    (case parse_wasm_mod w of Some m \<Rightarrow>
+    (case (list_map_get (time S) cid, list_map_get (balances S) cid, list_map_get (canister_status S) cid) of
+      (Some t, Some bal, Some can_status) \<Rightarrow>
+      let env = \<lparr>env.time = t, balance = bal, freezing_limit = ic_freezing_limit S cid, certificate = None, status = simple_status can_status\<rparr>;
+      (new_state, cyc_used) = (case canister_module_init m (cid, a, cer, env) of Inr ret \<Rightarrow> (cycles_return.return ret, cycles_return.cycles_used ret)) in
+    S\<lparr>canisters := list_map_set (canisters S) cid (Some \<lparr>wasm_state = new_state, module = m, raw_module = w,
+        public_custom_sections = the (parse_public_custom_sections w), private_custom_sections = the (parse_private_custom_sections w)\<rparr>),
+      balances := list_map_set (balances S) cid (bal - cyc_used),
+      messages := take n (messages S) @ drop (Suc n) (messages S) @ [Response_message orig (Reply (blob_of_candid Candid_empty)) trans_cycles]\<rparr>)))))"
+
+definition ic_code_installation_burned_cycles :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> nat" where
+  "ic_code_installation_burned_cycles n S = (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
+    (case candid_parse_cid a of Some cid \<Rightarrow>
+    (case (candid_parse_blob a [encode_string ''wasm_module''], candid_parse_blob a [encode_string ''arg'']) of
+      (Some w, Some a) \<Rightarrow>
+    (case parse_wasm_mod w of Some m \<Rightarrow>
+    (case (list_map_get (time S) cid, list_map_get (balances S) cid, list_map_get (canister_status S) cid) of
+      (Some t, Some bal, Some can_status) \<Rightarrow>
+      let env = \<lparr>env.time = t, balance = bal, freezing_limit = ic_freezing_limit S cid, certificate = None, status = simple_status can_status\<rparr> in
+      (case canister_module_init m (cid, a, cer, env) of Inr ret \<Rightarrow> cycles_return.cycles_used ret))))))"
+
+lemma ic_code_installation_cycles_inv:
+  assumes "ic_code_installation_pre n S"
+  shows "total_cycles S = total_cycles (ic_code_installation_post n S) + ic_code_installation_burned_cycles n S"
+proof -
+  obtain orig cer cee mn a trans_cycles q where msg: "messages S ! n = Call_message orig cer cee mn a trans_cycles q"
+    using assms
+    by (auto simp: ic_code_installation_pre_def split: message.splits)
+  define older where "older = take n (messages S)"
+  define younger where "younger = drop (Suc n) (messages S)"
+  have msgs: "messages S = older @ Call_message orig cer cee mn a trans_cycles q # younger" "(older @ w # younger) ! n = w"
+    "take n older = older" "take (n - length older) ws = []" "drop (Suc n) older = []"
+    "drop (Suc n - length older) (w # ws) = ws" for w ws
+    using id_take_nth_drop[of n "messages S"] assms
+    by (auto simp: ic_code_installation_pre_def msg younger_def older_def nth_append)
+  show ?thesis
+    using assms list_map_sum_in_ge[where ?f="balances S" and ?g=id and ?x="the (candid_parse_cid a)"]
+    by (auto simp: ic_code_installation_pre_def ic_code_installation_post_def ic_code_installation_burned_cycles_def total_cycles_def Let_def msgs list_map_sum_in[where ?f="balances S"] split: message.splits option.splits sum.splits prod.splits)
+qed
+
+lemma ic_code_installation_ic_inv:
+  assumes "ic_code_installation_pre n S" "ic_inv S"
+  shows "ic_inv (ic_code_installation_post n S)"
+proof -
+  obtain orig cer cee mn a trans_cycles q cid mode w ar m ctrls t bal can_status where msg: "messages S ! n = Call_message orig cer cee mn a trans_cycles q"
+    and parse: "candid_parse_cid a = Some cid"
+    "candid_parse_text a [encode_string ''mode''] = Some mode"
+    "candid_parse_blob a [encode_string ''wasm_module''] = Some w"
+    "candid_parse_blob a [encode_string ''arg''] = Some ar"
+    "parse_wasm_mod w = Some m"
+    and list_map_get:
+    "list_map_get (controllers S) cid = Some ctrls"
+    "list_map_get (time S) cid = Some t"
+    "list_map_get (balances S) cid = Some bal"
+    "list_map_get (canister_status S) cid = Some can_status"
+    using assms
+    by (auto simp: ic_code_installation_pre_def split: message.splits option.splits)
+  show ?thesis
+    using assms
+    by (auto simp: ic_inv_def ic_code_installation_pre_def ic_code_installation_post_def msg parse list_map_get Let_def
+        split: sum.splits call_origin.splits message.splits
+        dest!: in_set_takeD in_set_dropD nth_mem[of n "messages S"] in_set_updD list_map_range_setD list_map_get_range list_map_range_del)
+qed
+
+
+
+(* System transition: IC Management Canister: Code upgrade [DONE] *)
+
+definition ic_code_upgrade_pre :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  "ic_code_upgrade_pre n S = (n < length (messages S) \<and> (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
+    (q = Unordered \<or> (\<forall>j < n. message_queue (messages S ! j) \<noteq> Some q)) \<and>
+    cee = ic_principal \<and>
+    mn = encode_string ''install_code'' \<and>
+    (case candid_parse_cid a of Some cid \<Rightarrow>
+    (case (candid_parse_text a [encode_string ''mode''], candid_parse_blob a [encode_string ''wasm_module''], candid_parse_blob a [encode_string ''arg'']) of
+      (Some mode, Some w, Some ar) \<Rightarrow>
+    (case parse_wasm_mod w of Some m \<Rightarrow>
+      parse_public_custom_sections w \<noteq> None \<and>
+      parse_private_custom_sections w \<noteq> None \<and>
+    (case (list_map_get (canisters S) cid, list_map_get (controllers S) cid, list_map_get (time S) cid, list_map_get (balances S) cid, list_map_get (canister_status S) cid) of
+      (Some (Some can), Some ctrls, Some t, Some bal, Some can_status) \<Rightarrow>
+      let env = \<lparr>env.time = t, balance = bal, freezing_limit = ic_freezing_limit S cid, certificate = None, status = simple_status can_status\<rparr> in
+      mode = encode_string ''upgrade'' \<and>
+      cer \<in> ctrls \<and>
+      (case canister_module_pre_upgrade (module can) (wasm_state can, cer, env) of Inr pre_ret \<Rightarrow>
+      (case canister_module_post_upgrade m (cid, cycles_return.return pre_ret, ar, cer, env) of Inr post_ret \<Rightarrow>
+        cycles_return.cycles_used pre_ret + cycles_return.cycles_used post_ret \<le> bal
+      | _ \<Rightarrow> False) | _ \<Rightarrow> False) \<and>
+      list_map_dom (canister_module_update_methods m) \<inter> list_map_dom (canister_module_query_methods m) = {}
+    | _ \<Rightarrow> False) | _ \<Rightarrow> False) | _ \<Rightarrow> False) | _ \<Rightarrow> False)
+  | _ \<Rightarrow> False))"
+
+definition ic_code_upgrade_post :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "ic_code_upgrade_post n S = (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
+    (case candid_parse_cid a of Some cid \<Rightarrow>
+    (case (candid_parse_text a [encode_string ''mode''], candid_parse_blob a [encode_string ''wasm_module''], candid_parse_blob a [encode_string ''arg'']) of
+      (Some mode, Some w, Some ar) \<Rightarrow>
+    (case parse_wasm_mod w of Some m \<Rightarrow>
+    (case (list_map_get (canisters S) cid, list_map_get (time S) cid, list_map_get (balances S) cid, list_map_get (canister_status S) cid) of
+      (Some (Some can), Some t, Some bal, Some can_status) \<Rightarrow>
+      let env = \<lparr>env.time = t, balance = bal, freezing_limit = ic_freezing_limit S cid, certificate = None, status = simple_status can_status\<rparr> in
+      (case canister_module_pre_upgrade (module can) (wasm_state can, cer, env) of Inr pre_ret \<Rightarrow>
+      (case canister_module_post_upgrade m (cid, cycles_return.return pre_ret, ar, cer, env) of Inr post_ret \<Rightarrow>
+    S\<lparr>canisters := list_map_set (canisters S) cid (Some \<lparr>wasm_state = cycles_return.return post_ret, module = m, raw_module = w,
+        public_custom_sections = the (parse_public_custom_sections w), private_custom_sections = the (parse_private_custom_sections w)\<rparr>),
+      balances := list_map_set (balances S) cid (bal - (cycles_return.cycles_used pre_ret + cycles_return.cycles_used post_ret)),
+      messages := take n (messages S) @ drop (Suc n) (messages S) @ [Response_message orig (Reply (blob_of_candid Candid_empty)) trans_cycles]\<rparr>)))))))"
+
+definition ic_code_upgrade_burned_cycles :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> nat" where
+  "ic_code_upgrade_burned_cycles n S = (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
+    (case candid_parse_cid a of Some cid \<Rightarrow>
+    (case (candid_parse_text a [encode_string ''mode''], candid_parse_blob a [encode_string ''wasm_module''], candid_parse_blob a [encode_string ''arg'']) of
+      (Some mode, Some w, Some ar) \<Rightarrow>
+    (case parse_wasm_mod w of Some m \<Rightarrow>
+    (case (list_map_get (canisters S) cid, list_map_get (time S) cid, list_map_get (balances S) cid, list_map_get (canister_status S) cid) of
+      (Some (Some can), Some t, Some bal, Some can_status) \<Rightarrow>
+      let env = \<lparr>env.time = t, balance = bal, freezing_limit = ic_freezing_limit S cid, certificate = None, status = simple_status can_status\<rparr> in
+      (case canister_module_pre_upgrade (module can) (wasm_state can, cer, env) of Inr pre_ret \<Rightarrow>
+      (case canister_module_post_upgrade m (cid, cycles_return.return pre_ret, ar, cer, env) of Inr post_ret \<Rightarrow>
+      cycles_return.cycles_used pre_ret + cycles_return.cycles_used post_ret)))))))"
+
+lemma ic_code_upgrade_cycles_inv:
+  assumes "ic_code_upgrade_pre n S"
+  shows "total_cycles S = total_cycles (ic_code_upgrade_post n S) + ic_code_upgrade_burned_cycles n S"
+proof -
+  obtain orig cer cee mn a trans_cycles q where msg: "messages S ! n = Call_message orig cer cee mn a trans_cycles q"
+    using assms
+    by (auto simp: ic_code_upgrade_pre_def split: message.splits)
+  define older where "older = take n (messages S)"
+  define younger where "younger = drop (Suc n) (messages S)"
+  have msgs: "messages S = older @ Call_message orig cer cee mn a trans_cycles q # younger" "(older @ w # younger) ! n = w"
+    "take n older = older" "take (n - length older) ws = []" "drop (Suc n) older = []"
+    "drop (Suc n - length older) (w # ws) = ws" for w ws
+    using id_take_nth_drop[of n "messages S"] assms
+    by (auto simp: ic_code_upgrade_pre_def msg younger_def older_def nth_append)
+  show ?thesis
+    using assms list_map_sum_in_ge[where ?f="balances S" and ?g=id and ?x="the (candid_parse_cid a)"]
+    by (auto simp: ic_code_upgrade_pre_def ic_code_upgrade_post_def ic_code_upgrade_burned_cycles_def total_cycles_def Let_def msgs list_map_sum_in[where ?f="balances S"] split: message.splits option.splits sum.splits)
+qed
+
+lemma ic_code_upgrade_ic_inv:
+  assumes "ic_code_upgrade_pre n S" "ic_inv S"
+  shows "ic_inv (ic_code_upgrade_post n S)"
+proof -
+  obtain orig cer cee mn a trans_cycles q cid mode w ar m can ctrls t bal can_status where msg: "messages S ! n = Call_message orig cer cee mn a trans_cycles q"
+    and parse: "candid_parse_cid a = Some cid"
+    "candid_parse_text a [encode_string ''mode''] = Some mode"
+    "candid_parse_blob a [encode_string ''wasm_module''] = Some w"
+    "candid_parse_blob a [encode_string ''arg''] = Some ar"
+    "parse_wasm_mod w = Some m"
+    and list_map_get:
+    "list_map_get (canisters S) cid = Some (Some can)"
+    "list_map_get (controllers S) cid = Some ctrls"
+    "list_map_get (time S) cid = Some t"
+    "list_map_get (balances S) cid = Some bal"
+    "list_map_get (canister_status S) cid = Some can_status"
+    using assms
+    by (auto simp: ic_code_upgrade_pre_def split: message.splits option.splits)
+  show ?thesis
+    using assms
+    by (auto simp: ic_inv_def ic_code_upgrade_pre_def ic_code_upgrade_post_def msg parse list_map_get Let_def
+        split: sum.splits call_origin.splits message.splits
+        dest!: in_set_takeD in_set_dropD nth_mem[of n "messages S"] in_set_updD list_map_range_setD list_map_get_range list_map_range_del)
+qed
+
+
+
+(* System transition: IC Management Canister: Code uninstallation [DONE] *)
+
+definition ic_code_uninstallation_pre :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  "ic_code_uninstallation_pre n S = (n < length (messages S) \<and> (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
+    (q = Unordered \<or> (\<forall>j < n. message_queue (messages S ! j) \<noteq> Some q)) \<and>
+    cee = ic_principal \<and>
+    mn = encode_string ''uninstall_code'' \<and>
+    (case candid_parse_cid a of Some cid \<Rightarrow>
+    (case list_map_get (controllers S) cid of Some ctrls \<Rightarrow> cer \<in> ctrls
+    | _ \<Rightarrow> False) | _ \<Rightarrow> False)
+  | _ \<Rightarrow> False))"
+
+definition ic_code_uninstallation_post :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "ic_code_uninstallation_post n S = (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
+    (case candid_parse_cid a of Some cid \<Rightarrow>
+    let call_ctxt_to_msg = (\<lambda>ctxt.
+      if call_ctxt_canister ctxt = cid \<and> call_ctxt_needs_to_respond ctxt then
+        Some (Response_message (call_ctxt_origin ctxt) (response.Reject CANISTER_REJECT (encode_string ''Canister has been uninstalled'')) (call_ctxt_available_cycles ctxt))
+      else None);
+    call_ctxt_to_ctxt = (\<lambda>ctxt. if call_ctxt_canister ctxt = cid then call_ctxt_delete ctxt else ctxt) in
+    S\<lparr>canisters := list_map_set (canisters S) cid None, certified_data := list_map_set (certified_data S) cid empty_blob,
+      messages := take n (messages S) @ drop (Suc n) (messages S) @ [Response_message orig (Reply (blob_of_candid Candid_empty)) trans_cycles] @
+        List.map_filter call_ctxt_to_msg (list_map_vals (call_contexts S)),
+      call_contexts := list_map_map call_ctxt_to_ctxt (call_contexts S)\<rparr>))"
+
+lemma ic_code_uninstallation_cycles_inv:
+  assumes "ic_code_uninstallation_pre n S"
+  shows "total_cycles S = total_cycles (ic_code_uninstallation_post n S)"
+proof -
+  obtain orig cer cee mn a trans_cycles q cid where msg: "messages S ! n = Call_message orig cer cee mn a trans_cycles q"
+    and cid_def: "candid_parse_cid a = Some cid"
+    using assms
+    by (auto simp: ic_code_uninstallation_pre_def split: message.splits option.splits)
+  define older where "older = take n (messages S)"
+  define younger where "younger = drop (Suc n) (messages S)"
+  have msgs: "messages S = older @ Call_message orig cer cee mn a trans_cycles q # younger" "(older @ w # younger) ! n = w"
+    "take n older = older" "take (n - length older) ws = []" "drop (Suc n) older = []"
+    "drop (Suc n - length older) (w # ws) = ws" for w ws
+    using id_take_nth_drop[of n "messages S"] assms
+    by (auto simp: ic_code_uninstallation_pre_def msg younger_def older_def nth_append)
+  have F1: "list_map_sum_vals call_ctxt_carried_cycles (call_contexts S) =
+    list_map_sum_vals id
+      (list_map_map (\<lambda>ctxt. if call_ctxt_canister ctxt = cid then call_ctxt_carried_cycles ctxt else 0) (call_contexts S)) +
+    list_map_sum_vals call_ctxt_carried_cycles
+      (list_map_map (\<lambda>ctxt. if call_ctxt_canister ctxt = cid then call_ctxt_delete ctxt else ctxt) (call_contexts S))"
+    using list_map_sum_vals_split[where ?f="call_ctxt_carried_cycles" and ?g="call_ctxt_delete", unfolded call_ctxt_delete_carried_cycles diff_zero]
+    by auto
+  show ?thesis
+    using assms
+    by (auto simp: ic_code_uninstallation_pre_def ic_code_uninstallation_post_def total_cycles_def call_ctxt_carried_cycles cid_def Let_def msgs F1
+        split: message.splits option.splits sum.splits if_splits intro!: list_map_sum_vals_filter)
+qed
+
+lemma ic_code_uninstallation_ic_inv:
+  assumes "ic_code_uninstallation_pre n S" "ic_inv S"
+  shows "ic_inv (ic_code_uninstallation_post n S)"
+  using assms
+  by (auto simp: ic_inv_def ic_code_uninstallation_pre_def ic_code_uninstallation_post_def Let_def
+      split: sum.splits message.splits call_origin.splits option.splits if_splits
+      dest!: in_set_takeD in_set_dropD nth_mem[of n "messages S"] in_set_updD list_map_range_setD list_map_get_range list_map_range_del
+      in_set_map_filter_vals)
+
+
+
+(* System transition: IC Management Canister: Stopping a canister (running) [DONE] *)
+
+definition ic_canister_stop_running_pre :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  "ic_canister_stop_running_pre n S = (n < length (messages S) \<and> (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
+    (q = Unordered \<or> (\<forall>j < n. message_queue (messages S ! j) \<noteq> Some q)) \<and>
+    cee = ic_principal \<and>
+    mn = encode_string ''stop_canister'' \<and>
+    (case candid_parse_cid a of Some cid \<Rightarrow>
+    (case (list_map_get (canister_status S) cid, list_map_get (controllers S) cid) of (Some Running, Some ctrls) \<Rightarrow>
+      cer \<in> ctrls
+    | _ \<Rightarrow> False) | _ \<Rightarrow> False)
+  | _ \<Rightarrow> False))"
+
+definition ic_canister_stop_running_post :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "ic_canister_stop_running_post n S = (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
+    let cid = the (candid_parse_cid a) in
+    S\<lparr>messages := take n (messages S) @ drop (Suc n) (messages S),
+      canister_status := list_map_set (canister_status S) cid (Stopping [(orig, trans_cycles)])\<rparr>)"
+
+lemma ic_canister_stop_running_cycles_inv:
+  assumes "ic_canister_stop_running_pre n S"
+  shows "total_cycles S = total_cycles (ic_canister_stop_running_post n S)"
+proof -
+  obtain orig cer cee mn a trans_cycles q cid where msg: "messages S ! n = Call_message orig cer cee mn a trans_cycles q"
+    and cid_def: "candid_parse_cid a = Some cid"
+    using assms
+    by (auto simp: ic_canister_stop_running_pre_def split: message.splits option.splits)
+  define older where "older = take n (messages S)"
+  define younger where "younger = drop (Suc n) (messages S)"
+  have msgs: "messages S = older @ Call_message orig cer cee mn a trans_cycles q # younger" "(older @ w # younger) ! n = w"
+    "take n older = older" "take (n - length older) ws = []" "drop (Suc n) older = []"
+    "drop (Suc n - length older) (w # ws) = ws" for w ws
+    using id_take_nth_drop[of n "messages S"] assms
+    by (auto simp: ic_canister_stop_running_pre_def msg younger_def older_def nth_append)
+  show ?thesis
+    using assms
+    by (auto simp: ic_canister_stop_running_pre_def ic_canister_stop_running_post_def total_cycles_def call_ctxt_carried_cycles cid_def Let_def msgs
+        list_map_sum_in[where ?g=status_cycles] split: message.splits option.splits sum.splits can_status.splits)
+qed
+
+lemma ic_canister_stop_running_ic_inv:
+  assumes "ic_canister_stop_running_pre n S" "ic_inv S"
+  shows "ic_inv (ic_canister_stop_running_post n S)"
+proof -
+  obtain orig cer cee mn a trans_cycles q cid where msg: "messages S ! n = Call_message orig cer cee mn a trans_cycles q"
+    and cid_def: "candid_parse_cid a = Some cid"
+    using assms
+    by (auto simp: ic_canister_stop_running_pre_def split: message.splits option.splits)
+  show ?thesis
+    using assms
+    by (force simp: ic_inv_def ic_canister_stop_running_pre_def ic_canister_stop_running_post_def msg Let_def
+        split: sum.splits message.splits call_origin.splits option.splits if_splits can_status.splits
+        dest!: in_set_takeD in_set_dropD nth_mem[of n "messages S"] in_set_updD list_map_range_setD list_map_get_range list_map_range_del
+        in_set_map_filter_vals intro!: ic_can_status_inv_stopping[where ?x="list_map_range (canister_status S)" and ?os=orig])
+qed
+
+
+
+(* System transition: IC Management Canister: Stopping a canister (stopping) [DONE] *)
+
+definition ic_canister_stop_stopping_pre :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  "ic_canister_stop_stopping_pre n S = (n < length (messages S) \<and> (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
+    (q = Unordered \<or> (\<forall>j < n. message_queue (messages S ! j) \<noteq> Some q)) \<and>
+    cee = ic_principal \<and>
+    mn = encode_string ''stop_canister'' \<and>
+    (case candid_parse_cid a of Some cid \<Rightarrow>
+    (case (list_map_get (canister_status S) cid, list_map_get (controllers S) cid) of (Some (Stopping os), Some ctrls) \<Rightarrow>
+      cer \<in> ctrls
+    | _ \<Rightarrow> False) | _ \<Rightarrow> False)
+  | _ \<Rightarrow> False))"
+
+definition ic_canister_stop_stopping_post :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "ic_canister_stop_stopping_post n S = (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
+    let cid = the (candid_parse_cid a) in
+    (case list_map_get (canister_status S) cid of Some (Stopping os) \<Rightarrow>
+    S\<lparr>messages := take n (messages S) @ drop (Suc n) (messages S),
+      canister_status := list_map_set (canister_status S) cid (Stopping (os @ [(orig, trans_cycles)]))\<rparr>))"
+
+lemma ic_canister_stop_stopping_cycles_inv:
+  assumes "ic_canister_stop_stopping_pre n S"
+  shows "total_cycles S = total_cycles (ic_canister_stop_stopping_post n S)"
+proof -
+  obtain orig cer cee mn a trans_cycles q cid where msg: "messages S ! n = Call_message orig cer cee mn a trans_cycles q"
+    and cid_def: "candid_parse_cid a = Some cid"
+    using assms
+    by (auto simp: ic_canister_stop_stopping_pre_def split: message.splits option.splits)
+  define older where "older = take n (messages S)"
+  define younger where "younger = drop (Suc n) (messages S)"
+  have msgs: "messages S = older @ Call_message orig cer cee mn a trans_cycles q # younger" "(older @ w # younger) ! n = w"
+    "take n older = older" "take (n - length older) ws = []" "drop (Suc n) older = []"
+    "drop (Suc n - length older) (w # ws) = ws" for w ws
+    using id_take_nth_drop[of n "messages S"] assms
+    by (auto simp: ic_canister_stop_stopping_pre_def msg younger_def older_def nth_append)
+  show ?thesis
+    using assms
+    by (auto simp: ic_canister_stop_stopping_pre_def ic_canister_stop_stopping_post_def total_cycles_def call_ctxt_carried_cycles cid_def Let_def msgs
+        list_map_sum_in[where ?g=status_cycles] split: message.splits option.splits sum.splits can_status.splits)
+qed
+
+lemma ic_canister_stop_stopping_ic_inv:
+  assumes "ic_canister_stop_stopping_pre n S" "ic_inv S"
+  shows "ic_inv (ic_canister_stop_stopping_post n S)"
+proof -
+  obtain orig cer cee mn a trans_cycles q cid where msg: "messages S ! n = Call_message orig cer cee mn a trans_cycles q"
+    and cid_def: "candid_parse_cid a = Some cid"
+    using assms
+    by (auto simp: ic_canister_stop_stopping_pre_def split: message.splits option.splits)
+  show ?thesis
+    using assms
+    by (force simp: ic_inv_def ic_canister_stop_stopping_pre_def ic_canister_stop_stopping_post_def msg Let_def
+        split: sum.splits message.splits call_origin.splits option.splits if_splits can_status.splits
+        dest!: in_set_takeD in_set_dropD nth_mem[of n "messages S"] in_set_updD list_map_range_setD list_map_get_range list_map_range_del
+        in_set_map_filter_vals intro!: ic_can_status_inv_stopping_app[where ?x="list_map_range (canister_status S)" and ?os=orig])
+qed
+
+
+
+(* System transition: IC Management Canister: Stopping a canister (done stopping) [DONE] *)
+
+definition ic_canister_stop_done_stopping_pre :: "'canid \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  "ic_canister_stop_done_stopping_pre cid S =
+    (case list_map_get (canister_status S) cid of Some (Stopping os) \<Rightarrow>
+      (\<forall>ctxt \<in> list_map_range (call_contexts S). call_ctxt_canister ctxt \<noteq> cid)
+    | _ \<Rightarrow> False)"
+
+definition ic_canister_stop_done_stopping_post :: "'canid \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "ic_canister_stop_done_stopping_post cid S = (
+    let orig_cycles_to_msg = (\<lambda>(or, cyc). Response_message or (Reply (blob_of_candid Candid_empty)) cyc) in
+    (case list_map_get (canister_status S) cid of Some (Stopping os) \<Rightarrow>
+    S\<lparr>canister_status := list_map_set (canister_status S) cid Stopped,
+      messages := messages S @ map orig_cycles_to_msg os\<rparr>))"
+
+lemma ic_canister_stop_done_stopping_cycles_inv:
+  assumes "ic_canister_stop_done_stopping_pre cid S"
+  shows "total_cycles S = total_cycles (ic_canister_stop_done_stopping_post cid S)"
+proof -
+  have F1: "(message_cycles \<circ> (\<lambda>(or, y). Response_message or (Reply (blob_of_candid Candid_empty)) y)) = (\<lambda>(or, y). carried_cycles or + y)"
+    by auto
+  have F2: "(\<Sum>(or, y)\<leftarrow>xs. carried_cycles or + y) = sum_list (map (carried_cycles \<circ> fst) xs) + sum_list (map snd xs)" for xs
+    by (induction xs) auto
+  show ?thesis
+    using assms list_map_sum_in_ge[where ?g=status_cycles and ?f="canister_status S" and ?x=cid]
+    by (auto simp: ic_canister_stop_done_stopping_pre_def ic_canister_stop_done_stopping_post_def total_cycles_def call_ctxt_carried_cycles Let_def
+        F1 F2 list_map_sum_in[where ?g=status_cycles] split: message.splits option.splits sum.splits can_status.splits)
+qed
+
+lemma ic_canister_stop_done_stopping_ic_inv:
+  assumes "ic_canister_stop_done_stopping_pre cid S" "ic_inv S"
+  shows "ic_inv (ic_canister_stop_done_stopping_post cid S)"
+  using assms
+  by (force simp: ic_inv_def ic_can_status_inv_def ic_canister_stop_done_stopping_pre_def ic_canister_stop_done_stopping_post_def Let_def
+      split: sum.splits message.splits call_origin.splits option.splits if_splits can_status.splits
+      dest!: in_set_takeD in_set_dropD in_set_updD list_map_range_setD list_map_get_range list_map_range_del
+      in_set_map_filter_vals)
+
+
+
+(* System transition: IC Management Canister: Stopping a canister (stopped) [DONE] *)
+
+definition ic_canister_stop_stopped_pre :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  "ic_canister_stop_stopped_pre n S = (n < length (messages S) \<and> (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
+    (q = Unordered \<or> (\<forall>j < n. message_queue (messages S ! j) \<noteq> Some q)) \<and>
+    cee = ic_principal \<and>
+    mn = encode_string ''stop_canister'' \<and>
+    (case candid_parse_cid a of Some cid \<Rightarrow>
+    (case (list_map_get (canister_status S) cid, list_map_get (controllers S) cid) of (Some Stopped, Some ctrls) \<Rightarrow>
+      cer \<in> ctrls
+    | _ \<Rightarrow> False) | _ \<Rightarrow> False)
+  | _ \<Rightarrow> False))"
+
+definition ic_canister_stop_stopped_post :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "ic_canister_stop_stopped_post n S = (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
+    S\<lparr>messages := take n (messages S) @ drop (Suc n) (messages S) @ [Response_message orig (Reply (blob_of_candid Candid_empty)) trans_cycles]\<rparr>)"
+
+lemma ic_canister_stop_stopped_cycles_inv:
+  assumes "ic_canister_stop_stopped_pre n S"
+  shows "total_cycles S = total_cycles (ic_canister_stop_stopped_post n S)"
+proof -
+  obtain orig cer cee mn a trans_cycles q cid where msg: "messages S ! n = Call_message orig cer cee mn a trans_cycles q"
+    and cid_def: "candid_parse_cid a = Some cid"
+    using assms
+    by (auto simp: ic_canister_stop_stopped_pre_def split: message.splits option.splits)
+  define older where "older = take n (messages S)"
+  define younger where "younger = drop (Suc n) (messages S)"
+  have msgs: "messages S = older @ Call_message orig cer cee mn a trans_cycles q # younger" "(older @ w # younger) ! n = w"
+    "take n older = older" "take (n - length older) ws = []" "drop (Suc n) older = []"
+    "drop (Suc n - length older) (w # ws) = ws" for w ws
+    using id_take_nth_drop[of n "messages S"] assms
+    by (auto simp: ic_canister_stop_stopped_pre_def msg younger_def older_def nth_append)
+  show ?thesis
+    using assms
+    by (auto simp: ic_canister_stop_stopped_pre_def ic_canister_stop_stopped_post_def total_cycles_def call_ctxt_carried_cycles cid_def Let_def msgs
+        split: message.splits option.splits sum.splits can_status.splits)
+qed
+
+lemma ic_canister_stop_stopped_ic_inv:
+  assumes "ic_canister_stop_stopped_pre n S" "ic_inv S"
+  shows "ic_inv (ic_canister_stop_stopped_post n S)"
+  using assms
+  by (auto simp: ic_inv_def ic_canister_stop_stopped_pre_def ic_canister_stop_stopped_post_def Let_def
+      split: sum.splits message.splits call_origin.splits option.splits if_splits can_status.splits
+      dest!: in_set_takeD in_set_dropD nth_mem[of n "messages S"] in_set_updD list_map_range_setD list_map_get_range list_map_range_del
+      in_set_map_filter_vals)
+
+
+
+(* System transition: IC Management Canister: Starting a canister (not stopping) [DONE] *)
+
+definition ic_canister_start_not_stopping_pre :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  "ic_canister_start_not_stopping_pre n S = (n < length (messages S) \<and> (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
+    (q = Unordered \<or> (\<forall>j < n. message_queue (messages S ! j) \<noteq> Some q)) \<and>
+    cee = ic_principal \<and>
+    mn = encode_string ''start_canister'' \<and>
+    (case candid_parse_cid a of Some cid \<Rightarrow>
+    (case (list_map_get (canister_status S) cid, list_map_get (controllers S) cid) of (Some can_status, Some ctrls) \<Rightarrow>
+      (can_status = Running \<or> can_status = Stopped) \<and>
+      cer \<in> ctrls
+    | _ \<Rightarrow> False) | _ \<Rightarrow> False)
+  | _ \<Rightarrow> False))"
+
+definition ic_canister_start_not_stopping_post :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "ic_canister_start_not_stopping_post n S = (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
+    let cid = the (candid_parse_cid a) in
+    S\<lparr>canister_status := list_map_set (canister_status S) cid Running,
+      messages := take n (messages S) @ drop (Suc n) (messages S) @ [Response_message orig (Reply (blob_of_candid Candid_empty)) trans_cycles]\<rparr>)"
+
+lemma ic_canister_start_not_stopping_cycles_inv:
+  assumes "ic_canister_start_not_stopping_pre n S"
+  shows "total_cycles S = total_cycles (ic_canister_start_not_stopping_post n S)"
+proof -
+  obtain orig cer cee mn a trans_cycles q cid where msg: "messages S ! n = Call_message orig cer cee mn a trans_cycles q"
+    and cid_def: "candid_parse_cid a = Some cid"
+    using assms
+    by (auto simp: ic_canister_start_not_stopping_pre_def split: message.splits option.splits)
+  define older where "older = take n (messages S)"
+  define younger where "younger = drop (Suc n) (messages S)"
+  have msgs: "messages S = older @ Call_message orig cer cee mn a trans_cycles q # younger" "(older @ w # younger) ! n = w"
+    "take n older = older" "take (n - length older) ws = []" "drop (Suc n) older = []"
+    "drop (Suc n - length older) (w # ws) = ws" for w ws
+    using id_take_nth_drop[of n "messages S"] assms
+    by (auto simp: ic_canister_start_not_stopping_pre_def msg younger_def older_def nth_append)
+  show ?thesis
+    using assms
+    by (auto simp: ic_canister_start_not_stopping_pre_def ic_canister_start_not_stopping_post_def total_cycles_def call_ctxt_carried_cycles cid_def Let_def msgs
+        list_map_sum_in[where ?g=status_cycles] split: message.splits option.splits sum.splits)
+qed
+
+lemma ic_canister_start_not_stopping_ic_inv:
+  assumes "ic_canister_start_not_stopping_pre n S" "ic_inv S"
+  shows "ic_inv (ic_canister_start_not_stopping_post n S)"
+  using assms
+  by (auto simp: ic_inv_def ic_canister_start_not_stopping_pre_def ic_canister_start_not_stopping_post_def Let_def
+      split: sum.splits message.splits call_origin.splits option.splits if_splits can_status.splits
+      dest!: in_set_takeD in_set_dropD nth_mem[of n "messages S"] in_set_updD list_map_range_setD list_map_get_range list_map_range_del
+      in_set_map_filter_vals intro: ic_can_status_inv_mono1)
+
+
+
+(* System transition: IC Management Canister: Starting a canister (stopping) [DONE] *)
+
+definition ic_canister_start_stopping_pre :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  "ic_canister_start_stopping_pre n S = (n < length (messages S) \<and> (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
+    (q = Unordered \<or> (\<forall>j < n. message_queue (messages S ! j) \<noteq> Some q)) \<and>
+    cee = ic_principal \<and>
+    mn = encode_string ''start_canister'' \<and>
+    (case candid_parse_cid a of Some cid \<Rightarrow>
+    (case (list_map_get (canister_status S) cid, list_map_get (controllers S) cid) of (Some (Stopping _), Some ctrls) \<Rightarrow>
+      cer \<in> ctrls
+    | _ \<Rightarrow> False) | _ \<Rightarrow> False)
+  | _ \<Rightarrow> False))"
+
+definition ic_canister_start_stopping_post :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "ic_canister_start_stopping_post n S = (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
+    let cid = the (candid_parse_cid a);
+    orig_cycles_to_msg = (\<lambda>(or, cyc). Response_message or (response.Reject CANISTER_REJECT (encode_string ''Canister has been restarted'')) cyc) in
+    (case list_map_get (canister_status S) cid of Some (Stopping os) \<Rightarrow>
+    S\<lparr>canister_status := list_map_set (canister_status S) cid Running,
+      messages := take n (messages S) @ drop (Suc n) (messages S) @ Response_message orig (Reply (blob_of_candid Candid_empty)) trans_cycles #
+      map orig_cycles_to_msg os\<rparr>))"
+
+lemma ic_canister_start_stopping_cycles_inv:
+  assumes "ic_canister_start_stopping_pre n S"
+  shows "total_cycles S = total_cycles (ic_canister_start_stopping_post n S)"
+proof -
+  obtain orig cer cee mn a trans_cycles q cid where msg: "messages S ! n = Call_message orig cer cee mn a trans_cycles q"
+    and cid_def: "candid_parse_cid a = Some cid"
+    using assms
+    by (auto simp: ic_canister_start_stopping_pre_def split: message.splits option.splits)
+  define older where "older = take n (messages S)"
+  define younger where "younger = drop (Suc n) (messages S)"
+  have msgs: "messages S = older @ Call_message orig cer cee mn a trans_cycles q # younger" "(older @ w # younger) ! n = w"
+    "take n older = older" "take (n - length older) ws = []" "drop (Suc n) older = []"
+    "drop (Suc n - length older) (w # ws) = ws" for w ws
+    using id_take_nth_drop[of n "messages S"] assms
+    by (auto simp: ic_canister_start_stopping_pre_def msg younger_def older_def nth_append)
+  have F1: "(message_cycles \<circ> (\<lambda>(or, y). Response_message or (response.Reject CANISTER_REJECT (encode_string ''Canister has been restarted'')) y)) = (\<lambda>(or, y). carried_cycles or + y)"
+    by auto
+  have F2: "(\<Sum>(or, y)\<leftarrow>xs. carried_cycles or + y) = sum_list (map (carried_cycles \<circ> fst) xs) + sum_list (map snd xs)" for xs
+    by (induction xs) auto
+  show ?thesis
+    using assms list_map_sum_in_ge[where ?g=status_cycles and ?f="canister_status S" and ?x=cid]
+    by (auto simp: ic_canister_start_stopping_pre_def ic_canister_start_stopping_post_def total_cycles_def call_ctxt_carried_cycles cid_def Let_def msgs F1 F2
+        list_map_sum_in[where ?g=status_cycles and ?f="canister_status S"]
+        split: message.splits option.splits sum.splits can_status.splits)
+qed
+
+lemma ic_canister_start_stopping_ic_inv:
+  assumes "ic_canister_start_stopping_pre n S" "ic_inv S"
+  shows "ic_inv (ic_canister_start_stopping_post n S)"
+  using assms
+  apply (auto simp: ic_inv_def ic_canister_start_stopping_pre_def ic_canister_start_stopping_post_def Let_def
+      split: sum.splits message.splits call_origin.splits option.splits if_splits can_status.splits
+      dest!: in_set_takeD in_set_dropD nth_mem[of n "messages S"] in_set_updD list_map_range_setD list_map_get_range list_map_range_del in_set_map_filter_vals
+      intro: ic_can_status_inv_mono1)
+   apply (fastforce simp: ic_can_status_inv_def)+
+  done
+
+
+
+(* System transition: IC Management Canister: Canister deletion [DONE] *)
+
+definition ic_canister_deletion_pre :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  "ic_canister_deletion_pre n S = (n < length (messages S) \<and> (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
+    (q = Unordered \<or> (\<forall>j < n. message_queue (messages S ! j) \<noteq> Some q)) \<and>
+    cee = ic_principal \<and>
+    mn = encode_string ''delete_canister'' \<and>
+    (case candid_parse_cid a of Some cid \<Rightarrow>
+    (case (list_map_get (canister_status S) cid, list_map_get (controllers S) cid, list_map_get (balances S) cid) of (Some Stopped, Some ctrls, Some bal) \<Rightarrow>
+      cer \<in> ctrls
+    | _ \<Rightarrow> False) | _ \<Rightarrow> False)
+  | _ \<Rightarrow> False))"
+
+definition ic_canister_deletion_post :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "ic_canister_deletion_post n S = (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
+    let cid = the (candid_parse_cid a) in
+    S\<lparr>canisters := list_map_del (canisters S) cid,
+      controllers := list_map_del (controllers S) cid,
+      freezing_threshold := list_map_del (freezing_threshold S) cid,
+      canister_status := list_map_del (canister_status S) cid,
+      time := list_map_del (time S) cid,
+      balances := list_map_del (balances S) cid,
+      certified_data := list_map_del (certified_data S) cid,
+      messages := take n (messages S) @ drop (Suc n) (messages S) @ [Response_message orig (Reply (blob_of_candid Candid_empty)) trans_cycles]\<rparr>)"
+
+definition ic_canister_deletion_burned_cycles :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> nat" where
+  "ic_canister_deletion_burned_cycles n S = (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
+    let cid = the (candid_parse_cid a) in the (list_map_get (balances S) cid))"
+
+lemma ic_canister_deletion_cycles_monotonic:
+  assumes "ic_canister_deletion_pre n S"
+  shows "total_cycles S = total_cycles (ic_canister_deletion_post n S) + ic_canister_deletion_burned_cycles n S"
+proof -
+  obtain orig cer cee mn a trans_cycles q cid where msg: "messages S ! n = Call_message orig cer cee mn a trans_cycles q"
+    and cid_def: "candid_parse_cid a = Some cid"
+    using assms
+    by (auto simp: ic_canister_deletion_pre_def split: message.splits option.splits)
+  define older where "older = take n (messages S)"
+  define younger where "younger = drop (Suc n) (messages S)"
+  have msgs: "messages S = older @ Call_message orig cer cee mn a trans_cycles q # younger" "(older @ w # younger) ! n = w"
+    "take n older = older" "take (n - length older) ws = []" "drop (Suc n) older = []"
+    "drop (Suc n - length older) (w # ws) = ws" for w ws
+    using id_take_nth_drop[of n "messages S"] assms
+    by (auto simp: ic_canister_deletion_pre_def msg younger_def older_def nth_append)
+  show ?thesis
+    using assms
+    by (auto simp: ic_canister_deletion_pre_def ic_canister_deletion_post_def ic_canister_deletion_burned_cycles_def total_cycles_def call_ctxt_carried_cycles cid_def Let_def msgs
+        list_map_del_sum[where ?g=id and ?f="balances S"] list_map_del_sum[where ?g=status_cycles and ?f="canister_status S"]
+        split: message.splits option.splits sum.splits can_status.splits)
+qed
+
+lemma ic_canister_deletion_ic_inv:
+  assumes "ic_canister_deletion_pre n S" "ic_inv S"
+  shows "ic_inv (ic_canister_deletion_post n S)"
+  using assms
+  by (auto simp: ic_inv_def ic_canister_deletion_pre_def ic_canister_deletion_post_def Let_def
+      split: sum.splits message.splits call_origin.splits option.splits if_splits can_status.splits
+      dest!: in_set_takeD in_set_dropD nth_mem[of n "messages S"] in_set_updD list_map_range_setD list_map_get_range list_map_range_del in_set_map_filter_vals
+      intro: ic_can_status_inv_mono1)
+
+
+
+(* System transition: IC Management Canister: Depositing cycles [DONE] *)
+
+definition ic_depositing_cycles_pre :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  "ic_depositing_cycles_pre n S = (n < length (messages S) \<and> (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
+    (q = Unordered \<or> (\<forall>j < n. message_queue (messages S ! j) \<noteq> Some q)) \<and>
+    cee = ic_principal \<and>
+    mn = encode_string ''deposit_cycles'' \<and>
+    (case candid_parse_cid a of Some cid \<Rightarrow>
+    (case list_map_get (balances S) cid of Some bal \<Rightarrow>
+      True
+    | _ \<Rightarrow> False) | _ \<Rightarrow> False)
+  | _ \<Rightarrow> False))"
+
+definition ic_depositing_cycles_post :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "ic_depositing_cycles_post n S = (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
+    let cid = the (candid_parse_cid a) in
+    (case list_map_get (balances S) cid of Some bal \<Rightarrow>
+    S\<lparr>balances := list_map_set (balances S) cid (bal + trans_cycles),
+      messages := take n (messages S) @ drop (Suc n) (messages S) @ [Response_message orig (Reply (blob_of_candid Candid_empty)) 0]\<rparr>))"
+
+lemma ic_depositing_cycles_cycles_monotonic:
+  assumes "ic_depositing_cycles_pre n S"
+  shows "total_cycles S = total_cycles (ic_depositing_cycles_post n S)"
+proof -
+  obtain orig cer cee mn a trans_cycles q cid where msg: "messages S ! n = Call_message orig cer cee mn a trans_cycles q"
+    and cid_def: "candid_parse_cid a = Some cid"
+    using assms
+    by (auto simp: ic_depositing_cycles_pre_def split: message.splits option.splits)
+  define older where "older = take n (messages S)"
+  define younger where "younger = drop (Suc n) (messages S)"
+  have msgs: "messages S = older @ Call_message orig cer cee mn a trans_cycles q # younger" "(older @ w # younger) ! n = w"
+    "take n older = older" "take (n - length older) ws = []" "drop (Suc n) older = []"
+    "drop (Suc n - length older) (w # ws) = ws" for w ws
+    using id_take_nth_drop[of n "messages S"] assms
+    by (auto simp: ic_depositing_cycles_pre_def msg younger_def older_def nth_append)
+  show ?thesis
+    using assms list_map_sum_in_ge[where ?g=id and ?f="balances S" and ?x=cid]
+    by (auto simp: ic_depositing_cycles_pre_def ic_depositing_cycles_post_def total_cycles_def call_ctxt_carried_cycles cid_def Let_def msgs
+        list_map_sum_in[where ?g=id and ?f="balances S"] min_def split: message.splits option.splits sum.splits)
+qed
+
+lemma ic_depositing_cycles_ic_inv:
+  assumes "ic_depositing_cycles_pre n S" "ic_inv S"
+  shows "ic_inv (ic_depositing_cycles_post n S)"
+  using assms
+  by (auto simp: ic_inv_def ic_depositing_cycles_pre_def ic_depositing_cycles_post_def Let_def
+      split: sum.splits message.splits call_origin.splits option.splits if_splits can_status.splits
+      dest!: in_set_takeD in_set_dropD nth_mem[of n "messages S"] in_set_updD list_map_range_setD list_map_get_range list_map_range_del
+      in_set_map_filter_vals)
+
+
+
+(* System transition: IC Management Canister: Random numbers [DONE] *)
+
+definition ic_random_numbers_pre :: "nat \<Rightarrow> 'b \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  "ic_random_numbers_pre n b S = (n < length (messages S) \<and> (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
+    (q = Unordered \<or> (\<forall>j < n. message_queue (messages S ! j) \<noteq> Some q)) \<and>
+    cee = ic_principal \<and>
+    mn = encode_string ''raw_rand'' \<and>
+    a = blob_of_candid Candid_empty \<and>
+    blob_length b = 32
+  | _ \<Rightarrow> False))"
+
+definition ic_random_numbers_post :: "nat \<Rightarrow> 'b \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "ic_random_numbers_post n b S = (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
+    S\<lparr>messages := take n (messages S) @ drop (Suc n) (messages S) @ [Response_message orig (Reply (blob_of_candid (Candid_blob b))) trans_cycles]\<rparr>)"
+
+lemma ic_random_numbers_cycles_inv:
+  assumes "ic_random_numbers_pre n b S"
+  shows "total_cycles S = total_cycles (ic_random_numbers_post n b S)"
+proof -
+  obtain orig cer cee mn a trans_cycles q where msg: "messages S ! n = Call_message orig cer cee mn a trans_cycles q"
+    using assms
+    by (auto simp: ic_random_numbers_pre_def split: message.splits)
+  define older where "older = take n (messages S)"
+  define younger where "younger = drop (Suc n) (messages S)"
+  have msgs: "messages S = older @ Call_message orig cer cee mn a trans_cycles q # younger" "(older @ w # younger) ! n = w"
+    "take n older = older" "take (n - length older) ws = []" "drop (Suc n) older = []"
+    "drop (Suc n - length older) (w # ws) = ws" for w ws
+    using id_take_nth_drop[of n "messages S"] assms
+    by (auto simp: ic_random_numbers_pre_def msg younger_def older_def nth_append)
+  show ?thesis
+    using assms
+    by (auto simp: ic_random_numbers_pre_def ic_random_numbers_post_def total_cycles_def call_ctxt_carried_cycles Let_def msgs)
+qed
+
+lemma ic_random_numbers_ic_inv:
+  assumes "ic_random_numbers_pre n b S" "ic_inv S"
+  shows "ic_inv (ic_random_numbers_post n b S)"
+  using assms
+  by (auto simp: ic_inv_def ic_random_numbers_pre_def ic_random_numbers_post_def Let_def
+      split: sum.splits message.splits call_origin.splits option.splits if_splits can_status.splits
+      dest!: in_set_takeD in_set_dropD nth_mem[of n "messages S"] in_set_updD list_map_range_setD list_map_get_range list_map_range_del
+      in_set_map_filter_vals)
+
+
+
+(* System transition: IC Management Canister: Canister creation with cycles [DONE] *)
+
+definition ic_provisional_canister_creation_pre :: "nat \<Rightarrow> 'canid \<Rightarrow> nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  "ic_provisional_canister_creation_pre n cid t S = (n < length (messages S) \<and> (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
+    (case candid_parse_nat a [encode_string ''amount''] of Some cyc \<Rightarrow>
+      (q = Unordered \<or> (\<forall>j < n. message_queue (messages S ! j) \<noteq> Some q)) \<and>
+      cee = ic_principal \<and>
+      mn = encode_string ''provisional_create_canister_with_cycles'' \<and>
+      is_system_assigned (principal_of_canid cid) \<and>
+      cid \<notin> list_map_dom (canisters S) \<and>
+      cid \<notin> list_map_dom (time S) \<and>
+      cid \<notin> list_map_dom (controllers S) \<and>
+      cid \<notin> list_map_dom (balances S) \<and>
+      cid \<notin> list_map_dom (certified_data S) \<and>
+      cid \<notin> list_map_dom (canister_status S)
+    | _ \<Rightarrow> False) | _ \<Rightarrow> False))"
+
+definition ic_provisional_canister_creation_post :: "nat \<Rightarrow> 'canid \<Rightarrow> nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "ic_provisional_canister_creation_post n cid t S = (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
+    let cyc = the (candid_parse_nat a [encode_string ''amount'']) in
+    S\<lparr>canisters := list_map_set (canisters S) cid None,
+      time := list_map_set (time S) cid t,
+      controllers := list_map_set (controllers S) cid {cer},
+      freezing_threshold := list_map_set (freezing_threshold S) cid 2592000,
+      balances := list_map_set (balances S) cid cyc,
+      certified_data := list_map_set (certified_data S) cid empty_blob,
+      messages := take n (messages S) @ drop (Suc n) (messages S) @ [Response_message orig (Reply (blob_of_candid
+        (Candid_record (list_map_init [(encode_string ''canister_id'', Candid_blob (blob_of_canid cid))])))) trans_cycles],
+      canister_status := list_map_set (canister_status S) cid Running\<rparr>)"
+
+definition ic_provisional_canister_creation_minted_cycles :: "nat \<Rightarrow> 'canid \<Rightarrow> nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> nat" where
+  "ic_provisional_canister_creation_minted_cycles n cid t S = (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
+    the (candid_parse_nat a [encode_string ''amount'']))"
+
+lemma ic_provisional_canister_creation_cycles_antimonotonic:
+  assumes "ic_provisional_canister_creation_pre n cid t S"
+  shows "total_cycles S + ic_provisional_canister_creation_minted_cycles n cid t S  = total_cycles (ic_provisional_canister_creation_post n cid t S)"
+proof -
+  obtain orig cer cee mn a trans_cycles q where msg: "messages S ! n = Call_message orig cer cee mn a trans_cycles q"
+    using assms
+    by (auto simp: ic_provisional_canister_creation_pre_def split: message.splits)
+  define older where "older = take n (messages S)"
+  define younger where "younger = drop (Suc n) (messages S)"
+  have msgs: "messages S = older @ Call_message orig cer cee mn a trans_cycles q # younger" "(older @ w # younger) ! n = w"
+    "take n older = older" "take (n - length older) ws = []" "drop (Suc n) older = []"
+    "drop (Suc n - length older) (w # ws) = ws" for w ws
+    using id_take_nth_drop[of n "messages S"] assms
+    by (auto simp: ic_provisional_canister_creation_pre_def msg younger_def older_def nth_append)
+  show ?thesis
+    using assms
+    by (auto simp: ic_provisional_canister_creation_pre_def ic_provisional_canister_creation_post_def ic_provisional_canister_creation_minted_cycles_def total_cycles_def Let_def msgs
+        list_map_sum_out[where ?g=id] list_map_sum_out[where ?g=status_cycles] split: message.splits option.splits)
+qed
+
+lemma ic_provisional_canister_creation_ic_inv:
+  assumes "ic_provisional_canister_creation_pre n cid t S" "ic_inv S"
+  shows "ic_inv (ic_provisional_canister_creation_post n cid t S)"
+  using assms
+  by (auto simp: ic_inv_def ic_provisional_canister_creation_pre_def ic_provisional_canister_creation_post_def Let_def
+      split: sum.splits message.splits call_origin.splits option.splits if_splits can_status.splits
+      dest!: in_set_takeD in_set_dropD nth_mem[of n "messages S"] in_set_updD list_map_range_setD list_map_get_range list_map_range_del in_set_map_filter_vals
+      intro: ic_can_status_inv_mono1)
+
+
+
+(* System transition: IC Management Canister: Top up canister [DONE] *)
+
+definition ic_top_up_canister_pre :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  "ic_top_up_canister_pre n S = (n < length (messages S) \<and> (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
+    (case (candid_parse_cid a, candid_parse_nat a [encode_string ''amount'']) of (Some cid, Some cyc) \<Rightarrow>
+      (q = Unordered \<or> (\<forall>j < n. message_queue (messages S ! j) \<noteq> Some q)) \<and>
+      cee = ic_principal \<and>
+      mn = encode_string ''provisional_top_up_canister'' \<and>
+      cid \<in> list_map_dom (balances S)
+    | _ \<Rightarrow> False) | _ \<Rightarrow> False))"
+
+definition ic_top_up_canister_post :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "ic_top_up_canister_post n S = (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
+    let cid = the (candid_parse_cid a);
+    cyc = the (candid_parse_nat a [encode_string ''amount'']);
+    bal = the (list_map_get (balances S) cid) in
+    S\<lparr>balances := list_map_set (balances S) cid (bal + cyc)\<rparr>)"
+
+definition ic_top_up_canister_minted_cycles :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> nat" where
+  "ic_top_up_canister_minted_cycles n S = (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
+    the (candid_parse_nat a [encode_string ''amount'']))"
+
+lemma ic_top_up_canister_cycles_antimonotonic:
+  assumes "ic_top_up_canister_pre n S"
+  shows "total_cycles S + ic_top_up_canister_minted_cycles n S  = total_cycles (ic_top_up_canister_post n S)"
+proof -
+  obtain orig cer cee mn a trans_cycles q where msg: "messages S ! n = Call_message orig cer cee mn a trans_cycles q"
+    using assms
+    by (auto simp: ic_top_up_canister_pre_def split: message.splits)
+  define older where "older = take n (messages S)"
+  define younger where "younger = drop (Suc n) (messages S)"
+  have msgs: "messages S = older @ Call_message orig cer cee mn a trans_cycles q # younger" "(older @ w # younger) ! n = w"
+    "take n older = older" "take (n - length older) ws = []" "drop (Suc n) older = []"
+    "drop (Suc n - length older) (w # ws) = ws" for w ws
+    using id_take_nth_drop[of n "messages S"] assms
+    by (auto simp: ic_top_up_canister_pre_def msg younger_def older_def nth_append)
+  define cid where "cid = the (candid_parse_cid a)"
+  show ?thesis
+    using assms
+    by (cases "list_map_get (balances S) cid")
+       (auto simp: ic_top_up_canister_pre_def ic_top_up_canister_post_def ic_top_up_canister_minted_cycles_def total_cycles_def Let_def msgs cid_def
+        list_map_sum_in[where ?g=id] split: message.splits option.splits)
+qed
+
+lemma ic_top_up_canister_ic_inv:
+  assumes "ic_top_up_canister_pre n S" "ic_inv S"
+  shows "ic_inv (ic_top_up_canister_post n S)"
+  using assms
+  by (auto simp: ic_inv_def ic_top_up_canister_pre_def ic_top_up_canister_post_def Let_def
+      split: sum.splits message.splits call_origin.splits option.splits if_splits can_status.splits
+      dest!: in_set_takeD in_set_dropD nth_mem[of n "messages S"] in_set_updD list_map_range_setD list_map_get_range list_map_range_del
+      in_set_map_filter_vals)
+
+
+
+(* System transition: Callback invocation (not deleted) [DONE] *)
+
+definition callback_invocation_not_deleted_pre :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  "callback_invocation_not_deleted_pre n S = (n < length (messages S) \<and> (case messages S ! n of Response_message (From_canister ctxt_id c) resp ref_cycles \<Rightarrow>
+    (case list_map_get (call_contexts S) ctxt_id of Some ctxt \<Rightarrow>
+      let cid = call_ctxt_canister ctxt in
+      \<not>call_ctxt_deleted ctxt \<and>
+      (case list_map_get (balances S) cid of Some bal \<Rightarrow> True
+      | _ \<Rightarrow> False)
+    | _ \<Rightarrow> False)
+  | _ \<Rightarrow> False))"
+
+definition callback_invocation_not_deleted_post :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "callback_invocation_not_deleted_post n S = (case messages S ! n of Response_message (From_canister ctxt_id c) resp ref_cycles \<Rightarrow>
+    (case list_map_get (call_contexts S) ctxt_id of Some ctxt \<Rightarrow>
+      let cid = call_ctxt_canister ctxt in
+      (case list_map_get (balances S) cid of Some bal \<Rightarrow>
+        S\<lparr>balances := list_map_set (balances S) cid (bal + ref_cycles),
+          messages := list_update (messages S) n (Func_message ctxt_id cid (Callback c resp ref_cycles) Unordered)\<rparr>)))"
+
+lemma callback_invocation_not_deleted_cycles_inv:
+  assumes "callback_invocation_not_deleted_pre n S"
+  shows "total_cycles S = total_cycles (callback_invocation_not_deleted_post n S)"
+proof -
+  obtain ctxt_id c resp ref_cycles where msg: "messages S ! n = Response_message (From_canister ctxt_id c) resp ref_cycles"
+    using assms
+    by (auto simp: callback_invocation_not_deleted_pre_def split: message.splits option.splits call_origin.splits)
+  define older where "older = take n (messages S)"
+  define younger where "younger = drop (Suc n) (messages S)"
+  have msgs: "messages S = older @ Response_message (From_canister ctxt_id c) resp ref_cycles # younger" "(older @ w # younger) ! n = w"
+    and msgs_upd: "(older @ Response_message (From_canister ctxt_id c) resp ref_cycles # younger)[n := m] = older @ m # younger" for w m
+    using assms id_take_nth_drop[of n "messages S"] upd_conv_take_nth_drop[of n "messages S"] assms
+    by (auto simp: callback_invocation_not_deleted_pre_def msg older_def younger_def nth_append)
+  show ?thesis
+    using assms
+    by (auto simp: callback_invocation_not_deleted_pre_def callback_invocation_not_deleted_post_def total_cycles_def call_ctxt_carried_cycles Let_def msgs msgs_upd
+        list_map_sum_in[where ?g=id and ?f="balances S"] split: option.splits)
+qed
+
+lemma callback_invocation_not_deleted_ic_inv:
+  assumes "callback_invocation_not_deleted_pre n S" "ic_inv S"
+  shows "ic_inv (callback_invocation_not_deleted_post n S)"
+  using assms
+  by (auto simp: ic_inv_def callback_invocation_not_deleted_pre_def callback_invocation_not_deleted_post_def Let_def
+      split: sum.splits message.splits call_origin.splits option.splits if_splits can_status.splits
+      dest!: in_set_takeD in_set_dropD nth_mem[of n "messages S"] in_set_updD)
+
+
+
+(* System transition: Callback invocation (deleted) [DONE] *)
+
+definition callback_invocation_deleted_pre :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  "callback_invocation_deleted_pre n S = (n < length (messages S) \<and> (case messages S ! n of Response_message (From_canister ctxt_id c) resp ref_cycles \<Rightarrow>
+    (case list_map_get (call_contexts S) ctxt_id of Some ctxt \<Rightarrow>
+      let cid = call_ctxt_canister ctxt in
+      call_ctxt_deleted ctxt \<and>
+      (case list_map_get (balances S) cid of Some bal \<Rightarrow> True
+      | _ \<Rightarrow> False)
+    | _ \<Rightarrow> False)
+  | _ \<Rightarrow> False))"
+
+definition callback_invocation_deleted_post :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "callback_invocation_deleted_post n S = (case messages S ! n of Response_message (From_canister ctxt_id c) resp ref_cycles \<Rightarrow>
+    (case list_map_get (call_contexts S) ctxt_id of Some ctxt \<Rightarrow>
+      let cid = call_ctxt_canister ctxt in
+      (case list_map_get (balances S) cid of Some bal \<Rightarrow>
+        S\<lparr>balances := list_map_set (balances S) cid (bal + ref_cycles + MAX_CYCLES_PER_RESPONSE),
+          messages := take n (messages S) @ drop (Suc n) (messages S)\<rparr>)))"
+
+lemma callback_invocation_deleted_cycles_inv:
+  assumes "callback_invocation_deleted_pre n S"
+  shows "total_cycles S = total_cycles (callback_invocation_deleted_post n S)"
+proof -
+  obtain ctxt_id c resp ref_cycles where msg: "messages S ! n = Response_message (From_canister ctxt_id c) resp ref_cycles"
+    using assms
+    by (auto simp: callback_invocation_deleted_pre_def split: message.splits option.splits call_origin.splits)
+  define older where "older = take n (messages S)"
+  define younger where "younger = drop (Suc n) (messages S)"
+  have msgs: "messages S = older @ Response_message (From_canister ctxt_id c) resp ref_cycles # younger" "(older @ w # younger) ! n = w"
+    "take n older = older" "take (n - length older) ws = []" "drop (Suc n) older = []"
+    "drop (Suc n - length older) (w # ws) = ws" for w ws
+    using id_take_nth_drop[of n "messages S"] assms
+    by (auto simp: callback_invocation_deleted_pre_def msg younger_def older_def nth_append)
+  show ?thesis
+    using assms
+    by (auto simp: callback_invocation_deleted_pre_def callback_invocation_deleted_post_def total_cycles_def call_ctxt_carried_cycles Let_def msgs
+        list_map_sum_in[where ?g=id and ?f="balances S"] split: option.splits)
+qed
+
+lemma callback_invocation_deleted_ic_inv:
+  assumes "callback_invocation_deleted_pre n S" "ic_inv S"
+  shows "ic_inv (callback_invocation_deleted_post n S)"
+  using assms
+  by (auto simp: ic_inv_def callback_invocation_deleted_pre_def callback_invocation_deleted_post_def Let_def
+      split: sum.splits message.splits call_origin.splits option.splits if_splits can_status.splits
+      dest!: in_set_takeD in_set_dropD nth_mem[of n "messages S"] in_set_updD)
+
+
+
+(* System transition: Respond to user request [DONE] *)
+
+definition respond_to_user_request_pre :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  "respond_to_user_request_pre n S = (n < length (messages S) \<and> (case messages S ! n of Response_message (From_user req) resp ref_cycles \<Rightarrow>
+    (case list_map_get (requests S) req of Some Processing \<Rightarrow> True
+    | _ \<Rightarrow> False)
+  | _ \<Rightarrow> False))"
+
+definition respond_to_user_request_post :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "respond_to_user_request_post n S = (case messages S ! n of Response_message (From_user req) resp ref_cycles \<Rightarrow>
+    let req_resp = (case resp of Reply b \<Rightarrow> Replied b | response.Reject c b \<Rightarrow> Rejected c b) in
+    S\<lparr>messages := take n (messages S) @ drop (Suc n) (messages S),
+      requests := list_map_set (requests S) req req_resp\<rparr>)"
+
+definition respond_to_user_request_burned_cycles :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> nat" where
+  "respond_to_user_request_burned_cycles n S = (case messages S ! n of Response_message (From_user req) resp ref_cycles \<Rightarrow>
+    ref_cycles)"
+
+lemma respond_to_user_request_cycles_monotonic:
+  assumes "respond_to_user_request_pre n S"
+  shows "total_cycles S = total_cycles (respond_to_user_request_post n S) + respond_to_user_request_burned_cycles n S"
+proof -
+  obtain req resp ref_cycles where msg: "messages S ! n = Response_message (From_user req) resp ref_cycles"
+    using assms
+    by (auto simp: respond_to_user_request_pre_def split: message.splits option.splits call_origin.splits)
+  define older where "older = take n (messages S)"
+  define younger where "younger = drop (Suc n) (messages S)"
+  have msgs: "messages S = older @ Response_message (From_user req) resp ref_cycles # younger" "(older @ w # younger) ! n = w"
+    "take n older = older" "take (n - length older) ws = []" "drop (Suc n) older = []"
+    "drop (Suc n - length older) (w # ws) = ws" for w ws
+    using id_take_nth_drop[of n "messages S"] assms
+    by (auto simp: respond_to_user_request_pre_def msg younger_def older_def nth_append)
+  show ?thesis
+    using assms
+    by (auto simp: respond_to_user_request_pre_def respond_to_user_request_post_def respond_to_user_request_burned_cycles_def total_cycles_def call_ctxt_carried_cycles Let_def msgs
+        list_map_sum_in[where ?g=id and ?f="balances S"] split: option.splits request_status.splits)
+qed
+
+lemma respond_to_user_request_ic_inv:
+  assumes "respond_to_user_request_pre n S" "ic_inv S"
+  shows "ic_inv (respond_to_user_request_post n S)"
+  using assms
+  by (auto simp: ic_inv_def respond_to_user_request_pre_def respond_to_user_request_post_def Let_def
+      split: sum.splits message.splits call_origin.splits option.splits if_splits can_status.splits
+      dest!: in_set_takeD in_set_dropD nth_mem[of n "messages S"] in_set_updD)
+
+
+
+(* System transition: Request clean up [DONE] *)
+
+definition request_cleanup_pre :: "('b, 'p, 'uid, 'canid, 's) request \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  "request_cleanup_pre req S = (case list_map_get (requests S) req of Some req_status \<Rightarrow>
+    (case req_status of Replied _ \<Rightarrow> True | Rejected _ _ \<Rightarrow> True | _ \<Rightarrow> False)
+    | _ \<Rightarrow> False)"
+
+definition request_cleanup_post :: "('b, 'p, 'uid, 'canid, 's) request \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "request_cleanup_post req S = (S\<lparr>requests := list_map_set (requests S) req Done\<rparr>)"
+
+lemma request_cleanup_cycles_inv:
+  assumes "request_cleanup_pre n S"
+  shows "total_cycles S = total_cycles (request_cleanup_post n S)"
+  by (auto simp: request_cleanup_post_def total_cycles_def)
+
+lemma request_cleanup_ic_inv:
+  assumes "request_cleanup_pre req S" "ic_inv S"
+  shows "ic_inv (request_cleanup_post req S)"
+  using assms
+  by (auto simp: ic_inv_def request_cleanup_pre_def request_cleanup_post_def Let_def
+      split: sum.splits message.splits call_origin.splits option.splits if_splits can_status.splits
+      dest!: in_set_takeD in_set_dropD in_set_updD)
+
+
+
+(* System transition: Request clean up (expired) [DONE] *)
+
+definition request_cleanup_expired_pre :: "('b, 'p, 'uid, 'canid, 's) request \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  "request_cleanup_expired_pre req S = (case list_map_get (requests S) req of Some req_status \<Rightarrow>
+    (case req_status of Replied _ \<Rightarrow> True | Rejected _ _ \<Rightarrow> True | Done \<Rightarrow> True | _ \<Rightarrow> False) \<and>
+    request.ingress_expiry req < system_time S
+    | _ \<Rightarrow> False)"
+
+definition request_cleanup_expired_post :: "('b, 'p, 'uid, 'canid, 's) request \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "request_cleanup_expired_post req S = (S\<lparr>requests := list_map_del (requests S) req\<rparr>)"
+
+lemma request_cleanup_expired_cycles_inv:
+  assumes "request_cleanup_expired_pre n S"
+  shows "total_cycles S = total_cycles (request_cleanup_expired_post n S)"
+  by (auto simp: request_cleanup_expired_post_def total_cycles_def)
+
+lemma request_cleanup_expired_ic_inv:
+  assumes "request_cleanup_expired_pre req S" "ic_inv S"
+  shows "ic_inv (request_cleanup_expired_post req S)"
+  using assms
+  by (auto simp: ic_inv_def request_cleanup_expired_pre_def request_cleanup_expired_post_def Let_def
+      split: sum.splits message.splits call_origin.splits option.splits if_splits can_status.splits
+      dest!: in_set_takeD in_set_dropD in_set_updD)
+
+
+
+(* System transition: Canister out of cycles [DONE] *)
+
+definition canister_out_of_cycles_pre :: "'canid \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  "canister_out_of_cycles_pre cid S = (case list_map_get (balances S) cid of Some 0 \<Rightarrow> True
+  | _ \<Rightarrow> False)"
+
+definition canister_out_of_cycles_post :: "'canid \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "canister_out_of_cycles_post cid S = (
+    let call_ctxt_to_msg = (\<lambda>ctxt.
+      if call_ctxt_canister ctxt = cid \<and> call_ctxt_needs_to_respond ctxt then
+        Some (Response_message (call_ctxt_origin ctxt) (response.Reject CANISTER_REJECT (encode_string ''Canister has been uninstalled'')) (call_ctxt_available_cycles ctxt))
+      else None);
+    call_ctxt_to_ctxt = (\<lambda>ctxt. if call_ctxt_canister ctxt = cid then call_ctxt_delete ctxt else ctxt) in
+    S\<lparr>canisters := list_map_set (canisters S) cid None, certified_data := list_map_set (certified_data S) cid empty_blob,
+      messages := messages S @ List.map_filter call_ctxt_to_msg (list_map_vals (call_contexts S)),
+      call_contexts := list_map_map call_ctxt_to_ctxt (call_contexts S)\<rparr>)"
+
+lemma canister_out_of_cycles_cycles_inv:
+  assumes "canister_out_of_cycles_pre cid S"
+  shows "total_cycles S = total_cycles (canister_out_of_cycles_post cid S)"
+proof -
+  have F1: "list_map_sum_vals call_ctxt_carried_cycles (call_contexts S) =
+    list_map_sum_vals id
+      (list_map_map (\<lambda>ctxt. if call_ctxt_canister ctxt = cid then call_ctxt_carried_cycles ctxt else 0) (call_contexts S)) +
+    list_map_sum_vals call_ctxt_carried_cycles
+      (list_map_map (\<lambda>ctxt. if call_ctxt_canister ctxt = cid then call_ctxt_delete ctxt else ctxt) (call_contexts S))"
+    using list_map_sum_vals_split[where ?f="call_ctxt_carried_cycles" and ?g="call_ctxt_delete", unfolded call_ctxt_delete_carried_cycles diff_zero]
+    by auto
+  show ?thesis
+    using assms
+    by (auto simp: canister_out_of_cycles_pre_def canister_out_of_cycles_post_def total_cycles_def call_ctxt_carried_cycles Let_def F1
+        split: message.splits option.splits sum.splits if_splits intro!: list_map_sum_vals_filter)
+qed
+
+lemma canister_out_of_cycles_ic_inv:
+  assumes "canister_out_of_cycles_pre cid S" "ic_inv S"
+  shows "ic_inv (canister_out_of_cycles_post cid S)"
+  using assms
+  by (auto simp: ic_inv_def canister_out_of_cycles_pre_def canister_out_of_cycles_post_def Let_def
+      split: sum.splits message.splits call_origin.splits option.splits if_splits can_status.splits
+      dest!: in_set_takeD in_set_dropD in_set_updD list_map_range_setD list_map_get_range list_map_range_del
+      in_set_map_filter_vals)
+
+
+
+(* System transition: Time progressing and cycle consumption (canister time) [DONE] *)
+
+definition canister_time_progress_pre :: "'canid \<Rightarrow> nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  "canister_time_progress_pre cid t1 S = (case list_map_get (time S) cid of Some t0 \<Rightarrow>
+      t0 < t1
+    | _ \<Rightarrow> False)"
+
+definition canister_time_progress_post :: "'canid \<Rightarrow> nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "canister_time_progress_post cid t1 S = (S\<lparr>time := list_map_set (time S) cid t1\<rparr>)"
+
+lemma canister_time_progress_cycles_inv:
+  assumes "canister_time_progress_pre cid t1 S"
+  shows "total_cycles S = total_cycles (canister_time_progress_post cid t1 S)"
+  by (auto simp: canister_time_progress_post_def total_cycles_def)
+
+lemma canister_time_progress_ic_inv:
+  assumes "canister_time_progress_pre cid t1 S" "ic_inv S"
+  shows "ic_inv (canister_time_progress_post cid t1 S)"
+  using assms
+  by (auto simp: ic_inv_def canister_time_progress_pre_def canister_time_progress_post_def Let_def
+      split: sum.splits message.splits call_origin.splits option.splits if_splits can_status.splits
+      dest!: in_set_takeD in_set_dropD in_set_updD list_map_range_setD list_map_get_range list_map_range_del
+      in_set_map_filter_vals)
+
+
+
+(* System transition: Time progressing and cycle consumption (cycle consumption) [DONE] *)
+
+definition cycle_consumption_pre :: "'canid \<Rightarrow> nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  "cycle_consumption_pre cid b1 S = (case list_map_get (balances S) cid of Some b0 \<Rightarrow>
+      0 \<le> b1 \<and> b1 < b0
+    | _ \<Rightarrow> False)"
+
+definition cycle_consumption_post :: "'canid \<Rightarrow> nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "cycle_consumption_post cid b1 S = (S\<lparr>balances := list_map_set (balances S) cid b1\<rparr>)"
+
+definition cycle_consumption_burned_cycles :: "'canid \<Rightarrow> nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> nat" where
+  "cycle_consumption_burned_cycles cid b1 S = the (list_map_get (balances S) cid) - b1"
+
+lemma cycle_consumption_cycles_monotonic:
+  assumes "cycle_consumption_pre cid b1 S"
+  shows "total_cycles S = total_cycles (cycle_consumption_post cid b1 S) + cycle_consumption_burned_cycles cid b1 S"
+  using assms list_map_sum_in_ge[where ?g=id and ?f="balances S" and ?x=cid]
+  by (auto simp: cycle_consumption_pre_def cycle_consumption_post_def cycle_consumption_burned_cycles_def total_cycles_def
+      list_map_sum_in[where ?g=id and ?f="balances S"] split: option.splits)
+
+lemma cycle_consumption_ic_inv:
+  assumes "cycle_consumption_pre cid b1 S" "ic_inv S"
+  shows "ic_inv (cycle_consumption_post cid b1 S)"
+  using assms
+  by (auto simp: ic_inv_def cycle_consumption_pre_def cycle_consumption_post_def Let_def
+      split: sum.splits message.splits call_origin.splits option.splits if_splits can_status.splits
+      dest!: in_set_takeD in_set_dropD in_set_updD list_map_range_setD list_map_get_range list_map_range_del
+      in_set_map_filter_vals)
+
+
+
+(* System transition: Time progressing and cycle consumption (system time) [DONE] *)
+
+definition system_time_progress_pre :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  "system_time_progress_pre t1 S = (system_time S < t1)"
+
+definition system_time_progress_post :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
+  "system_time_progress_post t1 S = (S\<lparr>system_time := t1\<rparr>)"
+
+lemma system_time_progress_cycles_inv:
+  assumes "system_time_progress_pre t1 S"
+  shows "total_cycles S = total_cycles (system_time_progress_post t1 S)"
+  by (auto simp: system_time_progress_post_def total_cycles_def)
+
+lemma system_time_progress_ic_inv:
+  assumes "system_time_progress_pre t1 S" "ic_inv S"
+  shows "ic_inv (system_time_progress_post t1 S)"
+  using assms
+  by (auto simp: ic_inv_def system_time_progress_pre_def system_time_progress_post_def Let_def
+      split: sum.splits message.splits call_origin.splits option.splits if_splits can_status.splits
+      dest!: in_set_takeD in_set_dropD in_set_updD list_map_range_setD list_map_get_range list_map_range_del
+      in_set_map_filter_vals)
+
+
+
+(* State machine *)
+
+inductive ic_steps :: "'sig itself \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow>
+  nat \<Rightarrow> nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
+  ic_steps_refl: "ic_steps sig S 0 0 S"
+| request_submission: "ic_steps sig S0 minted burned S \<Longrightarrow> request_submission_pre (E :: ('b, 'p, 'uid, 'canid, 's, 'pk, 'sig) envelope) S \<Longrightarrow> ic_steps sig S0 minted (burned + request_submission_burned_cycles E S) (request_submission_post E S)"
+| request_rejection: "ic_steps sig S0 minted burned S \<Longrightarrow> request_rejection_pre (E :: ('b, 'p, 'uid, 'canid, 's, 'pk, 'sig) envelope) req code msg S \<Longrightarrow> ic_steps sig S0 minted burned (request_rejection_post E req code msg S)"
+| initiate_canister_call: "ic_steps sig S0 minted burned S \<Longrightarrow> initiate_canister_call_pre req S \<Longrightarrow> ic_steps sig S0 minted burned (initiate_canister_call_post req S)"
+| call_reject: "ic_steps sig S0 minted burned S \<Longrightarrow> call_reject_pre n S \<Longrightarrow> ic_steps sig S0 minted burned (call_reject_post n S)"
+| call_context_create: "ic_steps sig S0 minted burned S \<Longrightarrow> call_context_create_pre n ctxt_id S \<Longrightarrow> ic_steps sig S0 minted burned (call_context_create_post n ctxt_id S)"
+| call_context_heartbeat: "ic_steps sig S0 minted burned S \<Longrightarrow> call_context_heartbeat_pre cee ctxt_id S \<Longrightarrow> ic_steps sig S0 minted burned (call_context_heartbeat_post cee ctxt_id S)"
+| message_execution: "ic_steps sig S0 minted burned S \<Longrightarrow> message_execution_pre n S \<Longrightarrow> ic_steps sig S0 minted (burned + message_execution_burned_cycles n S) (message_execution_post n S)"
+| call_context_starvation: "ic_steps sig S0 minted burned S \<Longrightarrow> call_context_starvation_pre ctxt_id S \<Longrightarrow> ic_steps sig S0 minted burned (call_context_starvation_post ctxt_id S)"
+| call_context_removal: "ic_steps sig S0 minted burned S \<Longrightarrow> call_context_removal_pre ctxt_id S \<Longrightarrow> ic_steps sig S0 minted (burned + call_context_removal_burned_cycles ctxt_id S) (call_context_removal_post ctxt_id S)"
+| ic_canister_creation: "ic_steps sig S0 minted burned S \<Longrightarrow> ic_canister_creation_pre n cid t S \<Longrightarrow> ic_steps sig S0 minted burned (ic_canister_creation_post n cid t S)"
+| ic_update_settings: "ic_steps sig S0 minted burned S \<Longrightarrow> ic_update_settings_pre n S \<Longrightarrow> ic_steps sig S0 minted burned (ic_update_settings_post n S)"
+| ic_canister_status: "ic_steps sig S0 minted burned S \<Longrightarrow> ic_canister_status_pre n m S \<Longrightarrow> ic_steps sig S0 minted burned (ic_canister_status_post n m S)"
+| ic_code_installation: "ic_steps sig S0 minted burned S \<Longrightarrow> ic_code_installation_pre n S \<Longrightarrow> ic_steps sig S0 minted (burned + ic_code_installation_burned_cycles n S) (ic_code_installation_post n S)"
+| ic_code_upgrade: "ic_steps sig S0 minted burned S \<Longrightarrow> ic_code_upgrade_pre n S \<Longrightarrow> ic_steps sig S0 minted (burned + ic_code_upgrade_burned_cycles n S) (ic_code_upgrade_post n S)"
+| ic_code_uninstallation: "ic_steps sig S0 minted burned S \<Longrightarrow> ic_code_uninstallation_pre n S \<Longrightarrow> ic_steps sig S0 minted burned (ic_code_uninstallation_post n S)"
+| ic_canister_stop_running: "ic_steps sig S0 minted burned S \<Longrightarrow> ic_canister_stop_running_pre n S \<Longrightarrow> ic_steps sig S0 minted burned (ic_canister_stop_running_post n S)"
+| ic_canister_stop_stopping: "ic_steps sig S0 minted burned S \<Longrightarrow> ic_canister_stop_stopping_pre n S \<Longrightarrow> ic_steps sig S0 minted burned (ic_canister_stop_stopping_post n S)"
+| ic_canister_stop_done_stopping: "ic_steps sig S0 minted burned S \<Longrightarrow> ic_canister_stop_done_stopping_pre cid S \<Longrightarrow> ic_steps sig S0 minted burned (ic_canister_stop_done_stopping_post cid S)"
+| ic_canister_stop_stopped: "ic_steps sig S0 minted burned S \<Longrightarrow> ic_canister_stop_stopped_pre n S \<Longrightarrow> ic_steps sig S0 minted burned (ic_canister_stop_stopped_post n S)"
+| ic_canister_start_not_stopping: "ic_steps sig S0 minted burned S \<Longrightarrow> ic_canister_start_not_stopping_pre n S \<Longrightarrow> ic_steps sig S0 minted burned (ic_canister_start_not_stopping_post n S)"
+| ic_canister_start_stopping: "ic_steps sig S0 minted burned S \<Longrightarrow> ic_canister_start_stopping_pre n S \<Longrightarrow> ic_steps sig S0 minted burned (ic_canister_start_stopping_post n S)"
+| ic_canister_deletion: "ic_steps sig S0 minted burned S \<Longrightarrow> ic_canister_deletion_pre n S \<Longrightarrow> ic_steps sig S0 minted (burned + ic_canister_deletion_burned_cycles n S) (ic_canister_deletion_post n S)"
+| ic_depositing_cycles: "ic_steps sig S0 minted burned S \<Longrightarrow> ic_depositing_cycles_pre n S \<Longrightarrow> ic_steps sig S0 minted burned (ic_depositing_cycles_post n S)"
+| ic_random_numbers: "ic_steps sig S0 minted burned S \<Longrightarrow> ic_random_numbers_pre n b S \<Longrightarrow> ic_steps sig S0 minted burned (ic_random_numbers_post n b S)"
+| ic_provisional_canister_creation: "ic_steps sig S0 minted burned S \<Longrightarrow> ic_provisional_canister_creation_pre n cid t S \<Longrightarrow> ic_steps sig S0 (minted + ic_provisional_canister_creation_minted_cycles n cid t S) burned (ic_provisional_canister_creation_post n cid t S)"
+| ic_top_up_canister: "ic_steps sig S0 minted burned S \<Longrightarrow> ic_top_up_canister_pre n S \<Longrightarrow> ic_steps sig S0 (minted + ic_top_up_canister_minted_cycles n S) burned (ic_top_up_canister_post n S)"
+| callback_invocation_not_deleted: "ic_steps sig S0 minted burned S \<Longrightarrow> callback_invocation_not_deleted_pre n S \<Longrightarrow> ic_steps sig S0 minted burned (callback_invocation_not_deleted_post n S)"
+| callback_invocation_deleted: "ic_steps sig S0 minted burned S \<Longrightarrow> callback_invocation_deleted_pre n S \<Longrightarrow> ic_steps sig S0 minted burned (callback_invocation_deleted_post n S)"
+| respond_to_user_request: "ic_steps sig S0 minted burned S \<Longrightarrow> respond_to_user_request_pre n S \<Longrightarrow> ic_steps sig S0 minted (burned + respond_to_user_request_burned_cycles n S) (respond_to_user_request_post n S)"
+| request_cleanup: "ic_steps sig S0 minted burned S \<Longrightarrow> request_cleanup_pre req S \<Longrightarrow> ic_steps sig S0 minted burned (request_cleanup_post req S)"
+| request_cleanup_expired: "ic_steps sig S0 minted burned S \<Longrightarrow> request_cleanup_expired_pre req S \<Longrightarrow> ic_steps sig S0 minted burned (request_cleanup_expired_post req S)"
+| canister_out_of_cycles: "ic_steps sig S0 minted burned S \<Longrightarrow> canister_out_of_cycles_pre cid S \<Longrightarrow> ic_steps sig S0 minted burned (canister_out_of_cycles_post cid S)"
+| canister_time_progress: "ic_steps sig S0 minted burned S \<Longrightarrow> canister_time_progress_pre cid t1 S \<Longrightarrow> ic_steps sig S0 minted burned (canister_time_progress_post cid t1 S)"
+| cycle_consumption: "ic_steps sig S0 minted burned S \<Longrightarrow> cycle_consumption_pre cid b1 S \<Longrightarrow> ic_steps sig S0 minted (burned + cycle_consumption_burned_cycles cid b1 S) (cycle_consumption_post cid b1 S)"
+| system_time_progress: "ic_steps sig S0 minted burned S \<Longrightarrow> system_time_progress_pre t1 S \<Longrightarrow> ic_steps sig S0 minted burned (system_time_progress_post t1 S)"
+
+lemma total_cycles:
+  assumes "ic_steps TYPE('sig) S0 minted burned S"
+  shows "total_cycles S0 + minted = total_cycles S + burned"
+  using assms
+  apply (induction "TYPE('sig)" S0 minted burned S rule: ic_steps.induct)
+                      apply auto[1]
+  using request_submission_cycles_inv apply fastforce
+  using request_rejection_cycles_inv apply fastforce
+  using initiate_canister_call_cycles_inv apply fastforce
+  using call_reject_cycles_inv apply fastforce
+  using call_context_create_cycles_inv apply fastforce
+  using call_context_heartbeat_cycles_inv apply fastforce
+  using message_execution_cycles_monotonic apply fastforce
+  using call_context_starvation_cycles_inv apply fastforce
+  using call_context_removal_cycles_monotonic apply fastforce
+  using ic_canister_creation_cycles_inv apply fastforce
+  using ic_update_settings_cycles_inv apply fastforce
+  using ic_canister_status_cycles_inv apply fastforce
+  using ic_code_installation_cycles_inv apply fastforce
+  using ic_code_upgrade_cycles_inv apply fastforce
+  using ic_code_uninstallation_cycles_inv apply fastforce
+  using ic_canister_stop_running_cycles_inv apply fastforce
+  using ic_canister_stop_stopping_cycles_inv apply fastforce
+  using ic_canister_stop_done_stopping_cycles_inv apply fastforce
+  using ic_canister_stop_stopped_cycles_inv apply fastforce
+  using ic_canister_start_not_stopping_cycles_inv apply fastforce
+  using ic_canister_start_stopping_cycles_inv apply fastforce
+  using ic_canister_deletion_cycles_monotonic apply fastforce
+  using ic_depositing_cycles_cycles_monotonic apply fastforce
+  using ic_random_numbers_cycles_inv apply fastforce
+  using ic_provisional_canister_creation_cycles_antimonotonic apply fastforce
+  using ic_top_up_canister_cycles_antimonotonic apply fastforce
+  using callback_invocation_not_deleted_cycles_inv apply fastforce
+  using callback_invocation_deleted_cycles_inv apply fastforce
+  using respond_to_user_request_cycles_monotonic apply fastforce
+  using request_cleanup_cycles_inv apply fastforce
+  using request_cleanup_expired_cycles_inv apply fastforce
+  using canister_out_of_cycles_cycles_inv apply fastforce
+  using canister_time_progress_cycles_inv apply fastforce
+  using cycle_consumption_cycles_monotonic apply fastforce
+  using system_time_progress_cycles_inv apply fastforce
+  done
+
+lemma ic_inv:
+  assumes "ic_steps TYPE('sig) S0 minted burned S"
+  shows "ic_inv S0 \<Longrightarrow> ic_inv S"
+  using assms
+  apply (induction "TYPE('sig)" S0 minted burned S rule: ic_steps.induct)
+                      apply auto[1]
+  using request_submission_ic_inv apply fastforce
+  using request_rejection_ic_inv apply fastforce
+  using initiate_canister_call_ic_inv apply fastforce
+  using call_reject_ic_inv apply fastforce
+  using call_context_create_ic_inv apply fastforce
+  using call_context_heartbeat_ic_inv apply fastforce
+  using message_execution_ic_inv apply fastforce
+  using call_context_starvation_ic_inv apply fastforce
+  using call_context_removal_ic_inv apply fastforce
+  using ic_canister_creation_ic_inv apply fastforce
+  using ic_update_settings_ic_inv apply fastforce
+  using ic_canister_status_ic_inv apply fastforce
+  using ic_code_installation_ic_inv apply fastforce
+  using ic_code_upgrade_ic_inv apply fastforce
+  using ic_code_uninstallation_ic_inv apply fastforce
+  using ic_canister_stop_running_ic_inv apply fastforce
+  using ic_canister_stop_stopping_ic_inv apply fastforce
+  using ic_canister_stop_done_stopping_ic_inv apply fastforce
+  using ic_canister_stop_stopped_ic_inv apply fastforce
+  using ic_canister_start_not_stopping_ic_inv apply fastforce
+  using ic_canister_start_stopping_ic_inv apply fastforce
+  using ic_canister_deletion_ic_inv apply fastforce
+  using ic_depositing_cycles_ic_inv apply fastforce
+  using ic_random_numbers_ic_inv apply fastforce
+  using ic_provisional_canister_creation_ic_inv apply fastforce
+  using ic_top_up_canister_ic_inv apply fastforce
+  using callback_invocation_not_deleted_ic_inv apply fastforce
+  using callback_invocation_deleted_ic_inv apply fastforce
+  using respond_to_user_request_ic_inv apply fastforce
+  using request_cleanup_ic_inv apply fastforce
+  using request_cleanup_expired_ic_inv apply fastforce
+  using canister_out_of_cycles_ic_inv apply fastforce
+  using canister_time_progress_ic_inv apply fastforce
+  using cycle_consumption_ic_inv apply fastforce
+  using system_time_progress_ic_inv apply fastforce
+  done
 
 end
 
@@ -769,6 +2820,32 @@ export_code request_submission_pre request_submission_post
   message_execution_pre message_execution_post
   call_context_starvation_pre call_context_starvation_post
   call_context_removal_pre call_context_removal_post
+  ic_canister_creation_pre ic_canister_creation_post
+  ic_update_settings_pre ic_update_settings_post
+  ic_canister_status_pre ic_canister_status_post
+  ic_code_installation_pre ic_code_installation_post
+  ic_code_upgrade_pre ic_code_upgrade_post
+  ic_code_uninstallation_pre ic_code_uninstallation_post
+  ic_canister_stop_running_pre ic_canister_stop_running_post
+  ic_canister_stop_stopping_pre ic_canister_stop_stopping_post
+  ic_canister_stop_done_stopping_pre ic_canister_stop_done_stopping_post
+  ic_canister_stop_stopped_pre ic_canister_stop_stopped_post
+  ic_canister_start_not_stopping_pre ic_canister_start_not_stopping_post
+  ic_canister_start_stopping_pre ic_canister_start_stopping_post
+  ic_canister_deletion_pre ic_canister_deletion_post
+  ic_depositing_cycles_pre ic_depositing_cycles_post
+  ic_random_numbers_pre ic_random_numbers_post
+  ic_provisional_canister_creation_pre ic_provisional_canister_creation_post
+  ic_top_up_canister_pre ic_top_up_canister_post
+  callback_invocation_not_deleted_pre callback_invocation_not_deleted_post
+  callback_invocation_deleted_pre callback_invocation_deleted_post
+  respond_to_user_request_pre respond_to_user_request_post
+  request_cleanup_pre request_cleanup_post
+  request_cleanup_expired_pre request_cleanup_expired_post
+  canister_out_of_cycles_pre canister_out_of_cycles_post
+  canister_time_progress_pre canister_time_progress_post
+  cycle_consumption_pre cycle_consumption_post
+  system_time_progress_pre system_time_progress_post
 in Haskell module_name IC file_prefix code
 
 end

--- a/theories/IC.thy
+++ b/theories/IC.thy
@@ -1882,7 +1882,7 @@ qed
 definition ic_canister_stop_done_stopping_pre :: "'canid \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
   "ic_canister_stop_done_stopping_pre cid S =
     (case list_map_get (canister_status S) cid of Some (Stopping os) \<Rightarrow>
-      (\<forall>ctxt \<in> list_map_range (call_contexts S). call_ctxt_canister ctxt \<noteq> cid)
+      (\<forall>ctxt \<in> list_map_range (call_contexts S). call_ctxt_deleted ctxt \<or> call_ctxt_canister ctxt \<noteq> cid)
     | _ \<Rightarrow> False)"
 
 definition ic_canister_stop_done_stopping_post :: "'canid \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where

--- a/theories/ROOT
+++ b/theories/ROOT
@@ -1,0 +1,8 @@
+chapter IC
+
+session Internet_Computer (IC) = "HOL-Library" +
+  options [timeout=600]
+  theories
+    IC
+export_files (in ".") [2]
+    "Internet_Computer.IC:code/**"


### PR DESCRIPTION
Main changes:

* Canister access to performance metrics
* Query calls are rejected when the canister is frozen
* Support for implementation-specific error codes for requests
* Deleted call contexts do not prevent canister from reaching Stopped state
* Update effective canister id checks in certificate delegations
* Formal model in Isabelle

And a few clarifications and corrections.