### PR TITLE
chore: add a case to find_label

### DIFF
--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1916,6 +1916,7 @@ find_label(l, _ · Labeled l1 t · _)                | l == l1     = Found t
 find_label(l, _ · Labeled l1 _ · Labeled l2 _ · _) | l1 < l < l2 = Absent
 find_label(l,                    Labeled l2 _ · _) |      l < l2 = Absent
 find_label(l, _ · Labeled l1 _ )                   | l1 < l      = Absent
+find_label(l, [Leaf _])                                          = Absent
 find_label(l, [])                                                = Absent
 find_label(l, _)                                                 = Unknown
 ....
@@ -1928,7 +1929,7 @@ well_formed(tree) =
 well_formed_forest(trees) =
   strictly_increasing([l | Label l _ ∈ trees]) ∧
   ∀ Label _ t ∈ trees. well_formed(t) ∧
-  ∀ t ∈ trees ≠ Leaf _
+  ∀ t ∈ trees. t ≠ Leaf _
 ....
 
 [#certification-delegation]


### PR DESCRIPTION
Add a (forgotten) case to the definition of `find_label`:
```
find_label(l, [Leaf _]) = Absent
```

Note that `well_formed(tree)` implies that either
- `tree` is `Leaf v`: then `flatten_forks(tree) = [Leaf v]` and the new case from this PR triggers (before `find_label` would return `Unknown` which is unnecessarily conservative);
- otherwise, `flatten_forks(tree)` cannot contain any tree of the form `Leaf v`; hence we don't need to care about leaves in `find_label` beyond the case `[Leaf v]`.