### PR TITLE
Deleted call contexts again prevent canister from reaching Stopped state

### DIFF
--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1636,7 +1636,7 @@ Note that this is different from `uninstall_code` followed by `install_code`, as
 
 This is atomic: If the response to this request is a `reject`, then this call had no effect.
 
-NOTE: Some canisters may not be able to make sense of callbacks after upgrades; these should be stopped first, to wait for all outstanding callbacks, or be uninstalled first, to prevent outstanding callbacks from being invoked. It is expected that the canister admin (or their tooling) does that separately.
+NOTE: Some canisters may not be able to make sense of callbacks after upgrades; these should be stopped first, to wait for all outstanding callbacks, or be uninstalled first, to prevent outstanding callbacks from being invoked (by marking the corresponding call contexts as deleted). It is expected that the canister admin (or their tooling) does that separately.
 
 The `wasm_module` field specifies the canister module to be installed.
 The system supports multiple encodings of the `wasm_module` field, as described in <<canister-module-format>>:
@@ -2853,7 +2853,7 @@ State after::
 ==== Call context creation
 
 Before invoking a heartbeat, a global timer, or a message to a public entry point, a call context is created for bookkeeping purposes.
-For these invocations the canister must be running (so not stopped, or stopping).
+For these invocations the canister must be running (so not stopped or stopping).
 Additionally, these invocations only happen for "real" canisters, not the IC management canister.
 
 This “bookkeeping transition” must be immediately followed by the corresponding <<rule-message-execution,“Message execution” transition>>.
@@ -3589,7 +3589,7 @@ S with
 
 ==== IC Management Canister: Stopping a canister
 
-The controllers of a canister can stop a canister. Stopping a canister goes through two steps. First, the status of the canister is set to `Stopping`; as explained above, a stopping canister rejects all incoming requests and continues processing outstanding responses. When a stopping canister has no more open call contexts, its status is changed to `Stopped` and a response is generated. Note that when processing responses, a stopping canister can make calls to other canisters and thus create new call contexts. In addition, a canister which is stopped, or stopping will accept (and respond) to further `stop_canister` requests.
+The controllers of a canister can stop a canister. Stopping a canister goes through two steps. First, the status of the canister is set to `Stopping`; as explained above, a stopping canister rejects all incoming requests and continues processing outstanding responses. When a stopping canister has no more open call contexts, its status is changed to `Stopped` and a response is generated. Note that when processing responses, a stopping canister can make calls to other canisters and thus create new call contexts. In addition, a canister which is stopped or stopping will accept (and respond) to further `stop_canister` requests.
 
 We encode this behavior via three (types of) transitions:
 

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -228,7 +228,7 @@ The canister status can be used to control whether the canister is processing ca
 
 * In status `running`, calls to the canister are processed as normal.
 * In status `stopping`, calls to the canister are rejected by the IC with reject code `CANISTER_ERROR` (5), but responses to the canister are processed as normal.
-* In status `stopped`, calls to the canister are rejected by the IC with reject code `CANISTER_ERROR` (5), and there are no outstanding responses to call contexts that are not marked as deleted.
+* In status `stopped`, calls to the canister are rejected by the IC with reject code `CANISTER_ERROR` (5), and there are no outstanding responses.
 
 In all cases, calls to the <<ic-management-canister,management canister>> are processed, regardless of the state of the managed canister.
 
@@ -1636,7 +1636,7 @@ Note that this is different from `uninstall_code` followed by `install_code`, as
 
 This is atomic: If the response to this request is a `reject`, then this call had no effect.
 
-NOTE: Some canisters may not be able to make sense of callbacks after upgrades; these should be stopped first, to wait for all outstanding callbacks that are not marked as deleted, or be uninstalled first, to prevent outstanding callbacks from being invoked (by marking the corresponding call contexts as deleted). It is expected that the canister admin (or their tooling) does that separately.
+NOTE: Some canisters may not be able to make sense of callbacks after upgrades; these should be stopped first, to wait for all outstanding callbacks, or be uninstalled first, to prevent outstanding callbacks from being invoked. It is expected that the canister admin (or their tooling) does that separately.
 
 The `wasm_module` field specifies the canister module to be installed.
 The system supports multiple encodings of the `wasm_module` field, as described in <<canister-module-format>>:
