### PR TITLE
Introduce a canister state counter

### DIFF
--- a/spec/ic0.txt
+++ b/spec/ic0.txt
@@ -23,6 +23,7 @@ ic0.canister_self_copy : (dst : i32, offset : i32, size : i32) -> ();       // *
 ic0.canister_cycle_balance : () -> i64;                                     // *
 ic0.canister_cycle_balance128 : (dst : i32) -> ();                          // *
 ic0.canister_status : () -> i32;                                            // *
+ic0.canister_state_counter : () -> i64;                                     // *
 
 ic0.msg_method_name_size : () -> i32;                                       // F
 ic0.msg_method_name_copy : (dst : i32, offset : i32, size : i32) -> ();     // F

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -2307,7 +2307,6 @@ MethodCall = {
   arg: Blob;
   transferred_cycles: Nat;
   callback: Callback;
-  canister_state_counter: CanisterStateCounter;
 }
 
 UpdateFunc = WasmState -> Trap { cycles_used : Nat; } | Return {
@@ -4422,7 +4421,6 @@ ic0.call_new<es>(
       on_reject = Closure { fun = reject_fun; env = reject_env }
       on_cleanup = NoClosure
     };
-    canister_state_counter = es.params.sysenv.canister_state_counter;
   }
 
 ic0.call_data_append<es> (src : i32, size : i32) =

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1103,7 +1103,7 @@ Status `3` (stopped) can be observed, for example, in `canister_pre_upgrade` and
 [#system-api-canister-state-counter]
 === Canister state counter
 
-For each canister, the system maintains a _state counter_. Upon canister creation, it is set to 0, and it is incremented upon every change to the canister's state (except for changes affecting only the canister's balance or time), i.e., upon every (successful and unsuccessful) message execution (ingress message, inter-canister call, callback execution) on that canister, successful management canister call (`update_settings`, `install_code`, `uninstall_code`, `stop_canister`, `start_canister`, `deposit_cycles`, and `provisional_top_up_canister`) on that canister, change of the canister status of that canister from stopping to stopped, code uninstallation due to that canister running out of cycles, successful `inspect_message` execution for ingress messages, and charging canisters for (compute and memory) resource allocation and usage.
+For each canister, the system maintains a _state counter_. Upon canister creation, it is set to 0, and it is guaranteed to be incremented upon every change to the canister's state (except for changes affecting only the canister's time), i.e., upon every (successful and unsuccessful) message execution (ingress message, inter-canister call, callback execution) on that canister, successful management canister call (`update_settings`, `install_code`, `uninstall_code`, `stop_canister`, `start_canister`, `deposit_cycles`, and `provisional_top_up_canister`) on that canister, change of the canister status of that canister from stopping to stopped, code uninstallation due to that canister running out of cycles, successful `inspect_message` execution for ingress messages, and charging canisters for (compute and memory) resource allocation and usage. The system can arbitrarily increment the state counter also if the canister's state does not change.
 
 * `ic0.canister_state_counter : () -> i64`
 +
@@ -3768,7 +3768,7 @@ S with
 ....
 
 
-==== Time progressing and cycle consumption
+==== Time progressing, cycle consumption, and canister state counter increments
 
 Time progresses. Abstractly, it does so independently for each canister, and in unspecified intervals.
 
@@ -3808,6 +3808,19 @@ State after::
 ....
 S with
     system_time = T1
+....
+
+Finally, the canister state counter can be incremented arbitrarily:
+
+Conditions::
+....
+    N0 = S.canister_state_counter[CanisterId]
+    N1 > N0
+....
+State after::
+....
+S with
+    canister_state_counter[CanisterId] = N1
 ....
 
 ==== Query call

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1103,7 +1103,7 @@ Status `3` (stopped) can be observed, for example, in `canister_pre_upgrade` and
 [#system-api-canister-state-counter]
 === Canister state counter
 
-For each canister, the system maintains a _state counter_. Upon canister creation, it is set to 0, and it is incremented upon every change to the canister's state (except for changes affecting only the canister's balance or time), i.e., upon every successful message execution on that canister, successful management canister call (`update_settings`, `install_code`, `uninstall_code`, `stop_canister`, `start_canister`) on that canister, canister status (running, stopping, stopped) change of that canister, and code uninstallation due to that canister running out of cycles.
+For each canister, the system maintains a _state counter_. Upon canister creation, it is set to 0, and it is incremented upon every change to the canister's state (except for changes affecting only the canister's balance or time), i.e., upon every (successful and unsuccessful) message execution (ingress message, inter-canister call, callback execution) on that canister, successful management canister call (`update_settings`, `install_code`, `uninstall_code`, `stop_canister`, `start_canister`, `deposit_cycles`, and `provisional_top_up_canister`) on that canister, change of the canister status of that canister from stopping to stopped, code uninstallation due to that canister running out of cycles, successful `inspect_message` execution for ingress messages, and charging canisters for (compute and memory) resource allocation and usage.
 
 * `ic0.canister_state_counter : () -> i64`
 +
@@ -2721,6 +2721,7 @@ S with
     requests[E.content] = Received
     if E.content.canister_id ≠ ic_principal then
       balances[E.content.canister_id] = S.balances[E.content.canister_id] - Cycles_used
+      canister_state_counter[E.content.canister_id] = S.canister_state_counter[E.content.canister_id] + 1
 ....
 
 NOTE: This is not instantaneous (the IC takes some time to agree it accepts the request) nor guaranteed (a node could just drop the request, or maybe it did not pass validation). But once the request has entered the IC state like this, it will be acted upon.
@@ -2784,7 +2785,7 @@ Conditions::
 
 State after::
 ....
