### PR TITLE
Add custom DNS argument to HTTP outcalls

### DIFF
--- a/spec/ic.did
+++ b/spec/ic.did
@@ -111,6 +111,7 @@ service ic : {
   raw_rand : () -> (blob);
   http_request : (record {
     url : text;
+    custom_dns: opt text;
     max_response_bytes: opt nat64;
     method : variant { get; head; post };
     headers: vec http_header;

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1665,7 +1665,7 @@ The `2MiB` size limit also applies to the value returned by the `transform` func
 The following parameters should be supplied for the call:
 
 - `url` - the requested URL. The URL may specify a custom port number. However, only ports 80, 443, and 20000-65535 can be used.
-- `custom_dns` - optional, specifies a DNS server to be used for address resolution. This must be a valid IPv6 address of a public DNS server.
+- `custom_dns` - optional, specifies a DNS server to be used for address resolution. This must be a valid IPv6 address of a public DNS server (e.g., `2001:4860:4860::8888`).
 - `max_response_bytes` - optional, specifies the maximal size of the response in bytes. Any value less than or equal to `2MiB` is accepted. The call will be charged based on this parameter. If not provided, the maximum of `2MiB` will be used.
 - `method` - currently, only GET, HEAD, and POST are supported
 - `headers` - list of HTTP request headers and their corresponding values

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1665,6 +1665,7 @@ The `2MiB` size limit also applies to the value returned by the `transform` func
 The following parameters should be supplied for the call:
 
 - `url` - the requested URL. The URL may specify a custom port number. However, only ports 80, 443, and 20000-65535 can be used.
+- `custom_dns` - optional, specifies a DNS server to be used for address resolution. This must be a valid IPv6 address of a public DNS server.
 - `max_response_bytes` - optional, specifies the maximal size of the response in bytes. Any value less than or equal to `2MiB` is accepted. The call will be charged based on this parameter. If not provided, the maximum of `2MiB` will be used.
 - `method` - currently, only GET, HEAD, and POST are supported
 - `headers` - list of HTTP request headers and their corresponding values


### PR DESCRIPTION
This PR adds an optional argument for HTTP outcalls to specify a custom DNS resolver that will be used with the corresponding call. This is now under development.