@@ -1703,7 +1703,7 @@ The controllers of a canister may stop a canister (e.g., to prepare for a canist
 Stopping a canister is not an atomic action. The immediate effect is that the status of the canister is changed to `stopping` (unless the canister is already stopped).
 The IC will reject all calls to a stopping canister, indicating that the canister is stopping.
 Responses to a stopping canister are processed as usual.
-When all outstanding responses to call contexts that are not marked as deleted have been processed (so there are no open call contexts that are not marked as deleted), the canister status is changed to `stopped` and the management canister responds to the caller of the `stop_canister` request.
+When all outstanding responses have been processed (so there are no open call contexts), the canister status is changed to `stopped` and the management canister responds to the caller of the `stop_canister` request.
 
 [#ic-start_canister]
 === IC method `start_canister`
@@ -3589,12 +3589,12 @@ S with
 
 ==== IC Management Canister: Stopping a canister
 
-The controllers of a canister can stop a canister. Stopping a canister goes through two steps. First, the status of the canister is set to `Stopping`; as explained above, a stopping canister rejects all incoming requests and continues processing outstanding responses. When a stopping canister has no more open call contexts that are not marked as deleted, its status is changed to `Stopped` and a response is generated. Note that when processing responses, a stopping canister can make calls to other canisters and thus create new call contexts. In addition, a canister which is stopped, or stopping will accept (and respond) to further `stop_canister` requests.
+The controllers of a canister can stop a canister. Stopping a canister goes through two steps. First, the status of the canister is set to `Stopping`; as explained above, a stopping canister rejects all incoming requests and continues processing outstanding responses. When a stopping canister has no more open call contexts, its status is changed to `Stopped` and a response is generated. Note that when processing responses, a stopping canister can make calls to other canisters and thus create new call contexts. In addition, a canister which is stopped, or stopping will accept (and respond) to further `stop_canister` requests.
 
 We encode this behavior via three (types of) transitions:
 
 1. First, any `stop_canister` call sets the state of the canister to `Stopping`; we record in the status the origin (and cycles) of all `stop_canister` calls which arrive at the canister while it is stopping (or stopped).
-2. Next, when the canister has no open call contexts that are not marked as deleted (so, in particular, all outstanding responses to the canister have been processed or will be discared because the call context has been marked as deleted), the status of the canister is set to `Stopped`.
+2. Next, when the canister has no open call contexts (so, in particular, all outstanding responses to the canister have been processed), the status of the canister is set to `Stopped`.
 3. Finally, each pending `stop_canister` call (which are encoded in the status) is responded to, to indicate that the canister is stopped.
 
 Conditions::
@@ -3634,12 +3634,12 @@ S with
 ....
 
 
-The status of a stopping canister which has no open call contexts that are not marked as deleted is set to `Stopped`, and all pending `stop_canister` calls are replied to.
+The status of a stopping canister which has no open call contexts is set to `Stopped`, and all pending `stop_canister` calls are replied to.
 
 Conditions::
 ....
     S.canister_status[CanisterId] = Stopping Origins
-    ∀ Ctxt_id. S.call_contexts[Ctxt_id].deleted or S.call_contexts[Ctxt_id].canister ≠ CanisterId
+    ∀ Ctxt_id. S.call_contexts[Ctxt_id].canister ≠ CanisterId
 ....
 State after::
 ....

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -2655,6 +2655,13 @@ The following is an incomplete list of invariants that should hold for the abstr
   if Ctxt.needs_to_respond = false then Ctxt.available_cycles = 0
 ....
 
+* A stopped canister does not have any call contexts (in particular, a stopped canister does not have any call contexts marked as deleted):
++
+....
+∀ Ctxt_id ↦ Ctxt ∈ S.call_contexts:
+  S.canister_status[Ctxt.canister] ≠ Stopped
+....
+
 * Referenced call contexts exist:
 +
 ....

--- a/theories/IC.thy
+++ b/theories/IC.thy
@@ -2026,7 +2026,7 @@ qed
 definition ic_canister_stop_done_stopping_pre :: "'canid \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
   "ic_canister_stop_done_stopping_pre cid S =
     (case list_map_get (canister_status S) cid of Some (Stopping os) \<Rightarrow>
-      (\<forall>ctxt \<in> list_map_range (call_contexts S). call_ctxt_deleted ctxt \<or> call_ctxt_canister ctxt \<noteq> cid)
+      (\<forall>ctxt \<in> list_map_range (call_contexts S). call_ctxt_canister ctxt \<noteq> cid)
     | _ \<Rightarrow> False)"
 
 definition ic_canister_stop_done_stopping_post :: "'canid \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic" where

--- a/theories/IC.thy
+++ b/theories/IC.thy
@@ -306,6 +306,9 @@ lift_definition call_ctxt_respond :: "('p, 'uid, 'canid, 'b, 's, 'c, 'cid) call_
   "\<lambda>ctxt. ctxt\<lparr>needs_to_respond := False, available_cycles := 0\<rparr>"
   by auto
 
+lemma call_ctxt_respond_canister[simp]: "call_ctxt_canister (call_ctxt_respond ctxt) = call_ctxt_canister ctxt"
+  by transfer auto
+
 lemma call_ctxt_respond_origin[simp]: "call_ctxt_origin (call_ctxt_respond ctxt) = call_ctxt_origin ctxt"
   by transfer auto
 
@@ -319,6 +322,9 @@ lift_definition call_ctxt_deduct_cycles :: "nat \<Rightarrow> ('p, 'uid, 'canid,
   "\<lambda>n ctxt. ctxt\<lparr>available_cycles := available_cycles ctxt - n\<rparr>"
   by auto
 
+lemma call_ctxt_deduct_cycles_canister[simp]: "call_ctxt_canister (call_ctxt_deduct_cycles n ctxt) = call_ctxt_canister ctxt"
+  by transfer auto
+
 lemma call_ctxt_deduct_cycles_origin[simp]: "call_ctxt_origin (call_ctxt_deduct_cycles n ctxt) = call_ctxt_origin ctxt"
   by transfer auto
 
@@ -331,6 +337,9 @@ lemma call_ctxt_deduct_cycles_available_cycles[simp]: "call_ctxt_available_cycle
 lift_definition call_ctxt_delete :: "('p, 'uid, 'canid, 'b, 's, 'c, 'cid) call_ctxt \<Rightarrow> ('p, 'uid, 'canid, 'b, 's, 'c, 'cid) call_ctxt" is
   "\<lambda>ctxt. ctxt\<lparr>deleted := True, needs_to_respond := False, available_cycles := 0\<rparr>"
   by auto
+
+lemma call_ctxt_delete_canister[simp]: "call_ctxt_canister (call_ctxt_delete ctxt) = call_ctxt_canister ctxt"
+  by transfer auto
 
 lemma call_ctxt_delete_needs_to_respond[simp]: "call_ctxt_needs_to_respond (call_ctxt_delete ctxt) = False"
   by transfer auto
@@ -470,6 +479,53 @@ lemma ic_can_status_inv_del: "ic_can_status_inv x z \<Longrightarrow>
   ic_can_status_inv x (z - {ctxt_id})"
   by (fastforce simp: ic_can_status_inv_def split: can_status.splits call_origin.splits)
 
+definition ic_inv_call_ctxt_stopped :: "('p, 'uid, 'canid, 'b, 's, 'c, 'cid) call_ctxt set \<Rightarrow>
+  ('canid, ('b, 'p, 'uid, 'canid, 's, 'c, 'cid) can_status) list_map \<Rightarrow> bool" where
+  "ic_inv_call_ctxt_stopped ctxts can_status = (\<forall>ctxt \<in> ctxts. list_map_get can_status (call_ctxt_canister ctxt) \<noteq> Some Stopped)"
+
+lemma ic_inv_call_ctxt_stopped_mono1:
+  assumes "ic_inv_call_ctxt_stopped (list_map_range ctxts) can_status"
+  shows "ic_inv_call_ctxt_stopped (list_map_range (list_map_del ctxts ctxt_id)) can_status"
+  using assms
+  by (auto simp: ic_inv_call_ctxt_stopped_def list_map_range_del)
+
+lemma ic_inv_call_ctxt_stopped_mono2:
+  assumes "ic_inv_call_ctxt_stopped ctxts can_status"
+  shows "ic_inv_call_ctxt_stopped ctxts (list_map_del can_status can_id)"
+  using assms
+  by (auto simp: ic_inv_call_ctxt_stopped_def list_map_get_del)
+
+lemma ic_inv_stopped_ctxt_stopped_set_running:
+  assumes "ic_inv_call_ctxt_stopped ctxts can_status"
+  shows "ic_inv_call_ctxt_stopped ctxts (list_map_set can_status cid Running)"
+  using assms
+  by (auto simp: ic_inv_call_ctxt_stopped_def list_map_get_set)
+
+lemma ic_inv_call_ctxt_stopped_set_stopping:
+  assumes "ic_inv_call_ctxt_stopped ctxts can_status"
+  shows "ic_inv_call_ctxt_stopped ctxts (list_map_set can_status can_id (Stopping os))"
+  using assms
+  by (auto simp: ic_inv_call_ctxt_stopped_def list_map_get_set)
+
+lemma ic_inv_call_ctxt_stopped_set_stopped:
+  assumes "ic_inv_call_ctxt_stopped ctxts can_status"
+    "\<And>ctxt. ctxt \<in> ctxts \<Longrightarrow> call_ctxt_canister ctxt \<noteq> cid"
+  shows "ic_inv_call_ctxt_stopped ctxts (list_map_set can_status cid Stopped)"
+  using assms
+  by (auto simp: ic_inv_call_ctxt_stopped_def list_map_get_set)
+
+lemma ic_inv_call_ctxt_stopped_set_respond:
+  assumes "ic_inv_call_ctxt_stopped (list_map_range ctxts) can_status" "ctxt \<in> list_map_range ctxts"
+  shows "ic_inv_call_ctxt_stopped (list_map_range (list_map_set ctxts ctxt_id (call_ctxt_respond ctxt))) can_status"
+  using assms
+  by (auto simp: ic_inv_call_ctxt_stopped_def dest!: list_map_range_setD)
+
+lemma ic_inv_call_ctxt_stopped_map_map:
+  assumes "ic_inv_call_ctxt_stopped (list_map_range ctxts) can_status"
+  shows "ic_inv_call_ctxt_stopped (list_map_range (list_map_map (\<lambda>ctxt. if call_ctxt_canister ctxt = cid then call_ctxt_delete ctxt else ctxt) ctxts)) can_status"
+  using assms
+  by (auto simp: ic_inv_call_ctxt_stopped_def)
+
 definition ic_inv :: "('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
   "ic_inv S = ((\<forall>msg \<in> set (messages S). case msg of
     Call_message (From_canister ctxt_id _) _ _ _ _ _ _ \<Rightarrow> ctxt_id \<in> list_map_dom (call_contexts S)
@@ -478,10 +534,11 @@ definition ic_inv :: "('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Ri
   (\<forall>ctxt \<in> list_map_range (call_contexts S). call_ctxt_needs_to_respond ctxt \<longrightarrow>
     (case call_ctxt_origin ctxt of From_canister ctxt_id _ \<Rightarrow> ctxt_id \<in> list_map_dom (call_contexts S)
     | _ \<Rightarrow> True)) \<and>
-  ic_can_status_inv (list_map_range (canister_status S)) (list_map_dom (call_contexts S)))"
+  ic_can_status_inv (list_map_range (canister_status S)) (list_map_dom (call_contexts S)) \<and>
+  ic_inv_call_ctxt_stopped (list_map_range (call_contexts S)) (canister_status S))"
 
 lemma ic_initial_inv: "ic_inv (initial_ic t pk)"