-    S.messages = Older_messages · Younger_messages  ·
+    messages = Older_messages · Younger_messages  ·
       ResponseMessage {
           origin = CM.origin;
           response = Reject (CANISTER_ERROR, "canister not running");
@@ -2973,6 +2974,7 @@ else
     balances[M.receiver] =
       (S.balances[M.receiver] + (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE))
       - min (R.cycles_used, (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE))
+    canister_state_counter[M.receiver] = S.canister_state_counter[M.receiver] + 1
 ....
 
 
@@ -3544,6 +3546,7 @@ State after::
 S with
     balances[A.canister_id] =
       S.balances[A.canister_id] + M.transferred_cycles
+    canister_state_counter[A.canister_id] = S.canister_state_counter[A.canister_id] + 1
     messages = Older_messages · Younger_messages ·
       ResponseMessage {
         origin = M.origin
@@ -3626,6 +3629,7 @@ State after::
 ....
 S with
     balances[A.canister_id] = S.balances[A.canister_id] + A.amount
+    canister_state_counter[A.canister_id] = S.canister_state_counter[A.canister_id] + 1
 ....
 
 ==== Callback invocation
@@ -3790,6 +3794,7 @@ State after::
 ....
 S with
     balances[CanisterId] = B1
+    canister_state_counter[CanisterId] = S.canister_state_counter[CanisterId] + 1
 ....
 
 Similarly, the system time, used to expire requests, progresses:

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1100,6 +1100,15 @@ Status `1` indicates running, `2` indicates stopping, and `3` indicates stopped.
 +
 Status `3` (stopped) can be observed, for example, in `canister_pre_upgrade` and can be used to prevent accidentally upgrading a canister that is not fully stopped.
 
+[#system-api-canister-state-counter]
+=== Canister state counter
+
+For each canister, the system maintains a _state counter_. Upon canister creation, it is set to 0, and it is incremented upon every change to the canister's state (except for changes affecting only the canister's balance or time), i.e., upon every successful message execution on that canister, successful management canister call (`update_settings`, `install_code`, `uninstall_code`, `stop_canister`, `start_canister`) on that canister, canister status (running, stopping, stopped) change of that canister, and code uninstallation due to that canister running out of cycles.
+
+* `ic0.canister_state_counter : () -> i64`
++
+returns the current value of the state counter.
+
 [#system-api-call]
 === Inter-canister method calls
 
@@ -2280,12 +2289,14 @@ Arg = Blob;
 CallerId = Principal;
 
 Timestamp = Nat;
+CanisterStateCounter = Nat;
 Env = {
   time : Timestamp
   balance : Nat;
   freezing_limit : Nat;
-  certificate : NoCertificate | Blob
-  status : Running | Stopping | Stopped
+  certificate : NoCertificate | Blob;
+  status : Running | Stopping | Stopped;
+  canister_state_counter : CanisterStateCounter;
 }
 
 RejectCode = Nat
@@ -2296,6 +2307,7 @@ MethodCall = {
   arg: Blob;
   transferred_cycles: Nat;
   callback: Callback;
+  canister_state_counter: CanisterStateCounter;
 }
 
 UpdateFunc = WasmState -> Trap { cycles_used : Nat; } | Return {
@@ -2524,6 +2536,7 @@ S = {
   controllers : CanisterId ↦ Set Principal;
   freezing_threshold : CanisterId ↦ Nat;
   canister_status: CanisterId ↦ CanStatus;
+  canister_state_counter: CanisterId ↦ CanisterStateCounter;
   time : CanisterId ↦ Timestamp;
   balances: CanisterId ↦ Nat;
   certified_data: CanisterId ↦ Blob;
@@ -2551,6 +2564,7 @@ The initial state of the IC is
   controllers = ();
   freezing_threshold = ();
   canister_status = ();
+  canister_state_counter = ();
   time = ();
   balances = ();
   certified_data = ();
@@ -2695,6 +2709,7 @@ Conditions::
         freezing_limit = freezing_limit(S, E.content.canister_id);
         certificate = NoCertificate;
         status = simple_status(S.canister_status[E.content.canister_id]);
+        canister_state_counter = S.canister_state_counter[E.content.canister_id];
       }
       S.canisters[E.content.canister_id].module.inspect_message
         (E.content.method_name, S.canisters[E.content.canister_id].wasm_state, E.content.arg, E.content.sender, Env) = Return {status = Accept; cycles_used = Cycles_used;}
@@ -2885,6 +2900,7 @@ Conditions::
       freezing_limit = freezing_limit(S, M.receiver);
       certificate = NoCertificate;
       status = simple_status(S.canister_status[M.receiver]);
+      canister_state_counter = S.canister_state_counter[M.receiver];
     }
 
     Available = S.call_contexts[M.call_contexts].available_cycles
@@ -2951,6 +2967,7 @@ then
       certified_data[M.receiver] = res.new_certified_data
 
     balances[M.receiver] = New_balance
+    canister_state_counter[M.receiver] = S.canister_state_counter[M.receiver] + 1
 else
   S with
     messages = Older_messages · Younger_messages
@@ -3097,6 +3114,7 @@ S with
         refunded_cycles = 0
       }
     canister_status[CanisterId] = Running
+    canister_state_counter[CanisterId] = 0
 ....
 
 This uses the predicate
@@ -3134,6 +3152,7 @@ S with
       controllers[A.canister_id] = A.settings.controllers
     if A.settings.freezing_threshold is not null:
       freezing_threshold[A.canister_id] = A.settings.freezing_threshold
+    canister_state_counter[A.canister_id] = S.canister_state_counter[A.canister_id] + 1
     messages = Older_messages · Younger_messages ·
       ResponseMessage {
         origin = M.origin
@@ -3203,6 +3222,7 @@ Conditions::
       freezing_limit = freezing_limit(S, A.canister_id);
       certificate = NoCertificate;
       status = simple_status(S.canister_status[A.canister_id]);
+      canister_state_counter = S.canister_state_counter[A.canister_id];
     }
     Mod.init(A.canister_id, A.arg, M.caller, Env) = Return {new_state = New_state; cycles_used = Cycles_used;}
     Cycles_used ≤ S.balances[A.canister_id]
@@ -3220,6 +3240,7 @@ S with
       private_custom_sections = Private_custom_sections;
     }
     balances[A.canister_id] = S.balances[A.canister_id] - Cycles_used
+    canister_state_counter[A.canister_id] = S.canister_state_counter[A.canister_id] + 1
     messages = Older_messages · Younger_messages ·
       ResponseMessage {
         origin = M.origin;
@@ -3251,6 +3272,7 @@ Conditions::
       freezing_limit = freezing_limit(S, A.canister_id);
       certificate = NoCertificate;
       status = simple_status(S.canister_status[A.canister_id]);
+      canister_state_counter = S.canister_state_counter[A.canister_id];
     }
     Old_module.pre_upgrade(Old_State, M.caller, Env) = Return {stable_memory = Stable_memory; cycles_used = Cycles_used;}
     Mod.post_upgrade(A.canister_id, Stable_memory, A.arg, M.caller, Env) = Return {new_state = New_state; cycles_used = Cycles_used';}
@@ -3268,6 +3290,7 @@ S with
       private_custom_sections = Private_custom_sections;
     }
     balances[A.canister_id] = S.balances[A.canister_id] - (Cycles_used + Cycles_used');
+    canister_state_counter[A.canister_id] = S.canister_state_counter[A.canister_id] + 1
     messages = Older_messages · Younger_messages ·
       ResponseMessage {
         origin = M.origin;
@@ -3295,6 +3318,7 @@ State after::
 S with
     canisters[A.canister_id] = EmptyCanister
     certified_data[A.canister_id] = ""
+    canister_state_counter[A.canister_id] = S.canister_state_counter[A.canister_id] + 1
 
     messages = Older_messages · Younger_messages ·
       ResponseMessage {
@@ -3344,6 +3368,7 @@ State after::
 S with
     messages = Older_messages · Younger_messages
     canister_status[A.canister_id] = Stopping [(M.origin, M.transferred_cycles)]
+    canister_state_counter[A.canister_id] = S.canister_state_counter[A.canister_id] + 1
 ....
 
 The next two transitions record any additional 'stop_canister' requests that arrive at a stopping (or stopped) canister in its status.
@@ -3363,6 +3388,7 @@ State after::
 S with
     messages = Older_messages · Younger_messages
     canister_status[A.canister_id] = Stopping (Origins · [(M.origin, M.transferred_cycles)])
+    canister_state_counter[A.canister_id] = S.canister_state_counter[A.canister_id] + 1
 ....
 
 
@@ -3370,13 +3396,14 @@ The status of a stopping canister which has no open call contexts that are not m
 
 Conditions::
 ....
-    S.canister_status[Canister_id] = Stopping Origins
-    ∀ Ctxt_id. S.call_contexts[Ctxt_id].deleted or S.call_contexts[Ctxt_id].canister ≠ Canister_id
+    S.canister_status[CanisterId] = Stopping Origins
+    ∀ Ctxt_id. S.call_contexts[Ctxt_id].deleted or S.call_contexts[Ctxt_id].canister ≠ CanisterId
 ....
 State after::
 ....
 S with
     canister_status[CanisterId] = Stopped
+    canister_state_counter[CanisterId] = S.canister_state_counter[CanisterId] + 1
     messages = S.Messages ·
         [ ResponseMessage {
             origin = O
@@ -3402,6 +3429,7 @@ Conditions::
 State after::
 ....
 S with
+    canister_state_counter[A.canister_id] = S.canister_state_counter[A.canister_id] + 1
     messages = Older_messages · Younger_messages ·
       ResponseMessage {
         origin = M.origin;
@@ -3428,6 +3456,7 @@ State after::
 ....
 S with
     canister_status[A.canister_id] = Running
+    canister_state_counter[A.canister_id] = S.canister_state_counter[A.canister_id] + 1
     messages = Older_messages · Younger_messages ·
         ResponseMessage{
             origin = M.origin
@@ -3453,6 +3482,7 @@ State after::
 ....
 S with
     canister_status[A.canister_id] = Running
+    canister_state_counter[A.canister_id] = S.canister_state_counter[A.canister_id] + 1
     messages = Older_messages · Younger_messages ·
         ResponseMessage{
             origin = M.origin
@@ -3487,6 +3517,7 @@ S with
     controllers[A.canister_id] = (deleted)
     freezing_threshold[A.canister_id] = (deleted)
     canister_status[A.canister_id] = (deleted)
+    canister_state_counter[A.canister_id] = (deleted)
     time[A.canister_id] = (deleted)
     balances[A.canister_id] = (deleted)
     certified_data[A.canister_id] = (deleted)
@@ -3578,6 +3609,7 @@ S with
         transferred_cycles = M.transferred_cycles
       }
     canister_status[CanisterId] = Running
+    canister_state_counter[CanisterId] = 0
 ....
 
 ==== IC Management Canister: Top up canister
@@ -3711,7 +3743,8 @@ State after::
 ....
 S with
     canisters[CanisterId] = EmptyCanister
-    certified_data[Canister_id] = ""
+    certified_data[CanisterId] = ""
+    canister_state_counter[CanisterId] = S.canister_state_counter[CanisterId] + 1
 
     messages = S.messages ·
       [ ResponseMessage {
@@ -3799,6 +3832,7 @@ Conditions::
     freezing_limit = freezing_limit(S, Q.canister_id);
     certificate = Cert;
     status = simple_status(S.canister_status[Q.receiver]);
+    canister_state_counter = S.canister_state_counter[Q.receiver];
   }
 ....
 Read response::
@@ -4351,6 +4385,9 @@ ic0.canister_status<es>() : i32 =
     Stopping -> return 2
     Stopped  -> return 3
 
+ic0.canister_state_counter<es>() : i64 =
+  return es.params.sysenv.canister_state_counter
+
 ic0.call_new<es>(
     callee_src  : i32,
     callee_size : i32,
@@ -4385,6 +4422,7 @@ ic0.call_new<es>(
       on_reject = Closure { fun = reject_fun; env = reject_env }
       on_cleanup = NoClosure
     };
+    canister_state_counter = es.params.sysenv.canister_state_counter;
   }
 
 ic0.call_data_append<es> (src : i32, size : i32) =

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1103,7 +1103,7 @@ Status `3` (stopped) can be observed, for example, in `canister_pre_upgrade` and
 [#system-api-canister-state-counter]
 === Canister state counter
 
-For each canister, the system maintains a _state counter_. Upon canister creation, it is set to 0, and it is guaranteed to be incremented upon every change to the canister's state (except for changes affecting only the canister's time), i.e., upon every (successful and unsuccessful) message execution (ingress message, inter-canister call, callback execution) on that canister, successful management canister call (`update_settings`, `install_code`, `uninstall_code`, `stop_canister`, `start_canister`, `deposit_cycles`, and `provisional_top_up_canister`) on that canister, change of the canister status of that canister from stopping to stopped, code uninstallation due to that canister running out of cycles, successful `inspect_message` execution for ingress messages, and charging canisters for (compute and memory) resource allocation and usage. The system can arbitrarily increment the state counter also if the canister's state does not change.
+For each canister, the system maintains a _state counter_. Upon canister creation, it is set to 0, and it is *guaranteed* to be incremented upon every change of the canister's code or settings, i.e., upon every successful management canister call of methods `update_settings`, `install_code`, and `uninstall_code` on that canister and code uninstallation due to that canister running out of cycles. The system can arbitrarily increment the state counter also if the canister's code and settings do not change.
 
 * `ic0.canister_state_counter : () -> i64`
 +
@@ -2721,7 +2721,6 @@ S with
     requests[E.content] = Received
     if E.content.canister_id ≠ ic_principal then
       balances[E.content.canister_id] = S.balances[E.content.canister_id] - Cycles_used
-      canister_state_counter[E.content.canister_id] = S.canister_state_counter[E.content.canister_id] + 1
 ....
 
 NOTE: This is not instantaneous (the IC takes some time to agree it accepts the request) nor guaranteed (a node could just drop the request, or maybe it did not pass validation). But once the request has entered the IC state like this, it will be acted upon.
@@ -2967,14 +2966,12 @@ then
       certified_data[M.receiver] = res.new_certified_data
 
     balances[M.receiver] = New_balance
-    canister_state_counter[M.receiver] = S.canister_state_counter[M.receiver] + 1
 else
   S with
     messages = Older_messages · Younger_messages
     balances[M.receiver] =
       (S.balances[M.receiver] + (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE))
       - min (R.cycles_used, (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE))
-    canister_state_counter[M.receiver] = S.canister_state_counter[M.receiver] + 1
 ....
 
 
@@ -3369,7 +3366,6 @@ State after::
 S with
     messages = Older_messages · Younger_messages
     canister_status[A.canister_id] = Stopping [(M.origin, M.transferred_cycles)]
-    canister_state_counter[A.canister_id] = S.canister_state_counter[A.canister_id] + 1
 ....
 
 The next two transitions record any additional 'stop_canister' requests that arrive at a stopping (or stopped) canister in its status.
@@ -3389,7 +3385,6 @@ State after::
 S with
     messages = Older_messages · Younger_messages
     canister_status[A.canister_id] = Stopping (Origins · [(M.origin, M.transferred_cycles)])
-    canister_state_counter[A.canister_id] = S.canister_state_counter[A.canister_id] + 1
 ....
 
 
@@ -3404,7 +3399,6 @@ State after::
 ....
 S with
     canister_status[CanisterId] = Stopped
-    canister_state_counter[CanisterId] = S.canister_state_counter[CanisterId] + 1
     messages = S.Messages ·
         [ ResponseMessage {
             origin = O
@@ -3430,7 +3424,6 @@ Conditions::
 State after::
 ....
 S with
-    canister_state_counter[A.canister_id] = S.canister_state_counter[A.canister_id] + 1
     messages = Older_messages · Younger_messages ·
       ResponseMessage {
         origin = M.origin;
@@ -3457,7 +3450,6 @@ State after::
 ....
 S with
     canister_status[A.canister_id] = Running
-    canister_state_counter[A.canister_id] = S.canister_state_counter[A.canister_id] + 1
     messages = Older_messages · Younger_messages ·
         ResponseMessage{
             origin = M.origin
@@ -3483,7 +3475,6 @@ State after::
 ....
 S with
     canister_status[A.canister_id] = Running
-    canister_state_counter[A.canister_id] = S.canister_state_counter[A.canister_id] + 1
     messages = Older_messages · Younger_messages ·
         ResponseMessage{
             origin = M.origin
@@ -3546,7 +3537,6 @@ State after::
 S with
     balances[A.canister_id] =
       S.balances[A.canister_id] + M.transferred_cycles
-    canister_state_counter[A.canister_id] = S.canister_state_counter[A.canister_id] + 1
     messages = Older_messages · Younger_messages ·
       ResponseMessage {
         origin = M.origin
@@ -3629,7 +3619,6 @@ State after::
 ....
 S with
     balances[A.canister_id] = S.balances[A.canister_id] + A.amount
-    canister_state_counter[A.canister_id] = S.canister_state_counter[A.canister_id] + 1
 ....
 
 ==== Callback invocation
@@ -3794,7 +3783,6 @@ State after::
 ....
 S with
     balances[CanisterId] = B1
-    canister_state_counter[CanisterId] = S.canister_state_counter[CanisterId] + 1
 ....
 
 Similarly, the system time, used to expire requests, progresses:

--- a/theories/IC.thy
+++ b/theories/IC.thy
@@ -1112,17 +1112,78 @@ proof -
   qed
 qed
 
-lemma message_execution_ic_inv:
-  assumes "message_execution_pre n S" "ic_inv S"
-  shows "ic_inv (message_execution_post n S)"
-proof -
+lemma message_execution_cases:
+  assumes "message_execution_pre n S"
+  "\<And>ctxt_id recv ep q can bal can_status t ctxt Mod Is_response Env Available F R cyc_used cycles_accepted_res new_calls_res New_balance no_response result new_call_to_message response_messages msgs new_ctxt cert_data.
+    messages S ! n = Func_message ctxt_id recv ep q \<Longrightarrow> list_map_get (canisters S) recv = Some (Some can) \<Longrightarrow> list_map_get (balances S) recv = Some bal \<Longrightarrow>
+    list_map_get (canister_status S) recv = Some can_status \<Longrightarrow>
+    list_map_get (time S) recv = Some t \<Longrightarrow>
+    list_map_get (call_contexts S) ctxt_id = Some ctxt \<Longrightarrow>
+    Mod = module can \<Longrightarrow>
+    Is_response = (case ep of Callback _ _ _ \<Rightarrow> True | _ \<Rightarrow> False) \<Longrightarrow>
+    Env = \<lparr>env.time = t, balance = bal, freezing_limit = ic_freezing_limit S recv, certificate = None, status = simple_status can_status\<rparr> \<Longrightarrow>
+    Available = call_ctxt_available_cycles ctxt \<Longrightarrow>
+    F = exec_function ep Env Available Mod \<Longrightarrow>
+    R = F (wasm_state can) \<Longrightarrow>
+    cyc_used = (case R of Inr res \<Rightarrow> update_return.cycles_used res | Inl trap \<Rightarrow> cycles_return.cycles_used trap) \<Longrightarrow>
+    (cycles_accepted_res, new_calls_res) = (case R of Inr res \<Rightarrow> (update_return.cycles_accepted res, update_return.new_calls res)) \<Longrightarrow>
+    New_balance = bal + cycles_accepted_res + (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE)
+      - (cyc_used + sum_list (map (\<lambda>x. MAX_CYCLES_PER_RESPONSE + transferred_cycles x) new_calls_res)) \<Longrightarrow>
+    no_response = (case R of Inr result \<Rightarrow> update_return.response result = None) \<Longrightarrow>
+    \<not>isl R \<Longrightarrow> cyc_used \<le> (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE) \<Longrightarrow>
+    cycles_accepted_res \<le> Available \<Longrightarrow>
+    cyc_used + sum_list (map (\<lambda>x. MAX_CYCLES_PER_RESPONSE + transferred_cycles x) new_calls_res) \<le>
+      bal + cycles_accepted_res + (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE) \<Longrightarrow>
+    New_balance \<ge> (if Is_response then 0 else ic_freezing_limit S recv) \<Longrightarrow>
+    (no_response \<or> call_ctxt_needs_to_respond ctxt) \<Longrightarrow>
+    result = projr R \<Longrightarrow>
+    new_call_to_message = (\<lambda>call. Call_message (From_canister ctxt_id (method_call.callback call)) (principal_of_canid recv)
+      (method_call.callee call) (method_call.method_name call) (method_call.arg call) (method_call.transferred_cycles call) (Queue (Canister recv) (method_call.callee call))) \<Longrightarrow>
+    response_messages = (case update_return.response result of None \<Rightarrow> []
+      | Some resp \<Rightarrow> [Response_message (call_ctxt_origin ctxt) resp (Available - cycles_accepted_res)]) \<Longrightarrow>
+    msgs = take n (messages S) @ drop (Suc n) (messages S) @ map new_call_to_message new_calls_res @ response_messages \<Longrightarrow>
+    new_ctxt = (case update_return.response result of
+        None \<Rightarrow> call_ctxt_deduct_cycles cycles_accepted_res ctxt
+      | Some _ \<Rightarrow> call_ctxt_respond ctxt) \<Longrightarrow>
+    cert_data = (case new_certified_data result of None \<Rightarrow> certified_data S
+      | Some cd \<Rightarrow> list_map_set (certified_data S) recv cd) \<Longrightarrow>
+    P n S (S\<lparr>canisters := list_map_set (canisters S) recv (Some (can\<lparr>wasm_state := update_return.new_state result\<rparr>)),
+      messages := msgs, call_contexts := list_map_set (call_contexts S) ctxt_id new_ctxt,
+      certified_data := cert_data, balances := list_map_set (balances S) recv New_balance\<rparr>)"
+  "\<And>ctxt_id recv ep q can bal can_status t ctxt Mod Is_response Env Available F R cyc_used cycles_accepted_res new_calls_res New_balance no_response.
+    messages S ! n = Func_message ctxt_id recv ep q \<Longrightarrow> list_map_get (canisters S) recv = Some (Some can) \<Longrightarrow> list_map_get (balances S) recv = Some bal \<Longrightarrow>
+    list_map_get (canister_status S) recv = Some can_status \<Longrightarrow>
+    list_map_get (time S) recv = Some t \<Longrightarrow>
+    list_map_get (call_contexts S) ctxt_id = Some ctxt \<Longrightarrow>
+    Mod = module can \<Longrightarrow>
+    Is_response = (case ep of Callback _ _ _ \<Rightarrow> True | _ \<Rightarrow> False) \<Longrightarrow>
+    Env = \<lparr>env.time = t, balance = bal, freezing_limit = ic_freezing_limit S recv, certificate = None, status = simple_status can_status\<rparr> \<Longrightarrow>
+    Available = call_ctxt_available_cycles ctxt \<Longrightarrow>
+    F = exec_function ep Env Available Mod \<Longrightarrow>
+    R = F (wasm_state can) \<Longrightarrow>
+    cyc_used = (case R of Inr res \<Rightarrow> update_return.cycles_used res | Inl trap \<Rightarrow> cycles_return.cycles_used trap) \<Longrightarrow>
+    (cycles_accepted_res, new_calls_res) = (case R of Inr res \<Rightarrow> (update_return.cycles_accepted res, update_return.new_calls res)) \<Longrightarrow>
+    New_balance = bal + cycles_accepted_res + (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE)
+      - (cyc_used + sum_list (map (\<lambda>x. MAX_CYCLES_PER_RESPONSE + transferred_cycles x) new_calls_res)) \<Longrightarrow>
+    no_response = (case R of Inr result \<Rightarrow> update_return.response result = None) \<Longrightarrow>
+    \<not>(\<not>isl R \<and> cyc_used \<le> (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE) \<and>
+      cycles_accepted_res \<le> Available \<and>
+      cyc_used + sum_list (map (\<lambda>x. MAX_CYCLES_PER_RESPONSE + transferred_cycles x) new_calls_res) \<le>
+      bal + cycles_accepted_res + (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE) \<and>
+      New_balance \<ge> (if Is_response then 0 else ic_freezing_limit S recv) \<and>
+      (no_response \<or> call_ctxt_needs_to_respond ctxt)) \<Longrightarrow>
+    P n S (S\<lparr>messages := take n (messages S) @ drop (Suc n) (messages S),
+      balances := list_map_set (balances S) recv ((bal + (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE))
+      - min cyc_used (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE))\<rparr>)"
+  shows "P n S (message_execution_post n S)"
+  proof -
   obtain ctxt_id recv ep q can bal can_status t ctxt where msg: "messages S ! n = Func_message ctxt_id recv ep q"
     and prod: "list_map_get (canisters S) recv = Some (Some can)"
     "list_map_get (balances S) recv = Some bal"
     "list_map_get (canister_status S) recv = Some can_status"
     "list_map_get (time S) recv = Some t"
     "list_map_get (call_contexts S) ctxt_id = Some ctxt"
-    using assms
+    using assms(1)
     by (auto simp: message_execution_pre_def split: message.splits option.splits)
   define Mod where "Mod = can_state_rec.module can"
   define Is_response where "Is_response = (case ep of Callback _ _ _ \<Rightarrow> True | _ \<Rightarrow> False)"
@@ -1138,12 +1199,6 @@ proof -
   define no_response where "no_response = (case R of Inr result \<Rightarrow> update_return.response result = None)"
   define older where "older = take n (messages S)"
   define younger where "younger = drop (Suc n) (messages S)"
-  have msgs: "messages S = older @ Func_message ctxt_id recv ep q # younger"
-    "take n older = older" "drop (Suc n) older = []"
-    "take (n - length older) ws = []" "drop (Suc n - length older) (w # ws) = ws"
-    for w and ws :: "('b, 'p, 'uid, 'canid, 's, 'c, 'cid) message list"
-    using id_take_nth_drop[of n "messages S"] assms
-    by (auto simp: message_execution_pre_def msg older_def younger_def)
   define S'' where "S'' = S\<lparr>messages := take n (messages S) @ drop (Suc n) (messages S),
     balances := list_map_set (balances S) recv ((bal + (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE)) - min cyc_used (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE))\<rparr>"
   define cond where "cond = (\<not>isl R \<and> cyc_used \<le> (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE) \<and>
@@ -1161,19 +1216,11 @@ proof -
           Mod_def[symmetric] Is_response_def[symmetric] Env_def[symmetric] Available_def[symmetric] F_def[symmetric] R_def[symmetric] cyc_used_def[symmetric] res[symmetric]
           New_balance_def[symmetric] no_response_def[symmetric] S''_def[symmetric] cond_def[symmetric])
     then show ?thesis
-      using assms(2)
-      apply (auto simp: ic_inv_def S''_def msgs split: message.splits call_origin.splits)
-         apply force
-        apply fast
-       apply force
-      apply fast
-      done
+      using assms(3)[OF msg prod Mod_def Is_response_def Env_def Available_def F_def R_def cyc_used_def res New_balance_def no_response_def, folded cond_def S''_def] False
+      by auto
   next
     case True
     define result where "result = projr R"
-    have R_Inr: "R = Inr result"
-      using True
-      by (auto simp: cond_def result_def split: option.splits)
     define response_messages where "response_messages = (case update_return.response result of None \<Rightarrow> []
       | Some resp \<Rightarrow> [Response_message (call_ctxt_origin ctxt) resp (Available - cycles_accepted_res)])"
     define new_call_to_message :: "(?'p, 'canid, 's, 'b, 'c) method_call \<Rightarrow> ('b, 'p, 'uid, 'canid, 's, 'c, 'cid) message" where
@@ -1188,12 +1235,6 @@ proof -
     define S' where "S' = S\<lparr>canisters := list_map_set (canisters S) recv (Some (can\<lparr>wasm_state := update_return.new_state result\<rparr>)),
       messages := messages, call_contexts := list_map_set (call_contexts S) ctxt_id new_ctxt,
       certified_data := certified_data, balances := list_map_set (balances S) recv New_balance\<rparr>"
-    have cycles_accepted_res_def: "cycles_accepted_res = update_return.cycles_accepted result"
-      and new_calls_res_def: "new_calls_res = new_calls result"
-      using res
-      by (auto simp: R_Inr)
-    have no_response: "no_response = (update_return.response result = None)"
-      by (auto simp: no_response_def R_Inr)
     have msg_exec: "message_execution_post n S = S'"
       using True
       by (simp_all add: message_execution_post_def Let_def msg prod
@@ -1201,35 +1242,43 @@ proof -
           New_balance_def[symmetric] no_response_def[symmetric] S''_def[symmetric] cond_def[symmetric]
           messages_def[symmetric] new_ctxt_def[symmetric] certified_data_def[symmetric] S'_def[symmetric]
           result_def[symmetric] response_messages_def[symmetric] new_call_to_message_def[symmetric])
-    have messages_msgs: "messages = older @ younger @ map new_call_to_message new_calls_res @ response_messages"
-      by (auto simp: messages_def older_def younger_def)
-    have ctxt_in_range: "ctxt \<in> list_map_range (call_contexts S)"
-      using prod(5)
-      by (simp add: list_map_get_range)
-    have response_msgsD: "msg \<in> set response_messages \<Longrightarrow> update_return.response result \<noteq> None \<and>
-      (\<exists>resp. msg = Response_message (call_ctxt_origin ctxt) resp (Available - cycles_accepted_res))" for msg
-      by (auto simp: response_messages_def) metis
-    have call_ctxt_origin_new_ctxt: "call_ctxt_origin new_ctxt = call_ctxt_origin ctxt"
-      by (auto simp: new_ctxt_def split: option.splits)
-    have call_ctxt_needs_to_respond_new_ctxtD: "call_ctxt_needs_to_respond new_ctxt \<Longrightarrow> call_ctxt_needs_to_respond ctxt"
-      by (auto simp: new_ctxt_def split: option.splits)
     show ?thesis
-      using assms(2) ctxt_in_range True call_ctxt_not_needs_to_respond_available_cycles[of ctxt]
-      apply (auto simp: cond_def msg_exec S'_def ic_inv_def msgs messages_msgs new_call_to_message_def
-          no_response_def R_Inr call_ctxt_origin_new_ctxt
-          split: option.splits message.splits call_origin.splits
-          dest!: list_map_range_setD response_msgsD call_ctxt_needs_to_respond_new_ctxtD
-          intro: ic_can_status_inv_mono2)
-             apply blast
-            apply fast
-           apply blast
-          apply fast
-         apply blast
-        apply fast
-       apply blast
-      apply fast
-      done
+      using assms(2)[OF msg prod Mod_def Is_response_def Env_def Available_def F_def R_def cyc_used_def res New_balance_def no_response_def _ _ _ _ _ _ result_def
+          new_call_to_message_def response_messages_def messages_def new_ctxt_def certified_data_def, folded S'_def] True
+      by (auto simp: cond_def msg_exec)
   qed
+qed
+
+lemma message_execution_ic_inv:
+  assumes "message_execution_pre n S" "ic_inv S"
+  shows "ic_inv (message_execution_post n S)"
+proof (rule message_execution_cases[OF assms(1)])
+  fix recv msgs ctxt_id new_ctxt cert_data New_balance new_calls_res response_messages ctxt Available cycles_accepted_res no_response
+  fix can :: "('p, 'canid, 'b, 'w, 'sm, 'c, 's) can_state_rec"
+  fix result :: "('w, 'p, 'canid, 's, 'b, 'c) update_return"
+  fix new_call_to_message :: "('p, 'canid, 's, 'b, 'c) method_call \<Rightarrow> ('b, 'p, 'uid, 'canid, 's, 'c, 'cid) message"
+  fix R :: "unit cycles_return + ('w, 'p, 'canid, 's, 'b, 'c) update_return"
+  assume ctxt: "list_map_get (call_contexts S) ctxt_id = Some ctxt"
+  assume "msgs = take n (messages S) @ drop (Suc n) (messages S) @ map new_call_to_message new_calls_res @ response_messages"
+    "new_call_to_message = (\<lambda>call. Call_message (From_canister ctxt_id (callback call)) (principal_of_canid recv) (callee call) (method_call.method_name call) (method_call.arg call) (transferred_cycles call)
+      (Queue (Canister recv) (callee call)))"
+    "response_messages = (case update_return.response result of None \<Rightarrow> [] | Some resp \<Rightarrow> [Response_message (call_ctxt_origin ctxt) resp (Available - cycles_accepted_res)])"
+    "no_response \<or> call_ctxt_needs_to_respond ctxt"
+    "no_response = (case R of Inr result \<Rightarrow> update_return.response result = None)"
+    "\<not> isl R" "result = projr R"
+    "new_ctxt = (case update_return.response result of None \<Rightarrow> call_ctxt_deduct_cycles cycles_accepted_res ctxt | Some x \<Rightarrow> call_ctxt_respond ctxt)"
+  then show "ic_inv (S\<lparr>canisters := list_map_set (canisters S) recv (Some (can\<lparr>wasm_state := update_return.new_state result\<rparr>)), messages := msgs,
+    call_contexts := list_map_set (call_contexts S) ctxt_id new_ctxt, certified_data := cert_data, balances := list_map_set (balances S) recv New_balance\<rparr>)"
+    using assms(2) list_map_get_range[OF ctxt]
+    by (cases R)
+       (force simp: ic_inv_def ic_can_status_inv_def split: message.splits call_origin.splits can_status.splits dest!: in_set_takeD in_set_dropD list_map_range_setD)+
+next
+  fix recv bal Is_response cyc_used
+  show "ic_inv (S\<lparr>messages := take n (messages S) @ drop (Suc n) (messages S),
+    balances := list_map_set (balances S) recv (bal + (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE)
+    - min cyc_used (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE))\<rparr>)"
+    using assms(2)
+    by (auto simp: ic_inv_def split: message.splits call_origin.splits can_status.splits dest!: in_set_takeD in_set_dropD)
 qed
 
 

--- a/theories/IC.thy
+++ b/theories/IC.thy
@@ -657,13 +657,13 @@ definition request_submission_post :: "('b, 'p, 'uid, 'canid, 's, 'pk, 'sig) env
   "request_submission_post E ECID S = (
     let req = projl (content E);
     cid = request.canister_id req;
-    balances = (if cid \<noteq> ic_principal then
+    (balances, canister_state_counter) = (if cid \<noteq> ic_principal then
       (case (list_map_get (canisters S) cid, list_map_get (time S) cid, list_map_get (balances S) cid, list_map_get (canister_status S) cid, list_map_get (canister_state_counter S) (request.canister_id req)) of
         (Some (Some can), Some t, Some bal, Some can_status, Some idx) \<Rightarrow>
         let env = \<lparr>env.time = t, balance = bal, freezing_limit = ic_freezing_limit S cid, certificate = None, status = simple_status can_status, canister_state_counter = idx\<rparr> in
         (case canister_module_inspect_message (module can) (request.method_name req, wasm_state can, request.arg req, principal_of_uid (request.sender req), env) of Inr ret \<Rightarrow>
-          list_map_set (balances S) cid (bal - cycles_return.cycles_used ret)))
-      else balances S) in
+          (list_map_set (balances S) cid (bal - cycles_return.cycles_used ret), list_map_set (canister_state_counter S) cid (Suc idx))))
+      else (balances S, canister_state_counter S)) in
     S\<lparr>requests := list_map_set (requests S) req Received, balances := balances\<rparr>)"
 
 definition request_submission_burned_cycles :: "('b, 'p, 'uid, 'canid, 's, 'pk, 'sig) envelope \<Rightarrow> 'p \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> nat" where
@@ -710,7 +710,7 @@ lemma request_submission_ic_inv:
   shows "ic_inv (request_submission_post E ECID S)"
   using assms
   by (auto simp: ic_inv_def request_submission_pre_def request_submission_post_def Let_def
-      split: sum.splits message.splits call_origin.splits)
+      split: sum.splits message.splits call_origin.splits prod.splits)
 
 
 
@@ -984,7 +984,8 @@ definition message_execution_post :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, '
               canister_state_counter := list_map_set (canister_state_counter S) recv (Suc idx)\<rparr>)
         else S\<lparr>messages := take n (messages S) @ drop (Suc n) (messages S),
           balances := list_map_set (balances S) recv ((bal + (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE))
-            - min cyc_used (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE))\<rparr>))
+            - min cyc_used (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE)),
+          canister_state_counter := list_map_set (canister_state_counter S) recv (Suc idx)\<rparr>))
     | _ \<Rightarrow> undefined)"
 
 definition message_execution_burned_cycles :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> nat" where
