### PR TITLE
refine conditions on effective canister ID

### DIFF
--- a/spec/index.md
+++ b/spec/index.md
@@ -730,6 +730,7 @@ Canister methods that do not change the canister state (except for cycle balance
 ### Effective canister id {#http-effective-canister-id}
 
 The `<effective_canister_id>` in the URL paths of requests is the *effective* destination of the request.
+It must be contained in the canister ranges of a subnet, otherwise the corresponding HTTP request is rejected.
 
 -   If the request is an update call to the Management Canister (`aaaaa-aa`), then:
 
@@ -737,15 +738,13 @@ The `<effective_canister_id>` in the URL paths of requests is the *effective* de
 
     -   Otherwise, if the `arg` is a Candid-encoded record with a `canister_id` field of type `principal`, then the effective canister id must be that principal.
 
-    -   Otherwise, the call is rejected by the system independently of the effective canister id.
+    -   Otherwise, the call is rejected with a [reject code](#reject-codes) independently of the effective canister id.
 
 -   If the request is an update call to a canister that is not the Management Canister (`aaaaa-aa`) or if the request is a query call, then the effective canister id must be the `canister_id` in the request.
 
 :::note
 
 The expectation is that user-side agent code shields users and developers from the notion of effective canister ID, in analogy to how the System API interface shields canister developers from worrying about routing.
-
-The Internet Computer blockchain mainnet rejects all requests whose effective canister id is in no subnet's canister ranges, independently of whether the remaining conditions on the effective canister id are satisfied.
 
 The Internet Computer blockchain mainnet does not support `provisional_create_canister_with_cycles` and thus all calls to this method are rejected independently of the effective canister id.
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -738,7 +738,7 @@ It must be contained in the canister ranges of a subnet, otherwise the correspon
 
     -   Otherwise, if the `arg` is a Candid-encoded record with a `canister_id` field of type `principal`, then the effective canister id must be that principal.
 
-    -   Otherwise, the call is rejected with a [reject code](#reject-codes) independently of the effective canister id.
+    -   Otherwise, the call is rejected by the system independently of the effective canister id.
 
 -   If the request is an update call to a canister that is not the Management Canister (`aaaaa-aa`) or if the request is a query call, then the effective canister id must be the `canister_id` in the request.
 


### PR DESCRIPTION
This PR refines conditions on effective canister ID in the URL of HTTP requests: it specifies that the effective canister ID must be contained the canister ranges of a subnet (before there was only a note about this for the IC mainnet).