-  by (auto simp: ic_inv_def ic_can_status_inv_def initial_ic_def split: call_origin.splits)
+  by (auto simp: ic_inv_def ic_can_status_inv_def ic_inv_call_ctxt_stopped_def initial_ic_def split: call_origin.splits)
 
 (* Candid *)
 
@@ -847,6 +904,9 @@ lift_definition create_call_ctxt :: "'canid \<Rightarrow> ('b, 'p, 'uid, 'canid,
   "\<lambda>cee orig trans_cycles. \<lparr>canister = cee, origin = orig, needs_to_respond = True, deleted = False, available_cycles = trans_cycles\<rparr>"
   by auto
 
+lemma create_call_ctxt_canister[simp]: "call_ctxt_canister (create_call_ctxt cee orig trans_cycles) = cee"
+  by transfer auto
+
 lemma create_call_ctxt_origin[simp]: "call_ctxt_origin (create_call_ctxt cee orig trans_cycles) = orig"
   by transfer auto
 
@@ -883,7 +943,7 @@ lemma call_context_create_ic_inv:
   assumes "call_context_create_pre n ctxt_id S" "ic_inv S"
   shows "ic_inv (call_context_create_post n ctxt_id S)"
   using assms
-  by (auto simp: ic_inv_def call_context_create_pre_def call_context_create_post_def Let_def
+  by (auto simp: ic_inv_def ic_inv_call_ctxt_stopped_def call_context_create_pre_def call_context_create_post_def Let_def
       split: sum.splits message.splits call_origin.splits option.splits
       dest!: in_set_takeD in_set_dropD nth_mem[of n "messages S"] in_set_updD list_map_range_setD
       intro: ic_can_status_inv_mono2)
@@ -895,6 +955,9 @@ lemma call_context_create_ic_inv:
 lift_definition create_call_ctxt_system_task :: "'canid \<Rightarrow> ('p, 'uid, 'canid, 'b, 's, 'c, 'cid) call_ctxt" is
   "\<lambda>cee. \<lparr>canister = cee, origin = From_system, needs_to_respond = False, deleted = False, available_cycles = 0\<rparr>"
   by auto
+
+lemma create_call_ctxt_system_task_canister[simp]: "call_ctxt_canister (create_call_ctxt_system_task cee) = cee"
+  by transfer auto
 
 lemma create_call_ctxt_system_task_needs_to_respond[simp]: "call_ctxt_needs_to_respond (create_call_ctxt_system_task cee) = False"
   by transfer auto
@@ -927,7 +990,7 @@ lemma call_context_heartbeat_ic_inv:
   assumes "call_context_heartbeat_pre cee ctxt_id S" "ic_inv S"
   shows "ic_inv (call_context_heartbeat_post cee ctxt_id S)"
   using assms
-  by (auto simp: ic_inv_def call_context_heartbeat_pre_def call_context_heartbeat_post_def Let_def
+  by (auto simp: ic_inv_def ic_inv_call_ctxt_stopped_def call_context_heartbeat_pre_def call_context_heartbeat_post_def Let_def
       split: sum.splits message.splits call_origin.splits option.splits
       dest!: in_set_takeD in_set_dropD in_set_updD list_map_range_setD
       intro: ic_can_status_inv_mono2)
@@ -963,7 +1026,7 @@ lemma call_context_global_timer_ic_inv:
   assumes "call_context_global_timer_pre cee ctxt_id S" "ic_inv S"
   shows "ic_inv (call_context_global_timer_post cee ctxt_id S)"
   using assms
-  by (auto simp: ic_inv_def call_context_global_timer_pre_def call_context_global_timer_post_def Let_def
+  by (auto simp: ic_inv_def ic_inv_call_ctxt_stopped_def call_context_global_timer_pre_def call_context_global_timer_post_def Let_def
       split: sum.splits message.splits call_origin.splits option.splits
       dest!: in_set_takeD in_set_dropD in_set_updD list_map_range_setD
       intro: ic_can_status_inv_mono2)
@@ -1349,7 +1412,7 @@ proof (rule message_execution_cases[OF assms(1)])
     call_contexts := list_map_set (call_contexts S) ctxt_id new_ctxt, certified_data := cert_data, global_timer := glob_timer, balances := list_map_set (balances S) recv New_balance\<rparr>)"
     using assms(2) list_map_get_range[OF ctxt]
     by (cases R)
-       (force simp: ic_inv_def ic_can_status_inv_def split: message.splits call_origin.splits can_status.splits dest!: in_set_takeD in_set_dropD list_map_range_setD)+
+       (force simp: ic_inv_def ic_can_status_inv_def ic_inv_call_ctxt_stopped_def split: message.splits call_origin.splits can_status.splits dest!: in_set_takeD in_set_dropD list_map_range_setD)+
 next
   fix recv bal Is_response cyc_used idx
   show "ic_inv (S\<lparr>messages := take n (messages S) @ drop (Suc n) (messages S),
@@ -1399,7 +1462,7 @@ lemma call_context_starvation_ic_inv:
   by (auto simp: ic_inv_def call_context_starvation_pre_def call_context_starvation_post_def Let_def
       split: sum.splits message.splits call_origin.splits option.splits
       dest!: in_set_takeD in_set_dropD in_set_updD list_map_range_setD list_map_get_range
-      intro: ic_can_status_inv_mono2)
+      intro: ic_can_status_inv_mono2 ic_inv_call_ctxt_stopped_set_respond)
 
 
 
@@ -1445,7 +1508,7 @@ lemma call_context_removal_ic_inv:
   by (force simp: ic_inv_def call_context_removal_pre_def call_context_removal_post_def Let_def
       split: sum.splits message.splits call_origin.splits option.splits
       dest!: in_set_takeD in_set_dropD in_set_updD list_map_range_setD list_map_get_range list_map_range_del
-      intro!: ic_can_status_inv_del[where ?z="list_map_dom (call_contexts S)"])
+      intro!: ic_can_status_inv_del[where ?z="list_map_dom (call_contexts S)"] ic_inv_call_ctxt_stopped_mono1)
 
 
 
