### PR TITLE
add note on confidentiality of values in certified state tree

### DIFF
--- a/spec/_attachments/interface-spec-changelog.md
+++ b/spec/_attachments/interface-spec-changelog.md
@@ -3,6 +3,7 @@
 ### ∞ (unreleased)
 * Canister cycle balance cannot decrease below the freezing limit after executing `install_code` on the management canister.
 * System API calls `ic0.msg_caller_size` and `ic0.msg_caller_copy` can be called in all contexts except for (start) function.
+* Added note on confidentiality of values in the certified state tree.
 
 ### 0.20.0 (2023-07-11) {#0_20_0}
 * IC Bitcoin API, ECDSA API, canister HTTPS outcalls API, and 128-bit cycles System API are considered stable.

--- a/spec/index.md
+++ b/spec/index.md
@@ -650,7 +650,7 @@ and whose paths might not even be allowed to be requested by the sender of the H
 This means that unauthorized users might obtain the SHA-256 hashes of ingress message responses
 and private custom sections of the canister's module.
 Hence, users are advised to use cryptographically strong nonces in their HTTP requests and
-canister developers are advised to add a cryptographic salt to their canister's responses and private custom sections.
+canister developers that aim at keeping data confidential are advised to add a secret cryptographic salt to their canister's responses and private custom sections.
 
 :::
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -643,6 +643,17 @@ The HTTP response to this request consists of a CBOR (see [CBOR](#cbor)) map wit
 
 The returned certificate reveals all values whose path is a suffix of a requested path. It also always reveals `/time`, even if not explicitly requested.
 
+:::note
+
+The returned certificate might also reveal the SHA-256 hashes of values whose paths have not been requested
+and whose paths might not even be allowed to be requested by the sender of the HTTP request.
+This means that unauthorized users might obtain the SHA-256 hashes of ingress message responses
+and private custom sections of the canister's module.
+Hence, users are advised to use cryptographically strong nonces in their HTTP requests and
+canister developers are advised to add a cryptographic salt to their canister's private custom sections.
+
+:::
+
 All requested paths must have one of the following paths as prefix:
 
 -   `/time`. Can always be requested.

--- a/spec/index.md
+++ b/spec/index.md
@@ -650,7 +650,7 @@ and whose paths might not even be allowed to be requested by the sender of the H
 This means that unauthorized users might obtain the SHA-256 hashes of ingress message responses
 and private custom sections of the canister's module.
 Hence, users are advised to use cryptographically strong nonces in their HTTP requests and
-canister developers are advised to add a cryptographic salt to their canister's private custom sections.
+canister developers are advised to add a cryptographic salt to their canister's responses and private custom sections.
 
 :::
 


### PR DESCRIPTION
This MR adds a note on confidentiality of values in the certified state tree that can be read via HTTP requests.