### PR TITLE
RUN-509: Enable Canister Timers in pre-upgrade

### DIFF
--- a/spec/ic0.txt
+++ b/spec/ic0.txt
@@ -60,7 +60,7 @@ ic0.data_certificate_size : () -> i32;                                      // *
 ic0.data_certificate_copy : (dst: i32, offset: i32, size: i32) -> ();       // *
 
 ic0.time : () -> (timestamp : i64);                                         // *
-ic0.global_timer_set : (timestamp : i64) -> i64;                            // I U Ry Rt C T
+ic0.global_timer_set : (timestamp : i64) -> i64;                            // I G U Ry Rt C T
 ic0.performance_counter : (counter_type : i32) -> (counter : i64);          // * s
 
 ic0.debug_print : (src : i32, size : i32) -> ();                            // * s

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -4740,7 +4740,7 @@ ic0.time<es>() : i32 =
   return es.params.sysenv.time
 
 ic0.global_timer_set<es>(timestamp: i64) : i64 =
-  if es.context ∉ {I, U, Ry, Rt, C, T} then Trap {cycles_used = es.cycles_used;}
+  if es.context ∉ {I, G, U, Ry, Rt, C, T} then Trap {cycles_used = es.cycles_used;}
   let prev_global_timer = es.new_global_timer
   es.new_global_timer := timestamp
   if prev_global_timer = NoGlobalTimer


### PR DESCRIPTION
Canister Timers are allowed in post-upgrade and init and it is easy to assume that they are also okay in pre-upgrade.