### PR TITLE
redefine lookup_path if path extends past a leaf in the tree

### DIFF
--- a/spec/index.md
+++ b/spec/index.md
@@ -2165,7 +2165,7 @@ find_label(l, _ · Labeled l1 t · _)                | l == l1     = Found t
 find_label(l, _ · Labeled l1 _ · Labeled l2 _ · _) | l1 < l < l2 = Absent
 find_label(l,                    Labeled l2 _ · _) |      l < l2 = Absent
 find_label(l, _ · Labeled l1 _ )                   | l1 < l      = Absent
-find_label(l, [Leaf _])                                          = Absent
+find_label(l, [Leaf _])                                          = Error
 find_label(l, [])                                                = Absent
 find_label(l, _)                                                 = Unknown
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -2165,7 +2165,7 @@ find_label(l, _ · Labeled l1 t · _)                | l == l1     = Found t
 find_label(l, _ · Labeled l1 _ · Labeled l2 _ · _) | l1 < l < l2 = Absent
 find_label(l,                    Labeled l2 _ · _) |      l < l2 = Absent
 find_label(l, _ · Labeled l1 _ )                   | l1 < l      = Absent
-find_label(l, [Leaf _])                                          = Error
+find_label(l, [Leaf _])                                          = Unknown
 find_label(l, [])                                                = Absent
 find_label(l, _)                                                 = Unknown
 


### PR DESCRIPTION
Suppose a tree has a path `/a/b` ending in a leaf with the value "secret". According to the current definition, `lookup_path` for the path `a/b/c` returns `Absent` and a pruned tree (witness for the lookup) must contain the leaf value "secret" although the value at that path was not requested. This PR redefines `lookup_path` (more precisely, a helper function `find_label` used by `lookup_path`) to return `Unknown` in that case so that a pruned tree (witness for the lookup) can actually have the leaf value "secret" pruned and the lookup in the pruned tree returns `Unknown` just like the lookup in the original tree (also returning `Unknown` after the change from this PR).

Note. The issue motivating this PR could be solved in a better way if it was possible to only prune the leaf value while still indicating that the tree has a leaf at a certain place: then we could keep the current definition of `lookup_path` yielding `Absent` (which is more precise than `Unknown`) without returning the actual leaf value "secret" (which is desirable as the value at this path was not requested). However, this would be a _breaking_ change (as it would require to change the tree datatype) and thus difficult to roll out in practice.