@@ -1038,7 +1039,8 @@ proof -
   note lm = list_map_sum_in[OF prod(2), where ?g=id, simplified] list_map_sum_in_ge[OF prod(2), where ?g=id, simplified]
     list_map_sum_in[OF prod(5), where ?g=call_ctxt_carried_cycles] list_map_sum_in_ge[OF prod(5), where ?g=call_ctxt_carried_cycles]
   define S'' where "S'' = S\<lparr>messages := take n (messages S) @ drop (Suc n) (messages S),
-    balances := list_map_set (balances S) recv ((bal + (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE)) - min cyc_used (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE))\<rparr>"
+    balances := list_map_set (balances S) recv ((bal + (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE)) - min cyc_used (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE)),
+    canister_state_counter := list_map_set (canister_state_counter S) recv (Suc idx)\<rparr>"
   define cond where "cond = (\<not>isl R \<and> cyc_used \<le> (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE) \<and>
     cycles_accepted_res \<le> Available \<and>
     cyc_used + sum_list (map (\<lambda>x. MAX_CYCLES_PER_RESPONSE + transferred_cycles x) new_calls_res) \<le>
@@ -1184,7 +1186,8 @@ lemma message_execution_cases:
       (no_response \<or> call_ctxt_needs_to_respond ctxt)) \<Longrightarrow>
     P n S (S\<lparr>messages := take n (messages S) @ drop (Suc n) (messages S),
       balances := list_map_set (balances S) recv ((bal + (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE))
-      - min cyc_used (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE))\<rparr>)"
+      - min cyc_used (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE)),
+      canister_state_counter := list_map_set (canister_state_counter S) recv (Suc idx)\<rparr>)"
   shows "P n S (message_execution_post n S)"
   proof -
   obtain ctxt_id recv ep q can bal can_status t ctxt idx where msg: "messages S ! n = Func_message ctxt_id recv ep q"
