### PR TITLE
update conditions on requested paths in HTTP read_state requests

### DIFF
--- a/spec/_attachments/interface-spec-changelog.md
+++ b/spec/_attachments/interface-spec-changelog.md
@@ -5,6 +5,7 @@
 * System API calls `ic0.msg_caller_size` and `ic0.msg_caller_copy` can be called in all contexts except for (start) function.
 * Added note on confidentiality of values in the certified state tree.
 * Update algorithm computing the request and response hash in the HTTP Gateway including clarification of when the HTTP Gateway can allow for arbitrary certification version in the canister's response.
+* Update conditions on requested paths in HTTP read state requests.
 
 ### 0.20.0 (2023-07-11) {#0_20_0}
 * IC Bitcoin API, ECDSA API, canister HTTPS outcalls API, and 128-bit cycles System API are considered stable.

--- a/spec/index.md
+++ b/spec/index.md
@@ -658,7 +658,7 @@ All requested paths must have the following form:
 
 -   `/time`. Can always be requested.
 
--   `/subnet`, `/subnet/<subnet_id>/public_key`, `/subnet/<subnet_id>/canister_ranges`. Can always be requested.
+-   `/subnet`, `/subnet/<subnet_id>`, `/subnet/<subnet_id>/public_key`, `/subnet/<subnet_id>/canister_ranges`. Can always be requested.
 
 -   `/request_status/<request_id>`, `/request_status/<request_id>/status`, `/request_status/<request_id>/reply`, `/request_status/<request_id>/reject_code`, `/request_status/<request_id>/reject_message`, `/request_status/<request_id>/error_code`. Can be requested if no path with such a prefix exists in the state tree or
 
@@ -4668,6 +4668,7 @@ The predicate `may_read_path` is defined as follows, implementing the access con
 
     may_read_path(S, _, ["time"]) = True
     may_read_path(S, _, ["subnet"]) = True
+    may_read_path(S, _, ["subnet", sid]) = True
     may_read_path(S, _, ["subnet", sid, "public_key"]) = True
     may_read_path(S, _, ["subnet", sid, "canister_ranges"]) = True
     may_read_path(S, _, ["request_status", Rid]) =

--- a/spec/index.md
+++ b/spec/index.md
@@ -654,13 +654,13 @@ canister developers that aim at keeping data confidential are advised to add a s
 
 :::
 
-All requested paths must have one of the following paths as prefix:
+All requested paths must have the following form:
 
 -   `/time`. Can always be requested.
 
--   `/subnet`. Can always be requested.
+-   `/subnet`, `/subnet/<subnet_id>/public_key`, `/subnet/<subnet_id>/canister_ranges`. Can always be requested.
 
--   `/request_status/<request_id>`. Can be requested if no path with such a prefix exists in the state tree or
+-   `/request_status/<request_id>`, `/request_status/<request_id>/status`, `/request_status/<request_id>/reply`, `/request_status/<request_id>/reject_code`, `/request_status/<request_id>/reject_message`, `/request_status/<request_id>/error_code`. Can be requested if no path with such a prefix exists in the state tree or
 
     -   the sender of the original request referenced by `<request_id>` is the same as the sender of the read state request and
 
@@ -4666,13 +4666,20 @@ A record with
 
 The predicate `may_read_path` is defined as follows, implementing the access control outlined in [Request: Read state](#http-read-state):
 
-    may_read_path(S, _, ["time"] · _) = True
-    may_read_path(S, _, ["subnet"] · _) = True
-    may_read_path(S, _, ["request_status", Rid] · _) =
+    may_read_path(S, _, ["time"]) = True
+    may_read_path(S, _, ["subnet"]) = True
+    may_read_path(S, _, ["subnet", sid, "public_key"]) = True
+    may_read_path(S, _, ["subnet", sid, "canister_ranges"]) = True
+    may_read_path(S, _, ["request_status", Rid]) =
+    may_read_path(S, _, ["request_status", Rid, "status"]) =
+    may_read_path(S, _, ["request_status", Rid, "reply"]) =
+    may_read_path(S, _, ["request_status", Rid, "reject_code"]) =
+    may_read_path(S, _, ["request_status", Rid, "reject_message"]) =
+    may_read_path(S, _, ["request_status", Rid, "error_code"]) =
       ∀ (R ↦ (_, ECID')) ∈ dom(S.requests). hash_of_map(R) = Rid => RS.sender == R.sender ∧ ECID == ECID'
-    may_read_path(S, _, ["canister", cid, "module_hash"] · _) = cid == ECID
-    may_read_path(S, _, ["canister", cid, "controllers"] · _) = cid == ECID
-    may_read_path(S, _, ["canister", cid, "metadata", name] · _) = cid == ECID ∧ UTF8(name) ∧
+    may_read_path(S, _, ["canister", cid, "module_hash"]) = cid == ECID
+    may_read_path(S, _, ["canister", cid, "controllers"]) = cid == ECID
+    may_read_path(S, _, ["canister", cid, "metadata", name]) = cid == ECID ∧ UTF8(name) ∧
       (cid ∉ dom(S.canisters[cid]) ∨
        S.canisters[cid] = EmptyCanister ∨
        name ∉ (dom(S.canisters[cid].public_custom_sections) ∪ dom(S.canisters[cid].private_custom_sections)) ∨
@@ -4706,7 +4713,7 @@ where `state_tree` constructs a labeled tree from the IC state `S` and the (so f
     request_status_tree(Processing) =
       { "status": "processing" }
     request_status_tree(Rejected (code, msg)) =
-      { "status": "rejected"; "reject_code": code; "reject_message": msg, error_code: <implementation-specific>}
+      { "status": "rejected"; "reject_code": code; "reject_message": msg; "error_code": <implementation-specific>}
     request_status_tree(Replied arg) =
       { "status": "replied"; "reply": arg }
     request_status_tree(Done) =


### PR DESCRIPTION
This PR tightens the conditions on requested paths in HTTP read_state requests: it forbids to request paths that cannot be present in the state tree according to its definition.