### PR TITLE
allow subnet id to be effective principal id

### DIFF
--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -550,7 +550,7 @@ The HTTP response to this request consists of a CBOR map with the following fiel
 
 * `certificate` (`blob`): A certificate (see <<certification>>).
 +
-If this `certificate` includes subnet delegations (possibly nested), then the `effective_principal_id` must be included in each delegation’s canister id range (see <<certification-delegation>>) or equal to the delegation’s subnet, unless
+If this `certificate` includes subnet delegations (possibly nested), then the `effective_principal_id` must be included in each delegation’s canister id range (see <<certification-delegation>>) or equal to the delegation’s subnet id, unless
 
 - the `effective_principal_id` is that of the Management Canister (`aaaaa-aa`),
 - all requested paths have `/time` or `/request_status/<request_id>` as prefix where the (single) original request referenced by `<request_id>` is an update call to the Management Canister (`aaaaa-aa`) and the method name is `provisional_create_canister_with_cycles`, and

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -448,14 +448,14 @@ It is recommended for the canister to have a custom section called "icp:public c
 
 The concrete mechanism that users use to send requests to the Internet Computer is via an HTTPS API, which exposes three endpoints to handle interactions, plus one for diagnostics:
 
-* At `/api/v2/canister/<effective_canister_id>/call` the user can submit (asynchronous, state-changing) calls.
-* At `/api/v2/canister/<effective_canister_id>/read_state` the user can read various information about the state of the Internet Computer. In particular, they can poll for the status of a call here.
-* At `/api/v2/canister/<effective_canister_id>/query` the user can perform (synchronous, non-state-changing) query calls.
+* At `/api/v2/canister/<effective_principal_id>/call` the user can submit (asynchronous, state-changing) calls.
+* At `/api/v2/canister/<effective_principal_id>/read_state` the user can read various information about the state of the Internet Computer. In particular, they can poll for the status of a call here.
+* At `/api/v2/canister/<effective_principal_id>/query` the user can perform (synchronous, non-state-changing) query calls.
 * At `/api/v2/status` the user can retrieve status information about the Internet Computer.
 
-In these paths, the `<effective_canister_id>` is the <<textual-ids,textual representation>> of the <<http-effective-canister-id,_effective_ canister id>>.
+In these paths, the `<effective_principal_id>` is the <<textual-ids,textual representation>> of the <<http-effective-principal-id,_effective_ principal id>>.
 
-Requests to `/api/v2/canister/<effective_canister_id>/call`, `/api/v2/canister/<effective_canister_id>/read_state` and `/api/v2/canister/<effective_canister_id>/query` are POST requests with a CBOR-encoded request body, which consists of a authentication envelope (as per <<authentication>>) and request-specific content as described below.
+Requests to `/api/v2/canister/<effective_principal_id>/call`, `/api/v2/canister/<effective_principal_id>/read_state` and `/api/v2/canister/<effective_principal_id>/query` are POST requests with a CBOR-encoded request body, which consists of a authentication envelope (as per <<authentication>>) and request-specific content as described below.
 
 NOTE: This document does not yet explain how to find the location and port of the Internet Computer.
 
