### PR TITLE
specify IC management method for retrieving metrics

### DIFF
--- a/spec/_attachments/ic.did
+++ b/spec/_attachments/ic.did
@@ -198,7 +198,7 @@ service ic : {
     requested_timestamp_nanos: nat64;
   }) -> (record {
     timestamp_nanos : nat64;
-    metrics : vec metrics;
+    node_metrics : vec node_metrics;
   });
 
   // provisional interfaces for the pre-ledger world

--- a/spec/_attachments/ic.did
+++ b/spec/_attachments/ic.did
@@ -199,9 +199,9 @@ service ic : {
   bitcoin_get_current_fee_percentiles: (get_current_fee_percentiles_request) -> (vec millisatoshi_per_byte);
 
   // metrics interface
-  node_metrics : (record {
+  node_metrics_history : (record {
     subnet_id : principal;
-    requested_timestamp_nanos: nat64;
+    start_at_timestamp_nanos: nat64;
   }) -> (vec record {
     timestamp_nanos : nat64;
     node_metrics : vec node_metrics;

--- a/spec/_attachments/ic.did
+++ b/spec/_attachments/ic.did
@@ -193,7 +193,7 @@ service ic : {
   bitcoin_get_current_fee_percentiles: (get_current_fee_percentiles_request) -> (vec millisatoshi_per_byte);
 
   // metrics interface
-  metrics : (record {
+  node_metrics : (record {
     subnet_id : principal;
     requested_timestamp_nanos: nat64;
   }) -> (record {

--- a/spec/_attachments/ic.did
+++ b/spec/_attachments/ic.did
@@ -114,8 +114,8 @@ type millisatoshi_per_byte = nat64;
 type metrics = variant {
   node_metrics : record {
     node_id : principal;
-    num_blocks : nat64;
-    num_block_failures : nat64;
+    num_blocks_total : nat64;
+    num_block_failures_total : nat64;
   }
 };
 

--- a/spec/_attachments/ic.did
+++ b/spec/_attachments/ic.did
@@ -194,7 +194,7 @@ service ic : {
   node_metrics : (record {
     subnet_id : principal;
     requested_timestamp_nanos: nat64;
-  }) -> (record {
+  }) -> (vec record {
     timestamp_nanos : nat64;
     node_metrics : vec node_metrics;
   });

--- a/spec/_attachments/ic.did
+++ b/spec/_attachments/ic.did
@@ -114,9 +114,8 @@ type millisatoshi_per_byte = nat64;
 type metrics = variant {
   node_metrics : record {
     node_id : principal;
-    start_timestamp_nanos : nat64;
-    end_timestamp_nanos : nat64;
-    num_proposed_blocks : nat;
+    num_blocks : nat64;
+    num_block_failures : nat64;
   }
 };
 
@@ -197,6 +196,7 @@ service ic : {
   metrics : (record {
     subnet_id : principal;
   }) -> (record {
+    timestamp_nanos : nat64;
     metrics : vec metrics;
   });
 

--- a/spec/_attachments/ic.did
+++ b/spec/_attachments/ic.did
@@ -111,12 +111,10 @@ type send_transaction_request = record {
 
 type millisatoshi_per_byte = nat64;
 
-type node_metrics = variant {
-  node_metrics : record {
+type node_metrics = record {
     node_id : principal;
     num_blocks_total : nat64;
     num_block_failures_total : nat64;
-  }
 };
 
 service ic : {

--- a/spec/_attachments/ic.did
+++ b/spec/_attachments/ic.did
@@ -195,6 +195,7 @@ service ic : {
   // metrics interface
   metrics : (record {
     subnet_id : principal;
+    requested_timestamp_nanos: nat64;
   }) -> (record {
     timestamp_nanos : nat64;
     metrics : vec metrics;

--- a/spec/_attachments/ic.did
+++ b/spec/_attachments/ic.did
@@ -111,7 +111,7 @@ type send_transaction_request = record {
 
 type millisatoshi_per_byte = nat64;
 
-type metrics = variant {
+type node_metrics = variant {
   node_metrics : record {
     node_id : principal;
     num_blocks_total : nat64;

--- a/spec/_attachments/ic.did
+++ b/spec/_attachments/ic.did
@@ -111,6 +111,15 @@ type send_transaction_request = record {
 
 type millisatoshi_per_byte = nat64;
 
+type metrics = variant {
+  node_metrics : record {
+    node_id : principal;
+    start_timestamp_nanos : nat64;
+    end_timestamp_nanos : nat64;
+    num_proposed_blocks : nat;
+  }
+};
+
 service ic : {
   create_canister : (record {
     settings : opt canister_settings;
@@ -183,6 +192,13 @@ service ic : {
   bitcoin_get_utxos: (get_utxos_request) -> (get_utxos_response);
   bitcoin_send_transaction: (send_transaction_request) -> ();
   bitcoin_get_current_fee_percentiles: (get_current_fee_percentiles_request) -> (vec millisatoshi_per_byte);
+
+  // metrics interface
+  metrics : (record {
+    subnet_id : principal;
+  }) -> (record {
+    metrics : vec metrics;
+  });
 
   // provisional interfaces for the pre-ledger world
   provisional_create_canister_with_cycles : (record {

--- a/spec/_attachments/interface-spec-changelog.md
+++ b/spec/_attachments/interface-spec-changelog.md
@@ -5,6 +5,7 @@
 * Update specification of responses from the endpoint `/api/v2/status`.
 * Stop canister calls might be rejected upon timeout.
 * The IC sends a `user-agent` header with the value `ic/1.0` in canister HTTPS outcalls if the canister does not provide one.
+* Add a management canister method for retrieving node metrics.
 
 ### 0.22.0 (2023-11-15) {#0_22_0}
 * Add metrics on subnet usage into the certified state tree and a new HTTP endpoint `/api/v2/subnet/<subnet_id>/read_state` for retrieving them.

--- a/spec/index.md
+++ b/spec/index.md
@@ -2034,7 +2034,7 @@ The node metrics management canister API is considered EXPERIMENTAL. Canister de
 
 :::
 
-Given a subnet ID as input, this method returns a collection of metrics for all nodes on the given subnet (field `node_metrics`) and a timestamp provided in nanoseconds since 1970-01-01 (field `timestamp_nanos`) at which the metrics were sampled. This timestamp is the earliest timestamp after the requested timestamp (field `requested_timestamp_nanos`) for which node metrics are available.
+Given a subnet ID as input, this method returns a collection of metrics for all nodes on the given subnet (field `node_metrics`) and timestamps provided in nanoseconds since 1970-01-01 (field `timestamp_nanos`) at which the metrics were sampled. The returned timestamps are all timestamps after (and including) the requested timestamp (field `requested_timestamp_nanos`) for which node metrics are available.
 
 A single metric entry is a record with the following fields:
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -4163,7 +4163,7 @@ S.messages = Older_messages · CallMessage M · Younger_messages
 (M.queue = Unordered) or (∀ msg ∈ Older_messages. msg.queue ≠ M.queue)
 M.callee = ic_principal
 M.method_name = 'metrics'
-M.arg = candid()
+M.arg = candid(A)
 R = <implementation-specific>
 
 ```

--- a/spec/index.md
+++ b/spec/index.md
@@ -2046,6 +2046,24 @@ Any user can top-up any canister this way.
 
 This method is only available in local development instances.
 
+### IC method `node_metrics` {#ic-node-metrics}
+
+:::note
+
+The node metrics management canister API is considered EXPERIMENTAL. Canister developers must be aware that the API may evolve in a non-backward-compatible way.
+
+:::
+
+Given a subnet ID as input, this method returns a collection of metrics for all nodes on the given subnet (field `node_metrics`) and a timestamp provided in nanoseconds since 1970-01-01 (field `timestamp_nanos`) at which the metrics were sampled. This timestamp is the earliest timestamp after the requested timestamp (field `requested_timestamp_nanos`) for which node metrics are available.
+
+A single metric entry is a record with the following fields:
+
+- `node_id` (`principal`): the principal characterizing a node;
+
+- `num_blocks_total` (`nat64`): the number of blocks proposed by this node;
+
+- `num_block_failures_total` (`nat64`): the number of failed block proposals by this node.
+
 ## The IC Bitcoin API {#ic-bitcoin-api}
 
 The Bitcoin functionality is exposed via the management canister. Information about Bitcoin can be found in the [Bitcoin developer guides](https://developer.bitcoin.org/devguide/). Invoking the functions of the Bitcoin API will cost cycles. We refer the reader to the [Bitcoin documentation](https://internetcomputer.org/docs/current/developer-docs/integrations/bitcoin/bitcoin-how-it-works) for further relevant information and the [IC pricing page](https://internetcomputer.org/docs/current/developer-docs/gas-cost) for information on pricing for the Bitcoin mainnet and testnet.
@@ -2113,24 +2131,6 @@ The transaction fees in the Bitcoin network change dynamically based on the numb
 This function returns fee percentiles, measured in millisatoshi/vbyte (1000 millisatoshi = 1 satoshi), over the last 10,000 transactions in the specified network, i.e., over the transactions in the last approximately 4-10 blocks.
 
 The [standard nearest-rank estimation method](https://en.wikipedia.org/wiki/Percentile#The_nearest-rank_method), inclusive, with the addition of a 0th percentile is used. Concretely, for any i from 1 to 100, the ith percentile is the fee with rank `⌈i * 100⌉`. The 0th percentile is defined as the smallest fee (excluding coinbase transactions).
-
-### IC method `node_metrics` {#ic-node-metrics}
-
-:::note
-
-The node metrics management canister API is considered EXPERIMENTAL. Canister developers must be aware that the API may evolve in a non-backward-compatible way.
-
-:::
-
-Given a subnet ID as input, this method returns a collection of metrics for all nodes on the given subnet (field `node_metrics`) and a timestamp provided in nanoseconds since 1970-01-01 (field `timestamp_nanos`) at which the metrics were sampled. This timestamp is the earliest timestamp after the requested timestamp (field `requested_timestamp_nanos`) for which node metrics are available.
-
-A single metric entry is a record with the following fields:
-
-- `node_id` (`principal`): the principal characterizing a node;
-
-- `num_blocks_total` (`nat64`): the number of blocks proposed by this node;
-
-- `num_block_failures_total` (`nat64`): the number of failed block proposals by this node.
 
 ## Certification {#certification}
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -2026,6 +2026,24 @@ If you do not specify the `max_response_bytes` parameter, the maximum of a `2MB`
 
 :::
 
+### IC method `node_metrics` {#ic-node-metrics}
+
+:::note
+
+The node metrics management canister API is considered EXPERIMENTAL. Canister developers must be aware that the API may evolve in a non-backward-compatible way.
+
+:::
+
+Given a subnet ID as input, this method returns a collection of metrics for all nodes on the given subnet (field `node_metrics`) and a timestamp provided in nanoseconds since 1970-01-01 (field `timestamp_nanos`) at which the metrics were sampled. This timestamp is the earliest timestamp after the requested timestamp (field `requested_timestamp_nanos`) for which node metrics are available.
+
+A single metric entry is a record with the following fields:
+
+- `node_id` (`principal`): the principal characterizing a node;
+
+- `num_blocks_total` (`nat64`): the number of blocks proposed by this node;
+
+- `num_block_failures_total` (`nat64`): the number of failed block proposals by this node.
+
 ### IC method `provisional_create_canister_with_cycles` {#ic-provisional_create_canister_with_cycles}
 
 As a provisional method on development instances, the `provisional_create_canister_with_cycles` method is provided. It behaves as `create_canister`, but initializes the canister's balance with `amount` fresh cycles (using `DEFAULT_PROVISIONAL_CYCLES_BALANCE` if `amount = null`). If `specified_id` is provided, the canister is created under this id. Note that canister creation using `create_canister` or `provisional_create_canister_with_cycles` with `specified_id = null` can fail after calling `provisional_create_canister_with_cycles` with provided `specified_id`. In that case, canister creation should be retried.
@@ -2045,24 +2063,6 @@ Cycles added to this call via `ic0.call_cycles_add128` are returned to the calle
 Any user can top-up any canister this way.
 
 This method is only available in local development instances.
-
-### IC method `node_metrics` {#ic-node-metrics}
-
-:::note
-
-The node metrics management canister API is considered EXPERIMENTAL. Canister developers must be aware that the API may evolve in a non-backward-compatible way.
-
-:::
-
-Given a subnet ID as input, this method returns a collection of metrics for all nodes on the given subnet (field `node_metrics`) and a timestamp provided in nanoseconds since 1970-01-01 (field `timestamp_nanos`) at which the metrics were sampled. This timestamp is the earliest timestamp after the requested timestamp (field `requested_timestamp_nanos`) for which node metrics are available.
-
-A single metric entry is a record with the following fields:
-
-- `node_id` (`principal`): the principal characterizing a node;
-
-- `num_blocks_total` (`nat64`): the number of blocks proposed by this node;
-
-- `num_block_failures_total` (`nat64`): the number of failed block proposals by this node.
 
 ## The IC Bitcoin API {#ic-bitcoin-api}
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -2128,9 +2128,9 @@ A single metric entry is of an enumeration type with a single variant (in the fu
 
 - `node_metrics`: provides metrics for a node characterized by its principal (field `node_id`) and the actual metrics values:
 
-  - `num_blocks` (`nat64`): the number of blocks proposed by this node;
+  - `num_blocks_total` (`nat64`): the number of blocks proposed by this node;
 
-  - `num_block_failures` (`nat64`): the number of failed block proposals by this node.
+  - `num_block_failures_total` (`nat64`): the number of failed block proposals by this node.
 
 ## Certification {#certification}
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -4152,7 +4152,7 @@ S with
 
 #### IC Management Canister: Metrics
 
-The management canister can returns metrics for a given subnet. The definition of the metrics values
+The management canister returns metrics for a given subnet. The definition of the metrics values
 is not captured in this formal semantics.
 
 Conditions

--- a/spec/index.md
+++ b/spec/index.md
@@ -2114,24 +2114,23 @@ This function returns fee percentiles, measured in millisatoshi/vbyte (1000 mill
 
 The [standard nearest-rank estimation method](https://en.wikipedia.org/wiki/Percentile#The_nearest-rank_method), inclusive, with the addition of a 0th percentile is used. Concretely, for any i from 1 to 100, the ith percentile is the fee with rank `⌈i * 100⌉`. The 0th percentile is defined as the smallest fee (excluding coinbase transactions).
 
-### IC method `metrics` {#ic-metrics}
+### IC method `node_metrics` {#ic-node-metrics}
 
 :::note
 
-The metrics management canister API is considered EXPERIMENTAL. Canister developers must be aware that the API may evolve in a non-backward-compatible way.
+The node metrics management canister API is considered EXPERIMENTAL. Canister developers must be aware that the API may evolve in a non-backward-compatible way.
 
 :::
 
-Given a subnet ID as input, this method returns a collection of metrics for the given subnet (field `metrics`) and a timestamp provided in nanoseconds since 1970-01-01 (field `timestamp_nanos`) at which the metrics are sampled.
-This timestamp is the earliest timestamp after the requested timestamp (field `requested_timestamp_nanos`) for which the metrics are available.
+Given a subnet ID as input, this method returns a collection of metrics for all nodes on the given subnet (field `node_metrics`) and a timestamp provided in nanoseconds since 1970-01-01 (field `timestamp_nanos`) at which the metrics were sampled. This timestamp is the earliest timestamp after the requested timestamp (field `requested_timestamp_nanos`) for which node metrics are available.
 
-A single metric entry is of an enumeration type with a single variant (in the future, more variants might be added):
+A single metric entry is a record with the following fields:
 
-- `node_metrics`: provides metrics for a node characterized by its principal (field `node_id`) and the actual metrics values:
+- `node_id` (`principal`): the principal characterizing a node;
 
-  - `num_blocks_total` (`nat64`): the number of blocks proposed by this node;
+- `num_blocks_total` (`nat64`): the number of blocks proposed by this node;
 
-  - `num_block_failures_total` (`nat64`): the number of failed block proposals by this node.
+- `num_block_failures_total` (`nat64`): the number of failed block proposals by this node.
 
 ## Certification {#certification}
 
@@ -4165,15 +4164,15 @@ S with
 
 ```
 
-#### IC Management Canister: Metrics
+#### IC Management Canister: Node Metrics
 
 :::note
 
-The metrics management canister API is considered EXPERIMENTAL. Canister developers must be aware that the API may evolve in a non-backward-compatible way.
+The node metrics management canister API is considered EXPERIMENTAL. Canister developers must be aware that the API may evolve in a non-backward-compatible way.
 
 :::
 
-The management canister returns metrics for a given subnet. The definition of the metrics values
+The management canister returns metrics for all nodes on a given subnet. The definition of the metrics values
 is not captured in this formal semantics.
 
 Conditions
@@ -4183,7 +4182,7 @@ Conditions
 S.messages = Older_messages · CallMessage M · Younger_messages
 (M.queue = Unordered) or (∀ msg ∈ Older_messages. msg.queue ≠ M.queue)
 M.callee = ic_principal
-M.method_name = 'metrics'
+M.method_name = 'node_metrics'
 M.arg = candid(A)
 R = <implementation-specific>
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -2095,7 +2095,7 @@ If you do not specify the `max_response_bytes` parameter, the maximum of a `2MB`
 
 :::
 
-### IC method `node_metrics` {#ic-node-metrics}
+### IC method `node_metrics_history` {#ic-node-metrics-history}
 
 :::note
 
@@ -2103,7 +2103,7 @@ The node metrics management canister API is considered EXPERIMENTAL. Canister de
 
 :::
 
-Given a subnet ID as input, this method returns a collection of metrics for all nodes on the given subnet (field `node_metrics`) and timestamps provided in nanoseconds since 1970-01-01 (field `timestamp_nanos`) at which the metrics were sampled. The returned timestamps are all timestamps after (and including) the requested timestamp (field `requested_timestamp_nanos`) for which node metrics are available.
+Given a subnet ID as input, this method returns collections of metrics for all nodes on the given subnet (field `node_metrics`) at timestamps provided in nanoseconds since 1970-01-01 (field `timestamp_nanos`) at which the metrics were sampled. The returned timestamps are all timestamps after (and including) the provided timestamp (field `start_at_timestamp_nanos`) for which node metrics are available.
 
 A single metric entry is a record with the following fields:
 
@@ -4504,7 +4504,7 @@ Conditions
 S.messages = Older_messages · CallMessage M · Younger_messages
 (M.queue = Unordered) or (∀ msg ∈ Older_messages. msg.queue ≠ M.queue)
 M.callee = ic_principal
-M.method_name = 'node_metrics'
+M.method_name = 'node_metrics_history'
 M.arg = candid(A)
 R = <implementation-specific>
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -2113,6 +2113,16 @@ This function returns fee percentiles, measured in millisatoshi/vbyte (1000 mill
 
 The [standard nearest-rank estimation method](https://en.wikipedia.org/wiki/Percentile#The_nearest-rank_method), inclusive, with the addition of a 0th percentile is used. Concretely, for any i from 1 to 100, the ith percentile is the fee with rank `⌈i * 100⌉`. The 0th percentile is defined as the smallest fee (excluding coinbase transactions).
 
+### IC method `metrics` {#ic-metrics}
+
+Given a subnet ID as input, this method returns a collection of metrics for the given subnet.
+
+A single metric entry is of an enumeration type with a single variant (in the future, more variants might be added):
+
+- `node_metrics`: provides metrics for a node characterized by its principal (field `node_id`), for a period of time characterized by start and end timestamps in nanoseconds since 1970-01-01 (fields `start_timestamp_nanos` and `end_timestamp_nanos`), and the actual metrics values:
+
+  - `num_proposed_blocks` (`nat`): the number of blocks proposed by this node.
+
 ## Certification {#certification}
 
 Some parts of the IC state are exposed to users in a tamperproof way via certification: the IC can reveal a *partial state tree* which includes just the data of interest, together with a signature on the root hash of the state tree. This means that a user can be sure that the response is correct, even if the user happens to be communicating with a malicious node, or has received the certificate via some other untrusted way.
@@ -4135,6 +4145,38 @@ S with
       ResponseMessage {
         origin = M.origin
         response = Reply (candid(B))
+        refunded_cycles = M.transferred_cycles
+      }
+
+```
+
+#### IC Management Canister: Metrics
+
+The management canister can returns metrics for a given subnet. The definition of the metrics values
+is not captured in this formal semantics.
+
+Conditions
+
+```html
+
+S.messages = Older_messages · CallMessage M · Younger_messages
+(M.queue = Unordered) or (∀ msg ∈ Older_messages. msg.queue ≠ M.queue)
+M.callee = ic_principal
+M.method_name = 'metrics'
+M.arg = candid()
+R = <implementation-specific>
+
+```
+
+State after
+
+```html
+
+S with
+    messages = Older_messages · Younger_messages ·
+      ResponseMessage {
+        origin = M.origin
+        response = Reply (candid(R))
         refunded_cycles = M.transferred_cycles
       }
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -2103,7 +2103,9 @@ The node metrics management canister API is considered EXPERIMENTAL. Canister de
 
 :::
 
-Given a subnet ID as input, this method returns collections of metrics for all nodes on the given subnet (field `node_metrics`) at timestamps provided in nanoseconds since 1970-01-01 (field `timestamp_nanos`) at which the metrics were sampled. The returned timestamps are all timestamps after (and including) the provided timestamp (field `start_at_timestamp_nanos`) for which node metrics are available. The maximum number of returned timestamps is 60 and no two returned timestamps belong to the same UTC day.
+Given a subnet ID as input, this method returns a time series of node metrics (field `node_metrics`). The timestamps are represented as nanoseconds since 1970-01-01 (field `timestamp_nanos`) at which the metrics were sampled. The returned timestamps are all timestamps after (and including) the provided timestamp (field `start_at_timestamp_nanos`) for which node metrics are available. The maximum number of returned timestamps is 60 and no two returned timestamps belong to the same UTC day.
+
+Note that a sample will only include metrics for nodes whose metrics changed compared to the previous sample. This means that if a node disappears in one sample and later reappears its metrics will restart from 0 and consumers of this API need to adjust for these resets when aggregating over multiple samples.
 
 A single metric entry is a record with the following fields:
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -2103,7 +2103,7 @@ The node metrics management canister API is considered EXPERIMENTAL. Canister de
 
 :::
 
-Given a subnet ID as input, this method returns collections of metrics for all nodes on the given subnet (field `node_metrics`) at timestamps provided in nanoseconds since 1970-01-01 (field `timestamp_nanos`) at which the metrics were sampled. The returned timestamps are all timestamps after (and including) the provided timestamp (field `start_at_timestamp_nanos`) for which node metrics are available.
+Given a subnet ID as input, this method returns collections of metrics for all nodes on the given subnet (field `node_metrics`) at timestamps provided in nanoseconds since 1970-01-01 (field `timestamp_nanos`) at which the metrics were sampled. The returned timestamps are all timestamps after (and including) the provided timestamp (field `start_at_timestamp_nanos`) for which node metrics are available. The maximum number of returned timestamps is 60 and no two returned timestamps belong to the same UTC day.
 
 A single metric entry is a record with the following fields:
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -2122,13 +2122,15 @@ The metrics management canister API is considered EXPERIMENTAL. Canister develop
 
 :::
 
-Given a subnet ID as input, this method returns a collection of metrics for the given subnet.
+Given a subnet ID as input, this method returns a collection of metrics for the given subnet (field `metrics`) and a timestamp provided in nanoseconds since 1970-01-01 (field `timestamp_nanos`) at which the metrics are sampled.
 
 A single metric entry is of an enumeration type with a single variant (in the future, more variants might be added):
 
-- `node_metrics`: provides metrics for a node characterized by its principal (field `node_id`), for a period of time characterized by start and end timestamps in nanoseconds since 1970-01-01 (fields `start_timestamp_nanos` and `end_timestamp_nanos`), and the actual metrics values:
+- `node_metrics`: provides metrics for a node characterized by its principal (field `node_id`) and the actual metrics values:
 
-  - `num_proposed_blocks` (`nat`): the number of blocks proposed by this node.
+  - `num_blocks` (`nat64`): the number of blocks proposed by this node;
+
+  - `num_block_failures` (`nat64`): the number of failed block proposals by this node.
 
 ## Certification {#certification}
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -4496,7 +4496,7 @@ The node metrics management canister API is considered EXPERIMENTAL. Canister de
 
 :::
 
-The management canister returns metrics for all nodes on a given subnet. The definition of the metrics values
+The management canister returns metrics for nodes on a given subnet. The definition of the metrics values
 is not captured in this formal semantics.
 
 Conditions

--- a/spec/index.md
+++ b/spec/index.md
@@ -2123,6 +2123,7 @@ The metrics management canister API is considered EXPERIMENTAL. Canister develop
 :::
 
 Given a subnet ID as input, this method returns a collection of metrics for the given subnet (field `metrics`) and a timestamp provided in nanoseconds since 1970-01-01 (field `timestamp_nanos`) at which the metrics are sampled.
+This timestamp is the earliest timestamp after the requested timestamp (field `requested_timestamp_nanos`) for which the metrics are available.
 
 A single metric entry is of an enumeration type with a single variant (in the future, more variants might be added):
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -2116,6 +2116,12 @@ The [standard nearest-rank estimation method](https://en.wikipedia.org/wiki/Perc
 
 ### IC method `metrics` {#ic-metrics}
 
+:::note
+
+The metrics management canister API is considered EXPERIMENTAL. Canister developers must be aware that the API may evolve in a non-backward-compatible way.
+
+:::
+
 Given a subnet ID as input, this method returns a collection of metrics for the given subnet.
 
 A single metric entry is of an enumeration type with a single variant (in the future, more variants might be added):
@@ -4152,6 +4158,12 @@ S with
 ```
 
 #### IC Management Canister: Metrics
+
+:::note
+
+The metrics management canister API is considered EXPERIMENTAL. Canister developers must be aware that the API may evolve in a non-backward-compatible way.
+
+:::
 
 The management canister returns metrics for a given subnet. The definition of the metrics values
 is not captured in this formal semantics.


### PR DESCRIPTION
This PR introduces a new IC management canister method called `node_metrics_history` for retrieving history of metrics for all nodes on a given subnet.