@@ -1511,7 +1574,7 @@ lemma ic_canister_creation_ic_inv:
   by (auto simp: ic_inv_def ic_canister_creation_pre_def ic_canister_creation_post_def Let_def
       split: sum.splits message.splits call_origin.splits option.splits
       dest!: in_set_takeD in_set_dropD nth_mem[of n "messages S"] in_set_updD list_map_range_setD list_map_get_range list_map_range_del
-      intro: ic_can_status_inv_mono1)
+      intro: ic_can_status_inv_mono1 ic_inv_stopped_ctxt_stopped_set_running)
 
 
 
@@ -1898,9 +1961,10 @@ lemma ic_code_uninstallation_ic_inv:
   shows "ic_inv (ic_code_uninstallation_post n S)"
   using assms
   by (auto simp: ic_inv_def ic_code_uninstallation_pre_def ic_code_uninstallation_post_def Let_def
+      simp del: list_map_range_map_map
       split: sum.splits message.splits call_origin.splits option.splits if_splits
       dest!: in_set_takeD in_set_dropD nth_mem[of n "messages S"] in_set_updD list_map_range_setD list_map_get_range list_map_range_del
-      in_set_map_filter_vals)
+      in_set_map_filter_vals intro!: ic_inv_call_ctxt_stopped_map_map) auto
 
 
 
