### PR TITLE
Fix the canister id  in install/upgrade transitions

### DIFF
--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -3186,11 +3186,11 @@ Conditions::
     or A.mode = reinstall
     M.caller ∈ S.controllers[A.canister_id]
     Env = {
-      time = S.time[M.receiver];
-      balance = S.balances[M.receiver];
-      freezing_limit = freezing_limit(S, M.receiver);
+      time = S.time[A.canister_id];
+      balance = S.balances[A.canister_id];
+      freezing_limit = freezing_limit(S, A.canister_id);
       certificate = NoCertificate;
-      status = simple_status(S.canister_status[M.receiver]);
+      status = simple_status(S.canister_status[A.canister_id]);
     }
     Mod.init(A.canister_id, A.arg, M.caller, Env) = Return {new_state = New_state; cycles_used = Cycles_used;}
     Cycles_used ≤ S.balances[A.canister_id]
@@ -3228,11 +3228,11 @@ Conditions::
     M.caller ∈ S.controllers[A.canister_id]
     S.canisters[A.canister_id] = { wasm_state = Old_state; module = Old_module }
     Env = {
-      time = S.time[M.receiver];
-      balance = S.balances[M.receiver];
-      freezing_limit = freezing_limit(S, M.receiver);
+      time = S.time[A.canister_id];
+      balance = S.balances[A.canister_id];
+      freezing_limit = freezing_limit(S, A.canister_id);
       certificate = NoCertificate;
-      status = simple_status(S.canister_status[M.receiver]);
+      status = simple_status(S.canister_status[A.canister_id]);
     }
     Old_module.pre_upgrade(Old_State, M.caller, Env) = Return {stable_memory = Stable_memory; cycles_used = Cycles_used;}
     Mod.post_upgrade(A.canister_id, Stable_memory, A.arg, M.caller, Env) = Return {new_state = New_state; cycles_used = Cycles_used';}


### PR DESCRIPTION
This replaces an incorrect `M.receiver` with `A.canister_id` in
the code installation and upgrade transitions.

This closes Issue #80 