### PR TITLE
add a remark on utf-8 encoding of custom section names

### DIFF
--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -879,6 +879,7 @@ In order for a WebAssembly module to be usable as the code for the canister, it 
 * If it exports any functions called `canister_update <name>` or `canister_query <name>` for some `name`, the functions must have type `+() -> ()+`.
 * It may not export both `canister_update <name>` and `canister_query <name>` with the same `name`.
 * It may not export other methods the names of which start with the prefix `canister_` besides the methods allowed above.
+* Every custom section name of the form `icp:public <name>` or `icp:private <name>` must be encoded in UTF-8 (the actual content of the custom section need not be encoded in UTF-8).
 * It may not have both `icp:public <name>` and `icp:private <name>` with the same `name` as the custom section name.
 * It may not have other custom sections the names of which start with the prefix `icp:` besides the `icp:public ` and `icp:private `.
 * The IC may reject WebAssembly modules that


### PR DESCRIPTION
The additional constraint is implemented in ic-ref and on the mainnet and tested in ic-ref-test so it is added for documentation purposes.