@@ -1954,10 +2018,10 @@ proof -
     by (auto simp: ic_canister_stop_running_pre_def split: message.splits option.splits)
   show ?thesis
     using assms
-    by (force simp: ic_inv_def ic_canister_stop_running_pre_def ic_canister_stop_running_post_def msg Let_def
+    by (auto simp: ic_inv_def ic_canister_stop_running_pre_def ic_canister_stop_running_post_def msg Let_def
         split: sum.splits message.splits call_origin.splits option.splits if_splits can_status.splits
         dest!: in_set_takeD in_set_dropD nth_mem[of n "messages S"] in_set_updD list_map_range_setD list_map_get_range list_map_range_del
-        in_set_map_filter_vals intro!: ic_can_status_inv_stopping[where ?x="list_map_range (canister_status S)" and ?os=orig])
+        in_set_map_filter_vals intro!: ic_can_status_inv_stopping[where ?x="list_map_range (canister_status S)" and ?os=orig] ic_inv_call_ctxt_stopped_set_stopping)
 qed
 
 
@@ -2016,7 +2080,7 @@ proof -
     by (force simp: ic_inv_def ic_canister_stop_stopping_pre_def ic_canister_stop_stopping_post_def msg Let_def
         split: sum.splits message.splits call_origin.splits option.splits if_splits can_status.splits
         dest!: in_set_takeD in_set_dropD nth_mem[of n "messages S"] in_set_updD list_map_range_setD list_map_get_range list_map_range_del
-        in_set_map_filter_vals intro!: ic_can_status_inv_stopping_app[where ?x="list_map_range (canister_status S)" and ?os=orig])
+        in_set_map_filter_vals intro!: ic_can_status_inv_stopping_app[where ?x="list_map_range (canister_status S)" and ?os=orig] ic_inv_call_ctxt_stopped_set_stopping)
 qed
 
 
