### PR TITLE
http_request: Add transform context

### DIFF
--- a/spec/ic.did
+++ b/spec/ic.did
@@ -115,9 +115,9 @@ service ic : {
     method : variant { get; head; post };
     headers: vec http_header;
     body : opt blob;
-    transform_context: blob;
-    transform : opt variant {
-      function: func (http_response, blob) -> (http_response) query
+    transform : opt record {
+      function: func (record { response: http_response; context: blob }) -> (http_response) query;
+      context: blob
     };
   }) -> (http_response);
 

--- a/spec/ic.did
+++ b/spec/ic.did
@@ -115,8 +115,9 @@ service ic : {
     method : variant { get; head; post };
     headers: vec http_header;
     body : opt blob;
+    transform_context: blob;
     transform : opt variant {
-      function: func (http_response) -> (http_response) query
+      function: func (http_response, blob) -> (http_response) query
     };
   }) -> (http_response);
 

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1683,6 +1683,8 @@ The returned response (and the response provided to the `transform` function, if
 The `transform` function may, for example, transform the body in any way, add or remove headers, modify headers, etc.
 When the transform function was invoked due to a canister HTTP request, the caller's identity is the principal of the management canister.
 
+NOTE: The `transform` function is invoked by the management canister (`aaaaa-aa`). This information can be used by developers to implement access control mechanism for this function.
+
 [#ic-provisional_create_canister_with_cycles]
 === IC method `provisional_create_canister_with_cycles`
 

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1672,8 +1672,7 @@ The following parameters should be supplied for the call:
 - `method` - currently, only GET, HEAD, and POST are supported
 - `headers` - list of HTTP request headers and their corresponding values
 - `body` - optional, the content of the request's body
-- `transform_context` - a byte-encoded context that is provided to the `transform` function, along with the response
-- `transform` - an optional function that transforms raw responses to sanitized responses. If provided, the calling canister itself must export this function.
+- `transform` - an optional record that includes a function that transforms raw responses to sanitized responses, and a byte-encoded context that is provided to the function upon invocation, along with the response to be sanitized. If provided, the calling canister itself must export this function.
 
 The returned response (and the response provided to the `transform` function, if specified) contains the following fields:
 

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1683,7 +1683,7 @@ The returned response (and the response provided to the `transform` function, if
 The `transform` function may, for example, transform the body in any way, add or remove headers, modify headers, etc.
 When the transform function was invoked due to a canister HTTP request, the caller's identity is the principal of the management canister.
 
-NOTE: The `caller_id` for a valid invocation of the `transform` function is `aaaaa-aa`. This information can be used by developers to implement access control mechanism for this function.
+NOTE: The identity of the caller for a valid invocation of the `transform` function is `aaaaa-aa`. This information can be used by developers to implement access control mechanism for this function.
 
 [#ic-provisional_create_canister_with_cycles]
 === IC method `provisional_create_canister_with_cycles`

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1671,6 +1671,8 @@ The following parameters should be supplied for the call:
 - `max_response_bytes` - optional, specifies the maximal size of the response in bytes. Any value less than or equal to `2MiB` is accepted. The call will be charged based on this parameter. If not provided, the maximum of `2MiB` will be used.
 - `method` - currently, only GET, HEAD, and POST are supported
 - `headers` - list of HTTP request headers and their corresponding values
+- `body` - optional, the content of the request's body
+- `transform_context` - a byte-encoded context that is provided to the `transform` function, along with the response
 - `transform` - an optional function that transforms raw responses to sanitized responses. If provided, the calling canister itself must export this function.
 
 The returned response (and the response provided to the `transform` function, if specified) contains the following fields:

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1683,7 +1683,7 @@ The returned response (and the response provided to the `transform` function, if
 The `transform` function may, for example, transform the body in any way, add or remove headers, modify headers, etc.
 When the transform function was invoked due to a canister HTTP request, the caller's identity is the principal of the management canister.
 
-NOTE: The `transform` function is invoked by the management canister (`aaaaa-aa`). This information can be used by developers to implement access control mechanism for this function.
+NOTE: The `caller_id` for a valid invocation of the `transform` function is `aaaaa-aa`. This information can be used by developers to implement access control mechanism for this function.
 
 [#ic-provisional_create_canister_with_cycles]
 === IC method `provisional_create_canister_with_cycles`

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -143,7 +143,7 @@ This has the form `0x04`, and is used for the anonymous caller. It can be used i
 
 5. _Reserved ids_
 +
-These have the form of `blob · 0xff`, `0 ≤ |blob| < 29`.
+These have the form of `blob · 0x7f`, `0 ≤ |blob| < 29`.
 +
 These ids can be useful for applications that want to re-use the <<textual-ids>> but want to indicate explicitly that the blob does not address any canisters or a user.
 


### PR DESCRIPTION
It has been decided to add a blob that represents any necessary context for the transform function, as an argument for the http_request method, and for the transform function.