### PR TITLE
Rename the transform context to arg

### DIFF
--- a/spec/ic.did
+++ b/spec/ic.did
@@ -116,8 +116,8 @@ service ic : {
     headers: vec http_header;
     body : opt blob;
     transform : opt record {
-      function : func (record {response : http_response; context : blob}) -> (http_response) query;
-      context : blob
+      function : func (record {response : http_response; arg : blob}) -> (http_response) query;
+      arg : blob
     };
   }) -> (http_response);
 


### PR DESCRIPTION
Going over the spec it seems we use the word "context" more in the situation of a callback. 

Also in the current spec it does seem that we already use the `arg` convention for the `install_code` method and within HTTPS API as part of the CBOR request. Those occurrences seem semantically closer to the transform context intent than a callback intent.