@@ -2057,7 +2121,7 @@ lemma ic_canister_stop_done_stopping_ic_inv:
   by (force simp: ic_inv_def ic_can_status_inv_def ic_canister_stop_done_stopping_pre_def ic_canister_stop_done_stopping_post_def Let_def
       split: sum.splits message.splits call_origin.splits option.splits if_splits can_status.splits
       dest!: in_set_takeD in_set_dropD in_set_updD list_map_range_setD list_map_get_range list_map_range_del
-      in_set_map_filter_vals)
+      in_set_map_filter_vals intro!: ic_inv_call_ctxt_stopped_set_stopped)
 
 
 
@@ -2159,7 +2223,7 @@ lemma ic_canister_start_not_stopping_ic_inv:
   by (auto simp: ic_inv_def ic_canister_start_not_stopping_pre_def ic_canister_start_not_stopping_post_def Let_def
       split: sum.splits message.splits call_origin.splits option.splits if_splits can_status.splits
       dest!: in_set_takeD in_set_dropD nth_mem[of n "messages S"] in_set_updD list_map_range_setD list_map_get_range list_map_range_del
-      in_set_map_filter_vals intro: ic_can_status_inv_mono1)
+      in_set_map_filter_vals intro: ic_can_status_inv_mono1 ic_inv_stopped_ctxt_stopped_set_running)
 
 
 
