### PR TITLE
add link to ic.did in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Internet Computer Reference
 
 This repository contains the source files of the Interface Spec, which describes the externally visible behaviour of the Internet Computer.
+The language-independent description of this IC interface is available in [ic.did](./spec/_attachments/ic.did).
 
 It used to contain a reference implementation and acceptance test suite; these can now be found at <https://github.com/dfinity/ic-hs>.
 


### PR DESCRIPTION
To match the file structure in the source repo of internetcomputer.org (dfinity/portal), the `ic.did` interface file has been moved from `spec/ic.did` to `spec/_attachments/ic.did` which caused some confusion among users of that file. Hence, this PR add a link to that file in the README.