### PR TITLE
IC-1462 extend the error space for update requests

### DIFF
--- a/spec/ic.did
+++ b/spec/ic.did
@@ -116,8 +116,8 @@ service ic : {
     headers: vec http_header;
     body : opt blob;
     transform : opt record {
-      function : func (record {response : http_response; context : blob}) -> (http_response) query;
-      context : blob
+      function : func (record {response : http_response; arg : blob}) -> (http_response) query;
+      arg : blob
     };
   }) -> (http_response);
 

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -530,7 +530,11 @@ In order to call a canister, the user makes a POST request to `/api/v2/canister/
 * `method_name` (`text`): Name of the canister method to call
 * `arg` (`blob`): Argument to pass to the canister method
 
-The HTTP response to this request has an empty body and HTTP status 202, or a HTTP error (4xx or 5xx). Paranoid agents should not trust this response, and use <<http-read-state,`read_state`>> to determine the status of the call.
+The HTTP response to this request can have the following responses:
+* 202 HTTP status with empty body. Implying the request was accepted by the IC for further processing. Users should use <<http-read-state,`read_state`>> to determine the status of the call.
+* 200 HTTP status with non-empty body. Implying an execution pre-processing error occurred. The body of the response contains more information about the user error. This return type
+is used when the error can be handled by the canister owner (e.g. when a canister is out of cycles) 
+* 4xx or 5xx HTTP error. 
 
 This request type can _also_ be used to call a query method. A user may choose to go this way, instead of via the faster and cheaper <<http-query>> below, if they want to get a _certified_ response.
 


### PR DESCRIPTION
More context can be found at https://dfinity.atlassian.net/browse/IC-1462.

To summarize, the current problem we are facing is that IC platform errors are mixed with canister owner errors which causes confusion among engineers how different errors should be handled.

This proposal is an attempt to have have a clear separation between canister owner errors and IC platform errors.