### PR TITLE
add note on supported certificate versions in HTTP Gateway

### DIFF
--- a/spec/_attachments/interface-spec-changelog.md
+++ b/spec/_attachments/interface-spec-changelog.md
@@ -3,7 +3,8 @@
 ### ∞ (unreleased)
 * Canister cycle balance cannot decrease below the freezing limit after executing `install_code` on the management canister.
 * System API calls `ic0.msg_caller_size` and `ic0.msg_caller_copy` can be called in all contexts except for (start) function.
-* Added note on confidentiality of values in the certified state tree.
+* Add note on confidentiality of values in the certified state tree.
+* Add note on `supported_certificate_versions` in HTTP Gateway.
 
 ### 0.20.0 (2023-07-11) {#0_20_0}
 * IC Bitcoin API, ECDSA API, canister HTTPS outcalls API, and 128-bit cycles System API are considered stable.

--- a/spec/http-gateway-protocol-spec.md
+++ b/spec/http-gateway-protocol-spec.md
@@ -375,9 +375,17 @@ The steps for response verification are as follows:
 
 ## Response Verification Version Assertion
 
-Canisters can report the versions of response verification that they support using public metadata in the [system state tree](https://internetcomputer.org/docs/current/references/ic-interface-spec/#state-tree-canister-information). This metadata will be read by the HTTP Gateway using a [read_state request](https://internetcomputer.org/docs/current/references/ic-interface-spec/#http-read-state). This metadata is a comma-delimited string of versions under the key "supported_certificate_versions”, for example: "1,2". This is treated as an optional, additional layer of security for canisters supporting multiple versions. If the metadata has not been added (i.e. the lookup of this metadata in the `read_state` response returns `Absent`), then the HTTP Gateway will allow for whatever version the canister has responded with.
+Canisters can report the supported versions of response verification using (public) metadata sections available in the [system state tree](https://internetcomputer.org/docs/current/references/ic-interface-spec/#state-tree-canister-information). This metadata will be read by the HTTP Gateway using a [read_state request](https://internetcomputer.org/docs/current/references/ic-interface-spec/#http-read-state). The metadata section must be a (public) custom section with the name `supported_certificate_versions` and contain a comma-delimited string of versions, e.g., `1,2`. This is treated as an optional, additional layer of security for canisters supporting multiple versions. If the metadata has not been added (i.e., the `read_state` request *succeeds* and the lookup of the metadata section in the `read_state` response certificate returns `Absent`), then the HTTP Gateway will allow for whatever version the canister has responded with.
+
 
 The request for the metadata will only be made by the HTTP Gateway if there is a downgrade. If the HTTP Gateway requests v2 and the canister responds with v2, then a request will not be made. If the HTTP Gateway requests v2 and the canister responds with v1, a request will be made. If a request is made, the HTTP Gateway will not accept any response from the canister that is below the max version supported by both the HTTP Gateway and the canister. This will guarantee that a canister supporting both v1 and v2 will always have v2 security when accessed by an HTTP Gateway that supports v2.
+
+:::note
+
+The HTTP Gateway can only allow for arbitrary certification version if the custom section `supported_certificate_versions` is *provably* not present, i.e., if the `read_state` response contains a valid certificate whose lookup of the corresponding path yields `Absent`. If the `read_state` request is rejected, e.g., if the replica is overloaded or because the custom section with the name `supported_certificate_versions` is private, then the HTTP Gateway should also reject the canister's response.
+
+:::
+
 
 ## Canister HTTP Interface
 

--- a/spec/http-gateway-protocol-spec.md
+++ b/spec/http-gateway-protocol-spec.md
@@ -382,7 +382,7 @@ The request for the metadata will only be made by the HTTP Gateway if there is a
 
 :::note
 
-The HTTP Gateway can only allow for arbitrary certification version if the custom section `supported_certificate_versions` is *provably* not present, i.e., if the `read_state` response contains a valid certificate whose lookup of the corresponding path yields `Absent`. If the `read_state` request is rejected, e.g., if the replica is overloaded or because the custom section with the name `supported_certificate_versions` is private, then the HTTP Gateway should also reject the canister's response.
+The HTTP Gateway can only allow for arbitrary certification version if the custom section `supported_certificate_versions` is *provably* not present, i.e., if the `read_state` response contains a valid certificate whose lookup of the corresponding path yields `Absent`. Otherwise, e.g., if the replica is overloaded or because the custom section with the name `supported_certificate_versions` is private, then the HTTP Gateway should also reject the canister's response.
 
 :::
 

--- a/spec/http-gateway-protocol-spec.md
+++ b/spec/http-gateway-protocol-spec.md
@@ -382,7 +382,7 @@ The request for the metadata will only be made by the HTTP Gateway if there is a
 
 :::note
 
-The HTTP Gateway can only allow for arbitrary certification version if the custom section `supported_certificate_versions` is *provably* not present, i.e., if the `read_state` response contains a valid certificate whose lookup of the corresponding path yields `Absent`. Otherwise, e.g., if the replica is overloaded or if the `read_state` is rejected because the custom section with the name `supported_certificate_versions` is private, then the HTTP Gateway should also reject the canister's response.
+The HTTP Gateway can only allow for arbitrary certification version if the custom section `supported_certificate_versions` is *provably* not present, i.e., if the `read_state` response contains a valid certificate whose lookup of the corresponding path yields `Absent`. Otherwise, e.g., if the replica is overloaded or if the `read_state` is rejected because the custom section with the name `supported_certificate_versions` is private, the HTTP Gateway should also reject the canister's response.
 
 :::
 

--- a/spec/http-gateway-protocol-spec.md
+++ b/spec/http-gateway-protocol-spec.md
@@ -382,7 +382,7 @@ The request for the metadata will only be made by the HTTP Gateway if there is a
 
 :::note
 
-The HTTP Gateway can only allow for arbitrary certification version if the custom section `supported_certificate_versions` is *provably* not present, i.e., if the `read_state` response contains a valid certificate whose lookup of the corresponding path yields `Absent`. Otherwise, e.g., if the replica is overloaded or because the custom section with the name `supported_certificate_versions` is private, then the HTTP Gateway should also reject the canister's response.
+The HTTP Gateway can only allow for arbitrary certification version if the custom section `supported_certificate_versions` is *provably* not present, i.e., if the `read_state` response contains a valid certificate whose lookup of the corresponding path yields `Absent`. Otherwise, e.g., if the replica is overloaded or if the `read_state` is rejected because the custom section with the name `supported_certificate_versions` is private, then the HTTP Gateway should also reject the canister's response.
 
 :::
 


### PR DESCRIPTION
This PR clarifies under which conditions the HTTP Gateway can allow for arbitrary certification version in the canister's response.