### PR TITLE
allow a canister to query its own status

### DIFF
--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1517,7 +1517,7 @@ Default value: 2592000 (approximately 30 days).
 [#ic-update_settings]
 === IC method `update_settings`
 
-Only _controllers_ of the canister can update settings. See <<ic-create_canister>> for a description of settings.
+Only _controllers_ of the canister, or the canister itself can update settings. See <<ic-create_canister>> for a description of settings.
 
 Not including a setting in the `settings` record means not changing that field. The defaults described above are only relevant during canister creation.
 
@@ -3122,7 +3122,7 @@ Conditions::
     M.callee = ic_principal
     M.method_name = 'update_settings'
     M.arg = candid(A)
-    M.caller ∈ S.controllers[A.canister_id]
+    M.caller ∈ S.controllers[A.canister_id] ∪ {A.canister_id}
 ....
 State after::
 ....

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -3154,7 +3154,7 @@ Conditions::
     M.callee = ic_principal
     M.method_name = 'canister_status'
     M.arg = candid(A)
-    M.caller ∈ S.controllers[A.canister_id]
+    M.caller ∈ S.controllers[A.canister_id] ∪ {A.canister_id}
 ....
 State after::
 ....

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -141,8 +141,13 @@ NOTE: Derived IDs are currently not explicitly used in this document, but they m
 +
 This has the form `0x04`, and is used for the anonymous caller. It can be used in call and query requests without a signature.
 
-When the IC creates a _fresh_ id, it never creates a self-authenticating id, an anonymous id or an id derived from what could be a canister or user.
+5. _Reserved ids_
++
+These have the form of `blob · 0xff`, `0 ≤ |blob| < 29`.
++
+These ids can be useful for applications that want to re-use the <<textual-ids>> but want to indicate explicitly that the blob does not address any canisters or a user.
 
+When the IC creates a _fresh_ id, it never creates a self-authenticating id, reserved id, an anonymous id or an id derived from what could be a canister or user.
 
 [#textual-ids]
 ==== Textual representation of principals

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -232,9 +232,9 @@ The canister status can be used to control whether the canister is processing ca
 
 In all cases, calls to the <<ic-management-canister,management canister>> are processed, regardless of the state of the managed canister.
 
-The controllers of the canister can initiate transitions between these states using <<ic-stop_canister,`stop_canister`>> and <<ic-start_canister,`start_canister`>>, and query the state using <<ic-canister_status,`canister_status`>>. The canister itself can also query its state using <<system-api-canister-status,`ic0.canister_status`>>.
+The controllers of the canister can initiate transitions between these states using <<ic-stop_canister,`stop_canister`>> and <<ic-start_canister,`start_canister`>>, and query the state using <<ic-canister_status,`canister_status`>> (NB: this call returns additional information, such as the cycle balance of the canister). The canister itself can also query its state using <<system-api-canister-status,`ic0.canister_status`>>.
 
-NOTE: This status is orthogonal to the question of whether a canister is empty or not: an empty canister can be in status `running`. Calls to such a canister are still rejected, but because the canister is empty.
+NOTE: This status is orthogonal to whether a canister is empty or not: an empty canister can be in status `running`. Calls to such a canister are still rejected, but because the canister is empty.
 
 [#signatures]
 === Signatures
@@ -1570,7 +1570,7 @@ Indicates various information about the canister. It contains:
 * The memory size taken by the canister.
 * The cycle balance of the canister.
 
-Only the controllers of the canister can request its status.
+Only the controllers of the canister or the canister itself can request its status.
 
 [#ic-stop_canister]
 === IC method `stop_canister`

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1517,7 +1517,7 @@ Default value: 2592000 (approximately 30 days).
 [#ic-update_settings]
 === IC method `update_settings`
 
-Only _controllers_ of the canister, or the canister itself can update settings. See <<ic-create_canister>> for a description of settings.
+Only _controllers_ of the canister can update settings. See <<ic-create_canister>> for a description of settings.
 
 Not including a setting in the `settings` record means not changing that field. The defaults described above are only relevant during canister creation.
 
@@ -3123,7 +3123,7 @@ Conditions::
     M.callee = ic_principal
     M.method_name = 'update_settings'
     M.arg = candid(A)
-    M.caller ∈ S.controllers[A.canister_id] ∪ {A.canister_id}
+    M.caller ∈ S.controllers[A.canister_id]
 ....
 State after::
 ....

--- a/theories/IC.thy
+++ b/theories/IC.thy
@@ -1393,7 +1393,7 @@ definition ic_update_settings_pre :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, '
       cee = ic_principal \<and>
       mn = encode_string ''update_settings'' \<and>
       (case candid_parse_cid a of Some cid \<Rightarrow>
-      (case list_map_get (controllers S) cid of Some ctrls \<Rightarrow> cer \<in> ctrls
+      (case list_map_get (controllers S) cid of Some ctrls \<Rightarrow> cer \<in> ctrls \<union> {principal_of_canid cid}
       | _ \<Rightarrow> False) | _ \<Rightarrow> False)
     | _ \<Rightarrow> False))"
 

--- a/theories/IC.thy
+++ b/theories/IC.thy
@@ -1393,7 +1393,7 @@ definition ic_update_settings_pre :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, '
       cee = ic_principal \<and>
       mn = encode_string ''update_settings'' \<and>
       (case candid_parse_cid a of Some cid \<Rightarrow>
-      (case list_map_get (controllers S) cid of Some ctrls \<Rightarrow> cer \<in> ctrls \<union> {principal_of_canid cid}
+      (case list_map_get (controllers S) cid of Some ctrls \<Rightarrow> cer \<in> ctrls
       | _ \<Rightarrow> False) | _ \<Rightarrow> False)
     | _ \<Rightarrow> False))"
 


### PR DESCRIPTION
Currently only controllers can request `canister_status` from the management canister. This PR changes the interface spec to make this query also available to the canister itself.