### PR TITLE
feat: Add a system api call to check whether a given principal is a controller

### DIFF
--- a/spec/ic0.txt
+++ b/spec/ic0.txt
@@ -62,6 +62,7 @@ ic0.data_certificate_copy : (dst: i32, offset: i32, size: i32) -> ();       // *
 ic0.time : () -> (timestamp : i64);                                         // *
 ic0.global_timer_set : (timestamp : i64) -> i64;                            // I G U Ry Rt C T
 ic0.performance_counter : (counter_type : i32) -> (counter : i64);          // * s
+ic0.is_controller: (src: i32, size: i32) -> ( result: i32);                 // * s
 
 ic0.debug_print : (src : i32, size : i32) -> ();                            // * s
 ic0.trap : (src : i32, size : i32) -> ();                                   // * s

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -2379,6 +2379,7 @@ Timestamp = Nat;
 CanisterVersion = Nat;
 Env = {
   time : Timestamp;
+  controllers : List Principal;
   global_timer : Nat;
   balance : Nat;
   freezing_limit : Nat;
@@ -2805,6 +2806,7 @@ Conditions::
       S.canisters[E.content.canister_id] ≠ EmptyCanister
       Env = {
         time = S.time[E.content.canister_id];
+        controllers = S.controllers[E.content.canister_id];
         global_timer = S.global_timer[E.content.canister_id];
         balance = S.balances[E.content.canister_id]
         freezing_limit = freezing_limit(S, E.content.canister_id);
@@ -3035,6 +3037,7 @@ Conditions::
 
     Env = {
       time = S.time[M.receiver];
+      controllers = S.controllers[M.receiver];
       global_timer = S.global_timer[M.receiver];
       balance = S.balances[M.receiver]
       freezing_limit = freezing_limit(S, M.receiver);
@@ -3370,6 +3373,7 @@ Conditions::
     M.caller ∈ S.controllers[A.canister_id]
     Env = {
       time = S.time[A.canister_id];
+      controllers = S.controllers[A.canister_id];
       global_timer = 0;
       balance = S.balances[A.canister_id];
       freezing_limit = freezing_limit(S, A.canister_id);
@@ -3427,6 +3431,7 @@ Conditions::
     S.canisters[A.canister_id] = { wasm_state = Old_state; module = Old_module, …}
     Env = {
       time = S.time[A.canister_id];
+      controllers = S.controllers[A.canister_id];
       balance = S.balances[A.canister_id];
       freezing_limit = freezing_limit(S, A.canister_id);
       certificate = NoCertificate;
@@ -4027,6 +4032,7 @@ Conditions::
   lookup(["time"], Cert) = Found S.system_time // or “recent enough”
   Env = {
     time = S.time[Q.receiver];
+    controllers = S.controllers[Q.receiver];
     global_timer = S.global_timer[Q.receiver];
     balance = S.balances[Q.canister_id];
     freezing_limit = freezing_limit(S, Q.canister_id);
@@ -4170,7 +4176,6 @@ ExecutionState = {
   wasm_state : WasmState;
   params : Params;
   response : NoResponse | Response;
-  controllers: List Principal;
   cycles_accepted : Nat;
   cycles_available : Nat;
   cycles_used : Nat;
@@ -4824,7 +4829,7 @@ ic0.performance_counter<es>(counter_type : i32) : i64 =
 
 ic0.is_controller<es>(src: i32, size: i32) : (result: i32) =
   principal = copy_from_canister<es>(src, size)
-  if principal ∉ es.controllers
+  if principal ∉ es.params.sysenv.controllers
   then return 0
   else return 1
 

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1460,6 +1460,18 @@ The system resets the counter at the beginning of each <<entry-points>> invocati
 
 The main purpose of this counter is to facilitate in-canister performance profiling.
 
+[#system-api-controller-check]
+=== Controller check
+
+The canister can check whether a given principal is one of its controllers.
+
+`+ic0.is_controller : (src : i32, size: i32) -> (result: i32)+`
+
+Checks whether the principal identified by `src`/`size` is one of the controllers of the canister. If yes, then a value of 1 is returned,
+otherwise a 0 is returned. It can be called multiple times.
+
+This system call traps if `src+size` exceeds the size of the WebAssembly memory.
+
 [#system-api-certified-data]
 === Certified data
 
@@ -4157,6 +4169,7 @@ ExecutionState = {
   wasm_state : WasmState;
   params : Params;
   response : NoResponse | Response;
+  controllers: List Principal;
   cycles_accepted : Nat;
   cycles_available : Nat;
   cycles_used : Nat;
@@ -4807,6 +4820,12 @@ ic0.data_certificate_copy<es>(dst: i32, offset: i32, size: i32) =
 
 ic0.performance_counter<es>(counter_type : i32) : i64 =
   arbitrary()
+
+ic0.is_controller<es>(src: i32, size: i32) : (result: i32) =
+  principal = copy_from_canister<es>(src, size)
+  if principal ∉ es.controllers
+  then return 0
+  else return 1
 
 ic0.debug_print<es>(src : i32, size : i32) =
   return

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1467,8 +1467,7 @@ The canister can check whether a given principal is one of its controllers.
 
 `+ic0.is_controller : (src : i32, size: i32) -> (result: i32)+`
 
-Checks whether the principal identified by `src`/`size` is one of the controllers of the canister. If yes, then a value of 1 is returned,
-otherwise a 0 is returned. It can be called multiple times.
+Checks whether the principal identified by `src`/`size` is one of the controllers of the canister. If yes, then a value of 1 is returned, otherwise a 0 is returned. It can be called multiple times.
 
 This system call traps if `src+size` exceeds the size of the WebAssembly memory.
 

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -4822,10 +4822,13 @@ ic0.performance_counter<es>(counter_type : i32) : i64 =
   arbitrary()
 
 ic0.is_controller<es>(src: i32, size: i32) : (result: i32) =
-  principal = copy_from_canister<es>(src, size)
-  if principal ∉ es.params.sysenv.controllers
-  then return 0
-  else return 1
+  bytes = copy_from_canister<es>(src, size)
+  if bytes encode a principal then
+    if bytes ∉ es.params.sysenv.controllers
+    then return 0
+    else return 1
+  else
+    Trap {cycles_used = es.cycles_used;}
 
 ic0.debug_print<es>(src : i32, size : i32) =
   return

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1471,7 +1471,7 @@ The canister can check whether a given principal is one of its controllers.
 
 Checks whether the principal identified by `src`/`size` is one of the controllers of the canister. If yes, then a value of 1 is returned, otherwise a 0 is returned. It can be called multiple times.
 
-This system call traps if `src+size` exceeds the size of the WebAssembly memory.
+This system call traps if `src+size` exceeds the size of the WebAssembly memory or the principal identified by `src`/`size` is not a valid binary encoding of a principal.
 
 [#system-api-certified-data]
 === Certified data


### PR DESCRIPTION
This PR adds a new system api call to allow a canister to check whether a given principal is one of its own controllers. This is a useful check for canisters and it has come up in various contexts, for example when canisters want to perform some access control on their methods based on whether the caller is a controller.