@@ -1211,7 +1214,8 @@ lemma message_execution_cases:
   define older where "older = take n (messages S)"
   define younger where "younger = drop (Suc n) (messages S)"
   define S'' where "S'' = S\<lparr>messages := take n (messages S) @ drop (Suc n) (messages S),
-    balances := list_map_set (balances S) recv ((bal + (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE)) - min cyc_used (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE))\<rparr>"
+    balances := list_map_set (balances S) recv ((bal + (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE)) - min cyc_used (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE)),
+    canister_state_counter := list_map_set (canister_state_counter S) recv (Suc idx)\<rparr>"
   define cond where "cond = (\<not>isl R \<and> cyc_used \<le> (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE) \<and>
     cycles_accepted_res \<le> Available \<and>
     cyc_used + sum_list (map (\<lambda>x. MAX_CYCLES_PER_RESPONSE + transferred_cycles x) new_calls_res) \<le>
@@ -1286,10 +1290,11 @@ proof (rule message_execution_cases[OF assms(1)])
     by (cases R)
        (force simp: ic_inv_def ic_can_status_inv_def split: message.splits call_origin.splits can_status.splits dest!: in_set_takeD in_set_dropD list_map_range_setD)+
 next
-  fix recv bal Is_response cyc_used
+  fix recv bal Is_response cyc_used idx
   show "ic_inv (S\<lparr>messages := take n (messages S) @ drop (Suc n) (messages S),
     balances := list_map_set (balances S) recv (bal + (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE)
-    - min cyc_used (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE))\<rparr>)"
+    - min cyc_used (if Is_response then MAX_CYCLES_PER_RESPONSE else MAX_CYCLES_PER_MESSAGE)),
+    canister_state_counter := list_map_set (canister_state_counter S) recv (Suc idx)\<rparr>)"
     using assms(2)
     by (auto simp: ic_inv_def split: message.splits call_origin.splits can_status.splits dest!: in_set_takeD in_set_dropD)
 qed
