### PR TITLE
fix timer spec in install

### DIFF
--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -3351,7 +3351,7 @@ Conditions::
     M.caller ∈ S.controllers[A.canister_id]
     Env = {
       time = S.time[A.canister_id];
-      global_timer = S.global_timer[A.canister_id];
+      global_timer = 0;
       balance = S.balances[A.canister_id];
       freezing_limit = freezing_limit(S, A.canister_id);
       certificate = NoCertificate;


### PR DESCRIPTION
The canister global timer is deactivated upon installing code to a canister and thus the init function of the WASM module sees the global timer equal to zero. This PR fixes that "typo" in the formal part of the specification.