### PR TITLE
revise Call context starvation transition

### DIFF
--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -3145,15 +3145,15 @@ Note that by construction, a query function will either trap or return with a re
 [#rule-starvation]
 ==== Call context starvation
 
-If the call context is not for heartbeat or global timer and there is no call, downstream calling context or response that could possibly fulfill a calling context, then a reject is synthesized. The error message below is _not_ indicative. In particular, if the IC has an idea about _why_ this starved, it can put that in there (e.g. the initial message handler trapped with an out-of-memory access).
+If the call context needs to respond (in particular, if the call context is not for a system task) and there is no call, downstream call context, or response that references a call context, then a reject is synthesized. The error message below is _not_ indicative. In particular, if the IC has an idea about _why_ this starved, it can put that in there (e.g. the initial message handler trapped with an out-of-memory access).
 
 Conditions::
 ....
     S.call_contexts[Ctxt_id].needs_to_respond = true
-    S.call_contexts[Ctxt_id].origin ≠ FromSystemTask
     ∀ CallMessage {origin = FromCanister O, …} ∈ S.messages. O.calling_context ≠ Ctxt_id
     ∀ ResponseMessage {origin = FromCanister O, …} ∈ S.messages. O.calling_context ≠ Ctxt_id
     ∀ _ ↦ {needs_to_respond = true, origin = FromCanister O, …} ∈ S.call_contexts: O.calling_context ≠ Ctxt_id
+    ∀ _ ↦ Stopping Origins ∈ S.canister_status: ∀(FromCanister O, _) ∈ Origins. O.calling_context ≠ Ctxt_id
 ....
 State after::
 ....

--- a/theories/IC.thy
+++ b/theories/IC.thy
@@ -1430,14 +1430,16 @@ definition call_context_starvation_pre :: "'cid \<Rightarrow> ('p, 'uid, 'canid,
   "call_context_starvation_pre ctxt_id S =
   (case list_map_get (call_contexts S) ctxt_id of Some call_context \<Rightarrow>
     call_ctxt_needs_to_respond call_context \<and>
-    call_ctxt_origin call_context \<noteq> From_system \<and>
     (\<forall>msg \<in> set (messages S). case msg of
         Call_message orig _ _ _ _ _ _ \<Rightarrow> calling_context orig \<noteq> Some ctxt_id
       | Response_message orig _ _ \<Rightarrow> calling_context orig \<noteq> Some ctxt_id
       | _ \<Rightarrow> True) \<and>
     (\<forall>other_call_context \<in> list_map_range (call_contexts S).
       call_ctxt_needs_to_respond other_call_context \<longrightarrow>
-      calling_context (call_ctxt_origin other_call_context) \<noteq> Some ctxt_id)
+      calling_context (call_ctxt_origin other_call_context) \<noteq> Some ctxt_id) \<and>
+    (\<forall>can_status \<in> list_map_range (canister_status S). case can_status of Stopping os \<Rightarrow>
+        \<forall>(orig, cyc) \<in> set os. calling_context orig \<noteq> Some ctxt_id
+      | _ \<Rightarrow> True)
   | None \<Rightarrow> False)"
 
 definition call_context_starvation_post :: "'cid \<Rightarrow>


### PR DESCRIPTION
This MR makes the following adjustments to the "Call context starvation" transition and its formal model:

- drops the condition `S.call_contexts[Ctxt_id].origin ≠ FromSystemTask` that is implied by `S.call_contexts[Ctxt_id].needs_to_respond = true`
- adds a condition referring to call contexts kept in the Stopping canister status (omitted before)