@@ -2227,16 +2232,18 @@ definition ic_depositing_cycles_pre :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b,
     cee = ic_principal \<and>
     mn = encode_string ''deposit_cycles'' \<and>
     (case candid_parse_cid a of Some cid \<Rightarrow>
-    (case list_map_get (balances S) cid of Some bal \<Rightarrow>
+    (case (list_map_get (balances S) cid, list_map_get (canister_state_counter S) cid) of (Some bal, Some idx) \<Rightarrow>
       True
     | _ \<Rightarrow> False) | _ \<Rightarrow> False)
   | _ \<Rightarrow> False))"
 
 definition ic_depositing_cycles_post :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
   "ic_depositing_cycles_post n S = (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
-    let cid = the (candid_parse_cid a) in
+    let cid = the (candid_parse_cid a);
+    idx = the (list_map_get (canister_state_counter S) cid) in
     (case list_map_get (balances S) cid of Some bal \<Rightarrow>
     S\<lparr>balances := list_map_set (balances S) cid (bal + trans_cycles),
+      canister_state_counter := list_map_set (canister_state_counter S) cid (Suc idx),
       messages := take n (messages S) @ drop (Suc n) (messages S) @ [Response_message orig (Reply (blob_of_candid Candid_empty)) 0]\<rparr>))"
 
 lemma ic_depositing_cycles_cycles_monotonic:
