### PR TITLE
chore: minor clarification

### DIFF
--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1102,7 +1102,7 @@ Eventually, the canister will want to respond to the original call, either by re
 +
 Appends data it to the (initially empty) data reply.
 +
-NOTE: This can be invoked multiple times to build up the argument with data from various places on the Wasm heap. This way, the canister does not have to first copy all the pieces from various places into one location.
+NOTE: This can be invoked multiple times within the same message execution to build up the argument with data from various places on the Wasm heap. This way, the canister does not have to first copy all the pieces from various places into one location.
 +
 This traps if the current call already has been or does not need to be responded to.
 

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1105,6 +1105,8 @@ Appends data it to the (initially empty) data reply.
 NOTE: This can be invoked multiple times within the same message execution to build up the argument with data from various places on the Wasm heap. This way, the canister does not have to first copy all the pieces from various places into one location.
 +
 This traps if the current call already has been or does not need to be responded to.
++
+Any data assembled, but not replied using `ic0.msg_reply`, gets discarded at the end of the current message execution.
 
 * `+ic0.msg_reply : () -> ()+`
 +

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1106,7 +1106,7 @@ NOTE: This can be invoked multiple times within the same message execution to bu
 +
 This traps if the current call already has been or does not need to be responded to.
 +
-Any data assembled, but not replied using `ic0.msg_reply`, gets discarded at the end of the current message execution.
+Any data assembled, but not replied using `ic0.msg_reply`, gets discarded at the end of the current message execution. In particular, the reply buffer gets reset when the canister yields control without calling `ic0.msg_reply`.
 
 * `+ic0.msg_reply : () -> ()+`
 +


### PR DESCRIPTION
As we start every message execution with an empty execution state,
the `response_data` added by the `ic0.msg_reply_data_append` system call
and not committed using the `ic0.msg_reply` gets dropped at the end
of the current message execution.

In other words, it's impossible to append the reply data across await points.
