### PR TITLE
revise Call context removal transition

### DIFF
--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -3171,17 +3171,11 @@ S with
 
 ==== Call context removal
 
-If there is no call, downstream calling context, or response that references a call context, and the call context has been replied to or the call context corresponds to a heartbeat or global timer that had already been executed, then the call context can be removed.
+If there is no call, downstream call context, or response that references a call context, and the call context does not need to respond (because it has already responded or its origin is a system task that does not await a response), then the call context can be removed.
 
 Conditions::
 ....
-    (
-      S.call_contexts[Ctxt_id].needs_to_respond = false
-    ) or
-    (
-      S.call_contexts[Ctxt_id].origin = FromSystemTask
-      ∀ FuncMessage M ∈ S.messages. M.call_context ≠ Ctxt_id
-    )
+    S.call_contexts[Ctxt_id].needs_to_respond = false
     ∀ CallMessage {origin = FromCanister O, …} ∈ S.messages. O.calling_context ≠ Ctxt_id
     ∀ ResponseMessage {origin = FromCanister O, …} ∈ S.messages. O.calling_context ≠ Ctxt_id
     ∀ _ ↦ {needs_to_respond = true, origin = FromCanister O, …} ∈ S.call_contexts: O.calling_context ≠ Ctxt_id

--- a/theories/IC.thy
+++ b/theories/IC.thy
@@ -1471,11 +1471,7 @@ lemma call_context_starvation_ic_inv:
 definition call_context_removal_pre :: "'cid \<Rightarrow> ('p, 'uid, 'canid, 'b, 'w, 'sm, 'c, 's, 'cid, 'pk) ic \<Rightarrow> bool" where
   "call_context_removal_pre ctxt_id S = (
     (case list_map_get (call_contexts S) ctxt_id of Some call_context \<Rightarrow>
-      (\<not>call_ctxt_needs_to_respond call_context \<or>
-        (call_ctxt_origin call_context = From_system \<and>
-          (\<forall>msg \<in> set (messages S). case msg of
-            Func_message other_ctxt_id _ _ _ \<Rightarrow> other_ctxt_id \<noteq> ctxt_id
-          | _ \<Rightarrow> True))) \<and>
+      \<not>call_ctxt_needs_to_respond call_context \<and>
       (\<forall>msg \<in> set (messages S). case msg of
           Call_message ctxt _ _ _ _ _ _ \<Rightarrow> calling_context ctxt \<noteq> Some ctxt_id
         | Response_message ctxt _ _ \<Rightarrow> calling_context ctxt \<noteq> Some ctxt_id
@@ -1484,7 +1480,7 @@ definition call_context_removal_pre :: "'cid \<Rightarrow> ('p, 'uid, 'canid, 'b
         call_ctxt_needs_to_respond other_call_context \<longrightarrow>
         calling_context (call_ctxt_origin other_call_context) \<noteq> Some ctxt_id) \<and>
       (\<forall>can_status \<in> list_map_range (canister_status S). case can_status of Stopping os \<Rightarrow>
-        \<forall>(orig, cyc) \<in> set os. (case orig of From_canister other_ctxt_id _ \<Rightarrow> ctxt_id \<noteq> other_ctxt_id | _ \<Rightarrow> True)
+        \<forall>(orig, cyc) \<in> set os. calling_context orig \<noteq> Some ctxt_id
       | _ \<Rightarrow> True)
     | None \<Rightarrow> False))"
 


### PR DESCRIPTION
This MR makes the following adjustments to the "Call context removal" transition and its formal model:
- "the call context has been replied to" is replaced by "the call context does not need to respond" because the former sounds like it refers to outstanding replies to this call context (instead of the reply from this call context to its origin) that are considered in the remaining conditions
- removes the condition
```
S.call_contexts[Ctxt_id].origin = FromSystemTask
∀ FuncMessage M ∈ S.messages. M.call_context ≠ Ctxt_id
```
because it implies that `needs_to_respond` is false (a system task does not await a response and a FuncMessage is never in the message queue when a Call context removal transition can be taken; this is because a FuncMessage is only added by transitions that need to be immediately followed by Message execution that consumes the FuncMessage).