@@ -2391,15 +2398,17 @@ definition ic_top_up_canister_pre :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, '
       (q = Unordered \<or> (\<forall>j < n. message_queue (messages S ! j) \<noteq> Some q)) \<and>
       cee = ic_principal \<and>
       mn = encode_string ''provisional_top_up_canister'' \<and>
-      cid \<in> list_map_dom (balances S)
+      cid \<in> list_map_dom (balances S) \<and>
+      cid \<in> list_map_dom (canister_state_counter S)
     | _ \<Rightarrow> False) | _ \<Rightarrow> False))"
 
 definition ic_top_up_canister_post :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
   "ic_top_up_canister_post n S = (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
     let cid = the (candid_parse_cid a);
+    idx = the (list_map_get (canister_state_counter S) cid);
     cyc = the (candid_parse_nat a [encode_string ''amount'']);
     bal = the (list_map_get (balances S) cid) in
-    S\<lparr>balances := list_map_set (balances S) cid (bal + cyc)\<rparr>)"
+    S\<lparr>balances := list_map_set (balances S) cid (bal + cyc), canister_state_counter := list_map_set (canister_state_counter S) cid (Suc idx)\<rparr>)"
 
 definition ic_top_up_canister_minted_cycles :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> nat" where
   "ic_top_up_canister_minted_cycles n S = (case messages S ! n of Call_message orig cer cee mn a trans_cycles q \<Rightarrow>