@@ -2218,7 +2282,7 @@ lemma ic_canister_start_stopping_ic_inv:
   apply (auto simp: ic_inv_def ic_canister_start_stopping_pre_def ic_canister_start_stopping_post_def Let_def
       split: sum.splits message.splits call_origin.splits option.splits if_splits can_status.splits
       dest!: in_set_takeD in_set_dropD nth_mem[of n "messages S"] in_set_updD list_map_range_setD list_map_get_range list_map_range_del in_set_map_filter_vals
-      intro: ic_can_status_inv_mono1)
+      intro: ic_can_status_inv_mono1 ic_inv_stopped_ctxt_stopped_set_running)
    apply (fastforce simp: ic_can_status_inv_def)+
   done
 
@@ -2284,7 +2348,7 @@ lemma ic_canister_deletion_ic_inv:
   by (auto simp: ic_inv_def ic_canister_deletion_pre_def ic_canister_deletion_post_def Let_def
       split: sum.splits message.splits call_origin.splits option.splits if_splits can_status.splits
       dest!: in_set_takeD in_set_dropD nth_mem[of n "messages S"] in_set_updD list_map_range_setD list_map_get_range list_map_range_del in_set_map_filter_vals
-      intro: ic_can_status_inv_mono1)
+      intro: ic_can_status_inv_mono1 ic_inv_call_ctxt_stopped_mono2)
 
 
 
@@ -2450,7 +2514,7 @@ lemma ic_provisional_canister_creation_ic_inv:
   by (auto simp: ic_inv_def ic_provisional_canister_creation_pre_def ic_provisional_canister_creation_post_def Let_def
       split: sum.splits message.splits call_origin.splits option.splits if_splits can_status.splits
       dest!: in_set_takeD in_set_dropD nth_mem[of n "messages S"] in_set_updD list_map_range_setD list_map_get_range list_map_range_del in_set_map_filter_vals
-      intro: ic_can_status_inv_mono1)
+      intro: ic_can_status_inv_mono1 ic_inv_stopped_ctxt_stopped_set_running)
 
 
 
@@ -2749,9 +2813,10 @@ lemma canister_out_of_cycles_ic_inv:
   shows "ic_inv (canister_out_of_cycles_post cid S)"
   using assms
   by (auto simp: ic_inv_def canister_out_of_cycles_pre_def canister_out_of_cycles_post_def Let_def
+      simp del: list_map_range_map_map
       split: sum.splits message.splits call_origin.splits option.splits if_splits can_status.splits
       dest!: in_set_takeD in_set_dropD in_set_updD list_map_range_setD list_map_get_range list_map_range_del
-      in_set_map_filter_vals)
+      in_set_map_filter_vals intro!: ic_inv_call_ctxt_stopped_map_map) auto
 
 
 


### PR DESCRIPTION
This PR reverts #83 and adds an invariant that stopped canisters do not have any call contexts (in particular, stopped canisters do not have any call contexts marked as deleted) with a corresponding extension of the formal model.