### PR TITLE
add missing sender_canister_version and note on order of controllers

### DIFF
--- a/spec/ic.did
+++ b/spec/ic.did
@@ -189,6 +189,7 @@ service ic : {
     amount: opt nat;
     settings : opt canister_settings;
     specified_id: opt canister_id;
+    sender_canister_version : opt nat64;
   }) -> (record {canister_id : canister_id});
   provisional_top_up_canister :
     (record { canister_id: canister_id; amount: nat }) -> ();

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1668,7 +1668,7 @@ Indicates various information about the canister. It contains:
 
 * The status of the canister. It could be one of `running`, `stopping` or `stopped`.
 * A SHA256 hash of the module installed on the canister. This is `null` if the canister is empty.
-* The controllers of the canister.
+* The controllers of the canister. The order of returned controllers may vary depending on the implementation.
 * The memory size taken by the canister.
 * The cycle balance of the canister.
 
@@ -1679,7 +1679,7 @@ Only the controllers of the canister or the canister itself can request its stat
 
 Provides the history of the canister, its current module SHA-256 hash, and its current controllers. Every canister can call this method on every other canister (including itself). Users cannot call this method.
 
-The canister history consists of a list of canister changes (canister creation, code uninstallation, code deployment, or controllers change). Every canister change consists of the system timestamp at which the change was performed, the canister version after performing the change, the change's origin (a user or a canister), and its details. The change origin includes the principal (called _originator_ in the following) that initiated the change and, if the originator is a canister, the originator's canister version when the originator initiated the change (if available). Code deployments are described by their mode (code install, code reinstall, code upgrade) and the SHA-256 hash of the newly deployed canister module. Canister creations and controllers changes are described by the full new set of the canister controllers after the change.
+The canister history consists of a list of canister changes (canister creation, code uninstallation, code deployment, or controllers change). Every canister change consists of the system timestamp at which the change was performed, the canister version after performing the change, the change's origin (a user or a canister), and its details. The change origin includes the principal (called _originator_ in the following) that initiated the change and, if the originator is a canister, the originator's canister version when the originator initiated the change (if available). Code deployments are described by their mode (code install, code reinstall, code upgrade) and the SHA-256 hash of the newly deployed canister module. Canister creations and controllers changes are described by the full new set of the canister controllers after the change. The order of controllers stored in the canister history may vary depending on the implementation.
 
 The system can drop the oldest canister changes from the list to keep its length bounded (at least `20` changes are guaranteed to remain in the list). The system also drops all canister changes if the canister runs out of cycles.
 
@@ -1693,7 +1693,7 @@ The returned response contains the following fields:
 * `total_num_changes`: the total number of canister changes that have been ever recorded in the history. This value does not change if the system drops the oldest canister changes from the list of changes.
 * `recent_changes`: the list containing the most recent canister changes. If `num_requested_changes` is provided, then this list contains that number of changes or, if more changes are requested than available in the history, then this list contains all changes available in the history. If `num_requested_changes` is not specified, then this list is empty.
 * `module_hash`: the SHA-256 hash of the currently installed canister module (or `null` if the canister is empty).
-* `controllers`: the current set of canister controllers.
+* `controllers`: the current set of canister controllers. The order of returned controllers may vary depending on the implementation.
 
 [#ic-stop_canister]
 === IC method `stop_canister`


### PR DESCRIPTION
This PR makes the following adjustments:
- add missing `sender_canister_version` field to `provisional_create_canister_with_cycles` request
- add notes on the order of controllers in management canister call responses and canister history