### PR TITLE
Bitcoin fees are measured in sat/vbyte

### DIFF
--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1801,7 +1801,7 @@ The transaction fees in the Bitcoin network change dynamically based on the numb
 pending transactions.
 It must be possible for a canister to determine an adequate fee when creating a Bitcoin transaction.
 
-This function returns the 100 fee percentiles, measured in millisatoshi/byte (10^3 millisatoshi = 1 satoshi), over the last 10,000 transactions in the specified network, i.e.,
+This function returns the 100 fee percentiles, measured in millisatoshi/vbyte (1000 millisatoshi = 1 satoshi), over the last 10,000 transactions in the specified network, i.e.,
 over the transactions in the last approximately 4-10 blocks.
 
 [#certification]


### PR DESCRIPTION
In Bitcoin, fees are measured in `sat/vbyte` (as opposed to `sat/byte`). This PR makes it clear that our IC method `bitcoin_get_current_fee_percentiles` is consistent with standard Bitcoin clients and returns fee percentiles in `sat/vbyte` as well.

The concept of virtual bytes (`vbytes`) and weight units is specified [here](https://en.bitcoin.it/wiki/Weight_units).
