### PR TITLE
fix: use 0x7f for reserved principals

### DIFF
--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -143,7 +143,7 @@ This has the form `0x04`, and is used for the anonymous caller. It can be used i
 
 5. _Reserved ids_
 +
-These have the form of `blob · 0xff`, `0 ≤ |blob| < 29`.
+These have the form of `blob · 0x7f`, `0 ≤ |blob| < 29`.
 +
 These ids can be useful for applications that want to re-use the <<textual-ids>> but want to indicate explicitly that the blob does not address any canisters or a user.
 


### PR DESCRIPTION
Rationale: Timo's vision is that we might have a lot of principal types one day. Would be nice to keep the most significant bit unreserved to simplify variable-length encoding of the tag.