@@ -2712,12 +2721,14 @@ lemma canister_time_progress_ic_inv:
 (* System transition: Time progressing and cycle consumption (cycle consumption) [DONE] *)
 
 definition cycle_consumption_pre :: "'canid \<Rightarrow> nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
-  "cycle_consumption_pre cid b1 S = (case list_map_get (balances S) cid of Some b0 \<Rightarrow>
+  "cycle_consumption_pre cid b1 S = (case (list_map_get (balances S) cid, list_map_get (canister_state_counter S) cid) of (Some b0, Some idx) \<Rightarrow>
       0 \<le> b1 \<and> b1 < b0
     | _ \<Rightarrow> False)"
 
 definition cycle_consumption_post :: "'canid \<Rightarrow> nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where
-  "cycle_consumption_post cid b1 S = (S\<lparr>balances := list_map_set (balances S) cid b1\<rparr>)"
+  "cycle_consumption_post cid b1 S = (
+    let idx = the (list_map_get (canister_state_counter S) cid) in
+    S\<lparr>balances := list_map_set (balances S) cid b1, canister_state_counter := list_map_set (canister_state_counter S) cid (Suc idx)\<rparr>)"
 
 definition cycle_consumption_burned_cycles :: "'canid \<Rightarrow> nat \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> nat" where
   "cycle_consumption_burned_cycles cid b1 S = the (list_map_get (balances S) cid) - b1"

--- a/theories/IC.thy
+++ b/theories/IC.thy
@@ -195,7 +195,6 @@ record ('p, 'canid, 's, 'b, 'c) method_call =
   arg :: 'b
   transferred_cycles :: nat
   callback :: 'c
-  canister_state_counter :: canister_state_counter
 
 record 'x cycles_return =
   return :: 'x


### PR DESCRIPTION
A *canister state counter* (represented as an unsigned integer) guaranteed to be incremented upon every change of the canister's code and settings is introduced. It is available to the canister via a system API call.

This PR only introduces the concept of a canister state counter. Its application will follow in separate PRs. Here we outline the anticipated applications of the canister state counter:

- used instead of *canister generation counter* proposed [here](https://github.com/dfinity/interface-spec/pull/19) for the sake of safe instantaneous (i.e., without stopping the canister) upgrades that handle all outstanding callbacks properly
- used instead of *canister history index* [here](https://github.com/dfinity/interface-spec/pull/103) to identify the canister's code version that triggered a change (e.g., code deployment) of another canister

Note. In the future, we might additionally guarantee that the state counter increases upon further changes of the canister's state. This is backwards-compatible because already now the state counter can be increased by the system at any time.