### PR TITLE
reset certified variables upon canister reinstall

### DIFF
--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1460,7 +1460,7 @@ The main purpose of this counter is to facilitate in-canister performance profil
 [#system-api-certified-data]
 === Certified data
 
-For each canister, the IC keeps track of “certified data”, a canister-defined blob. For fresh canisters, this blob is the empty blob (`""`).
+For each canister, the IC keeps track of “certified data”, a canister-defined blob. For fresh canisters (upon install or reinstall), this blob is the empty blob (`""`).
 
 * `+ic0.certified_data_set : (src: i32, size : i32) -> ()+`
 +

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -3376,10 +3376,7 @@ S with
       public_custom_sections = Public_custom_sections;
       private_custom_sections = Private_custom_sections;
     }
-    if New_certified_data ≠ NoCertifiedData:
-      certified_data[A.canister_id] = New_certified_data
-    else:
-      certified_data[A.canister_id] = NoCertifiedData
+    certified_data[A.canister_id] = NoCertifiedData
     if New_global_timer ≠ NoGlobalTimer:
       global_timer[A.canister_id] = New_global_timer
     else:

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -3378,6 +3378,8 @@ S with
     }
     if New_certified_data ≠ NoCertifiedData:
       certified_data[A.canister_id] = New_certified_data
+    else:
+      certified_data[A.canister_id] = NoCertifiedData
     if New_global_timer ≠ NoGlobalTimer:
       global_timer[A.canister_id] = New_global_timer
     else:

--- a/theories/IC.thy
+++ b/theories/IC.thy
@@ -1663,7 +1663,7 @@ definition ic_code_installation_post :: "nat \<Rightarrow> ('p, 'uid, 'canid, 'b
         (init_return.new_state ret, init_return.new_certified_data ret, init_return.new_global_timer ret, init_return.cycles_used ret)) in
     S\<lparr>canisters := list_map_set (canisters S) cid (Some \<lparr>wasm_state = new_state, module = m, raw_module = w,
         public_custom_sections = the (parse_public_custom_sections w), private_custom_sections = the (parse_private_custom_sections w)\<rparr>),
-      certified_data := (case new_certified_data of None \<Rightarrow> certified_data S | Some cd \<Rightarrow> list_map_set (certified_data S) cid cd),
+      certified_data := list_map_set (certified_data S) cid (case new_certified_data of None \<Rightarrow> empty_blob | Some cd \<Rightarrow> cd),
       global_timer := list_map_set (global_timer S) cid (case new_global_timer of None \<Rightarrow> 0 | Some new_timer \<Rightarrow> new_timer),
       canister_version := list_map_set (canister_version S) cid (Suc idx),
       balances := list_map_set (balances S) cid (bal - cyc_used),


### PR DESCRIPTION
Currently, certified variables are reset to empty if the canister is uninstalled, but if the canister is reinstalled. This MR makes this behavior consistent.