### PR TITLE
feat: a spec for reserved principals

### DIFF
--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -141,7 +141,7 @@ NOTE: Derived IDs are currently not explicitly used in this document, but they m
 +
 This has the form `0x04`, and is used for the anonymous caller. It can be used in call and query requests without a signature.
 
-5. _Invalid ids_
+5. _Reserved ids_
 +
 These have the form of `blob · 0xff`, with no restriction on the blob length.
 +

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -143,11 +143,11 @@ This has the form `0x04`, and is used for the anonymous caller. It can be used i
 
 5. _Reserved ids_
 +
-These have the form of `blob · 0xff`, with no restriction on the blob length.
+These have the form of `blob · 0xff`, `0 ≤ |blob| < 29`.
 +
 These ids can be useful for applications that want to re-use the <<textual-ids>> but want to indicate explicitly that the blob does not address any canisters or a user.
 
-When the IC creates a _fresh_ id, it never creates a self-authenticating id, an anonymous id or an id derived from what could be a canister or user.
+When the IC creates a _fresh_ id, it never creates a self-authenticating id, reserved id, an anonymous id or an id derived from what could be a canister or user.
 
 [#textual-ids]
 ==== Textual representation of principals

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -141,8 +141,13 @@ NOTE: Derived IDs are currently not explicitly used in this document, but they m
 +
 This has the form `0x04`, and is used for the anonymous caller. It can be used in call and query requests without a signature.
 
-When the IC creates a _fresh_ id, it never creates a self-authenticating id, an anonymous id or an id derived from what could be a canister or user.
+5. _Invalid ids_
++
+These have the form of `blob · 0xff`, with no restriction on the blob length.
++
+These ids can be useful for applications that want to re-use the <<textual-ids>> but want to indicate explicitly that the blob does not address any canisters or a user.
 
+When the IC creates a _fresh_ id, it never creates a self-authenticating id, an anonymous id or an id derived from what could be a canister or user.
 
 [#textual-ids]
 ==== Textual representation of principals


### PR DESCRIPTION
This change defines a way for apps to indicate that a blob is _not_ a valid principal.
This feature is particularly useful when an app wants to re-use the textual encoding for principals but does not want to confuse the system with blobs that _accidentally_ look like a valid principal (see https://github.com/dfinity/ICRC-1/pull/55 for an example).