### PR TITLE
Make replicated query semantics more explicit

### DIFF
--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -562,7 +562,7 @@ In order to call a canister, the user makes a POST request to `/api/v2/canister/
 
 The HTTP response to this request has an empty body and HTTP status 202, or a HTTP error (4xx or 5xx). Paranoid agents should not trust this response, and use <<http-read-state,`read_state`>> to determine the status of the call.
 
-This request type can _also_ be used to call a query method. A user may choose to go this way, instead of via the faster and cheaper <<http-query>> below, if they want to get a _certified_ response. Note that the canister change will not be changed by sending a call request type for a query method.
+This request type can _also_ be used to call a query method. A user may choose to go this way, instead of via the faster and cheaper <<http-query>> below, if they want to get a _certified_ response. Note that the canister state will not be changed by sending a call request type for a query method.
 
 NOTE: The functionality exposed via the <<ic-management-canister>> can be used this way.
 

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -478,7 +478,7 @@ It is recommended for the canister to have a custom section called "icp:public c
 
 The concrete mechanism that users use to send requests to the Internet Computer is via an HTTPS API, which exposes three endpoints to handle interactions, plus one for diagnostics:
 
-* At `/api/v2/canister/<effective_canister_id>/call` the user can submit (asynchronous, state-changing) calls.
+* At `/api/v2/canister/<effective_canister_id>/call` the user can submit (asynchronous, potentially state-changing) calls.
 * At `/api/v2/canister/<effective_canister_id>/read_state` the user can read various information about the state of the Internet Computer. In particular, they can poll for the status of a call here.
 * At `/api/v2/canister/<effective_canister_id>/query` the user can perform (synchronous, non-state-changing) query calls.
 * At `/api/v2/status` the user can retrieve status information about the Internet Computer.
@@ -562,7 +562,7 @@ In order to call a canister, the user makes a POST request to `/api/v2/canister/
 
 The HTTP response to this request has an empty body and HTTP status 202, or a HTTP error (4xx or 5xx). Paranoid agents should not trust this response, and use <<http-read-state,`read_state`>> to determine the status of the call.
 
-This request type can _also_ be used to call a query method. A user may choose to go this way, instead of via the faster and cheaper <<http-query>> below, if they want to get a _certified_ response.
+This request type can _also_ be used to call a query method. A user may choose to go this way, instead of via the faster and cheaper <<http-query>> below, if they want to get a _certified_ response. Note that the canister change will not be changed by sending a call request type for a query method.
 
 NOTE: The functionality exposed via the <<ic-management-canister>> can be used this way.
 


### PR DESCRIPTION
Several people have asked about whether send a call request type to a query method changes the canister state. In this PR I try to make it more explicit that the state will not be changed. 