@@ -522,7 +522,7 @@ When asking the IC about the state or call of a request, the user uses the reque
 [#http-call]
 === Request: Call
 
-In order to call a canister, the user makes a POST request to `/api/v2/canister/<effective_canister_id>/call`. The request body consists of an authentication envelope with a `content` map with the following fields:
+In order to call a canister, the user makes a POST request to `/api/v2/canister/<effective_principal_id>/call`. The request body consists of an authentication envelope with a `content` map with the following fields:
 
 * `request_type` (`text`): Always `call`
 * `sender`, `nonce`, `ingress_expiry`: See <<authentication>>
@@ -540,7 +540,7 @@ NOTE: The functionality exposed via the <<ic-management-canister>> can be used t
 [#http-read-state]
 === Request: Read state
 
-In order to read parts of the <<state-tree>>, the user makes a POST request to `/api/v2/canister/<effective_canister_id>/read_state`. The request body consists of an authentication envelope with a `content` map with the following fields:
+In order to read parts of the <<state-tree>>, the user makes a POST request to `/api/v2/canister/<effective_principal_id>/read_state`. The request body consists of an authentication envelope with a `content` map with the following fields:
 
 * `request_type` (`text`): Always `read_state`
 * `sender`, `nonce`, `ingress_expiry`: See <<authentication>>
@@ -550,9 +550,9 @@ The HTTP response to this request consists of a CBOR map with the following fiel
 
 * `certificate` (`blob`): A certificate (see <<certification>>).
 +
-If this `certificate` includes subnet delegations (possibly nested), then the `effective_canister_id` must be included in each delegation’s canister id range (see <<certification-delegation>>), unless
+If this `certificate` includes subnet delegations (possibly nested), then the `effective_principal_id` must be included in each delegation’s canister id range (see <<certification-delegation>>) or equal to the delegation’s subnet, unless
 
-- the `effective_canister_id` is that of the Management Canister (`aaaaa-aa`),
+- the `effective_principal_id` is that of the Management Canister (`aaaaa-aa`),
 - all requested paths have `/time` or `/request_status/<request_id>` as prefix where the (single) original request referenced by `<request_id>` is an update call to the Management Canister (`aaaaa-aa`) and the method name is `provisional_create_canister_with_cycles`, and
 - whenever the certificate contains the path `/request_status/<request_id>/reply`, then its value is a Candid-encoded record with a `canister_id` field of type `principal` and the `canister_id` must be included in each delegation’s canister id range.
 
@@ -562,10 +562,12 @@ All requested paths must have one of the following paths as prefix:
 
  * `/time`. Can be requested by anyone.
  * `/subnet`. Can be requested by anyone.
- * `/request_status/<request_id>`. Can only be requested by the same sender as the original request referenced by `<request_id>` and if the effective canister id of the original request matches `<effective_canister_id>`.
- * `/canisters/<canister_id>/module_hash`. Can be requested by anyone if `<canister_id>` matches `<effective_canister_id>`.
- * `/canisters/<canister_id>/controllers`. Can be requested by anyone if `<canister_id>` matches `<effective_canister_id>`. The order may vary depending on the implementation.
- * `/canisters/<canister_id>/metadata/<name>`. Can be requested by anyone if `<canister_id>` matches `<effective_canister_id>` and `<name>` is a public custom section. If `<name>` is a private custom section, it can only be requested by the controllers of the canister.
+ * `/request_status/<request_id>`. Can only be requested by the same sender as the original request referenced by `<request_id>` and if the effective principal id of the original request matches `<effective_principal_id>`.
+ * `/canisters/<canister_id>/module_hash`. Can be requested by anyone if `<canister_id>` matches `<effective_principal_id>`.
+ * `/canisters/<canister_id>/controllers`. Can be requested by anyone if `<canister_id>` matches `<effective_principal_id>`. The order of controllers in the value at this path may vary depending on the implementation.
+ * `/canisters/<canister_id>/metadata/<name>`. Can be requested by anyone if
+   - `<canister_id>` matches `<effective_principal_id>`;
+   - `<name>` is a public custom section or `<name>` is a private custom section and the sender is a controller of the canister.
 
 Note that the paths `/canisters/<canister_id>/certified_data` are not accessible with this method; these paths are only exposed to the canister themselves via the System API (see <<system-api-certified-data>>).
 
@@ -576,7 +578,7 @@ See <<state-tree>> for details on the state tree.
 
 A query call is a fast, but less secure way to call a canister. Only methods that are explicitly marked as “query methods” by the canister can be called this way.
 
-In order to make a query call to canister, the user makes a POST request to `/api/v2/canister/<effective_canister_id>/query`. The request body consists of an authentication envelope with a `content` map with the following fields:
+In order to make a query call to canister, the user makes a POST request to `/api/v2/canister/<effective_principal_id>/query`. The request body consists of an authentication envelope with a `content` map with the following fields:
 
 * `request_type` (`text`): Always `query`
 * `sender`, `nonce`, `ingress_expiry`: See <<authentication>>
@@ -598,28 +600,28 @@ If the call resulted in a reject, the response is a CBOR map with the following 
 
 Canister methods that do not change the canister state can be executed more efficiently. This method provides that ability, and returns the canister’s response directly within the HTTP response.
 
-[#http-effective-canister-id]
-=== Effective canister id
+[#http-effective-principal-id]
+=== Effective principal id
 
-The `<effective_canister_id>` in the URL paths of requests is the _effective_ destination of the request.
+The `<effective_principal_id>` in the URL paths of requests is the _effective_ destination of the request.
 
 * If the request is an update call to the Management Canister (`aaaaa-aa`), then:
-   - If the call is to the `provisional_create_canister_with_cycles` method, then any principal can be used as the effective canister id for this call.
-   - Otherwise, if the `arg` is a Candid-encoded record with a `canister_id` field of type `principal`, then the effective canister id must be that principal.
-   - Otherwise, the call is rejected by the system independently of the effective canister id.
+   - If the call is to the `provisional_create_canister_with_cycles` method, then any principal can be used as the effective principal id for this call.
+   - Otherwise, if the `arg` is a Candid-encoded record with a `canister_id` field of type `principal`, then the effective principal id must be that principal.
+   - Otherwise, the call is rejected by the system independently of the effective principal id.
 
-* If the request is an update call to a canister that is not the Management Canister (`aaaaa-aa`) or if the request is a query call, then the effective canister id must be the `canister_id` in the request.
+* If the request is an update call to a canister that is not the Management Canister (`aaaaa-aa`) or if the request is a query call, then the effective principal id must be the `canister_id` in the request.
 
 +
 [NOTE]
 ====
 The expectation is that user-side agent code shields users and developers from the notion of effective canister ID, in analogy to how the System API interface shields canister developers from worrying about routing.
 
-The Internet Computer blockchain mainnet rejects all requests whose effective canister id is in no subnet's canister ranges, independently of whether the remaining conditions on the effective canister id are satisfied.
+The Internet Computer blockchain mainnet rejects all requests whose effective principal id is in no subnet's canister ranges, independently of whether the remaining conditions on the effective principal id are satisfied.
 
-The Internet Computer blockchain mainnet does not support `provisional_create_canister_with_cycles` and thus all calls to this method are rejected independently of the effective canister id.
+The Internet Computer blockchain mainnet does not support `provisional_create_canister_with_cycles` and thus all calls to this method are rejected independently of the effective principal id.
 
-In development instances of the Internet Computer Protocol (e.g. testnets), the effective canister id of a request submitted to a node must be a canister id from the canister ranges of the subnet to which the node belongs, unless the request is an update call to the Management Canister (`aaaaa-aa`), the method name is `provisional_create_canister_with_cycles`, and the effective canister id is that of the Management Canister (`aaaaa-aa`).
+In development instances of the Internet Computer Protocol (e.g. testnets), the effective principal id of a request submitted to a node must be a canister id from the canister ranges of the subnet to which the node belongs or the subnet id of the subnet to which the node belongs, unless the request is an update call to the Management Canister (`aaaaa-aa`), the method name is `provisional_create_canister_with_cycles`, and the effective principal id is that of the Management Canister (`aaaaa-aa`).
 ====
 
 [#authentication]
@@ -2642,14 +2644,15 @@ delegated_senders(D)
     else D.senders
 ....
 
-==== Effective canister ids
+==== Effective principal ids
 
-A `Request` has an effective canister id according to the rules in <<#http-effective-canister-id>>:
+A `Request` has an effective principal id according to the rules in <<#http-effective-principal-id>>:
 
 ....
-is_effective_canister_id(Request {canister_id = ic_principal, method = provisional_create_canister_with_cycles, p)
-is_effective_canister_id(Request {canister_id = ic_principal, arg = candid({canister_id = p, …}), …}, p)
-is_effective_canister_id(Request {canister_id = p, …}, p), if p ≠ ic_principal
+//TODO is_effective_principal_id(Request {canister_id = ic_principal, arg = candid({subnet_id = p, …}), method = provisional_create_canister_with_cycles, p)
+is_effective_principal_id(Request {canister_id = ic_principal, method = provisional_create_canister_with_cycles, p)
+is_effective_principal_id(Request {canister_id = ic_principal, arg = candid({canister_id = p, …}), …}, p)
+is_effective_principal_id(Request {canister_id = p, …}, p), if p ≠ ic_principal
 ....
 
 ==== API Request submission
@@ -2678,7 +2681,7 @@ Conditions::
     E.content.canister_id ∈ verify_envelope(E, E.content.sender, S.system_time)
     E.content ∉ dom(S.requests)
     S.system_time <= E.content.ingress_expiry
-    is_effective_canister_id(E.content, ECID)
+    is_effective_principal_id(E.content, ECID)
     ( E.content.canister_id = ic_principal
       E.content.arg = candid({canister_id = CanisterId, …})
       E.content.sender ∈ S.controllers[CanisterId]
@@ -3784,7 +3787,7 @@ Conditions::
 ....
   E.content = CanisterQuery Q
   Q.canister_id ∈ verify_envelope(E, Q.sender, S.system_time)
-  is_effective_canister_id(E.content, ECID)
+  is_effective_principal_id(E.content, ECID)
   S.system_time <= Q.ingress_expiry
   S.canisters[Q.canister_id] ≠ EmptyCanister
   S.canister_status[Q.canister_id] = Running ∧ S.balances[Q.canister_id] >= freezing_limit(S, Q.canister_id)
@@ -3840,7 +3843,7 @@ The predicate `may_read_path` is defined as follows, implementing the access con
 may_read_path(S, _, ["time"]) = True
 may_read_path(S, _, ["request_status", Rid] · _) =
   if ∃ R ∈ S.requests ∧ hash_of_map(R) = Rid
-  then RS.sender == R.sender ∧ is_effective_canister_id(R, ECID)
+  then RS.sender == R.sender ∧ is_effective_principal_id(R, ECID)
   else True
 may_read_path(S, _, ["canister", cid, "module_hash"]) = cid == ECID
 may_read_path(S, _, ["canister", cid, "controllers"]) = cid == ECID


### PR DESCRIPTION
To avoid the special case of update calls to the Management Canister (`aaaaa-aa`) with the method name `provisional_create_canister_with_cycles` and the effective canister id equal to that of the Management Canister (`aaaaa-aa`), I propose to change the specification and implementation in several steps as follows:

1. the specification is relaxed (this PR):
- rename effective *canister* id to effective *principal* id
- effective principal id can be equal to subnet id for requests submitted to nodes in testnets
- effective principal id can be equal to subnet id in certificate delegation checking

2. checks in `agent-rs` are relaxed according to the relaxed specification

3. IC testnet (and potentially also boundary node) implementation is incrementally updated

4. the specification is tightened (future PR) to avoid the special case

5. checks in `agent-rs` are tightened according to the tightened specification