### PR TITLE
Clarification to `bitcoin_send_transaction` API

### DIFF
--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1879,8 +1879,8 @@ If at least one of these checks fails, the call is rejected.
 
 If the transaction passes these tests, the transaction is forwarded to the
 specified Bitcoin network.
-Note that the function does not provide any guarantees that a submitted
-transaction will ever appear in a block.
+Note that the function does not provide any guarantees that the transaction will make it into the mempool or that
+the transaction will ever appear in a block.
 
 [#ic-bitcoin_get_current_fee_percentiles]
 === IC method `bitcoin_get_current_fee_percentiles`


### PR DESCRIPTION
In some discussions, people assumed that the `bitcoin_send_transaction` endpoint guarantees delivery to the mempool. This commit adds a clarification that explicitly states that delivery to the mempool is not guaranteed.