### PR TITLE
add canister_composite_query to WASM module requirements section

### DIFF
--- a/spec/index.md
+++ b/spec/index.md
@@ -1067,9 +1067,9 @@ In order for a WebAssembly module to be usable as the code for the canister, it 
 
     -   declare more than 16 exported custom sections (the custom section names with prefix `icp:`), or
 
-    -   the number of all exported functions called `canister_update <name>` or `canister_query <name>` exceeds 1,000, or
+    -   the number of all exported functions called `canister_update <name>`, `canister_query <name>`, or `canister_composite_query <name>` exceeds 1,000, or
 
-    -   the sum of `<name>` lengths in all exported functions called `canister_update <name>` or `canister_query <name>` exceeds 20,000, or
+    -   the sum of `<name>` lengths in all exported functions called `canister_update <name>`, `canister_query <name>`, or `canister_composite_query <name>` exceeds 20,000, or
 
     -   the total size of the custom sections (the sum of `<name>` lengths in their names `icp:public <name>` and `icp:private <name>` plus the sum of their content lengths) exceeds 1MiB.
 


### PR DESCRIPTION
This PR fixes an oversight when merging composite queries and recent WASM module requirements changes.