### PR TITLE
feat: add query endpoints to the Bitcoin API

### DIFF
--- a/.github/workflows/check-cddl-candid.yml
+++ b/.github/workflows/check-cddl-candid.yml
@@ -13,7 +13,7 @@ jobs:
         docker run --rm -v $PWD/spec/_attachments:/workdir ghcr.io/anweiss/cddl-cli:0.9.1 compile-cddl --cddl /workdir/requests.cddl
     - name: Check candid files
       run: |
-        curl -L https://github.com/dfinity/candid/releases/download/2023-05-26/didc-linux64 -o didc
+        curl -L https://github.com/dfinity/candid/releases/download/2023-07-25/didc-linux64 -o didc
         chmod +x didc
         ./didc check spec/_attachments/http-gateway.did
         ./didc check spec/_attachments/ic.did

--- a/spec/_attachments/ic.did
+++ b/spec/_attachments/ic.did
@@ -180,9 +180,9 @@ service ic : {
 
   // bitcoin interface
   bitcoin_get_balance: (get_balance_request) -> (satoshi);
-  bitcoin_get_balance_untrusted: (get_balance_request) -> (satoshi) composite_query;
+  bitcoin_get_balance_query: (get_balance_request) -> (satoshi) composite_query;
   bitcoin_get_utxos: (get_utxos_request) -> (get_utxos_response);
-  bitcoin_get_utxos_untrusted: (get_utxos_request) -> (get_utxos_response) composite_query;
+  bitcoin_get_utxos_query: (get_utxos_request) -> (get_utxos_response) composite_query;
   bitcoin_send_transaction: (send_transaction_request) -> ();
   bitcoin_get_current_fee_percentiles: (get_current_fee_percentiles_request) -> (vec millisatoshi_per_byte);
 

--- a/spec/_attachments/ic.did
+++ b/spec/_attachments/ic.did
@@ -180,7 +180,9 @@ service ic : {
 
   // bitcoin interface
   bitcoin_get_balance: (get_balance_request) -> (satoshi);
+  bitcoin_get_balance_untrusted: (get_balance_request) -> (satoshi) composite_query;
   bitcoin_get_utxos: (get_utxos_request) -> (get_utxos_response);
+  bitcoin_get_utxos_untrusted: (get_utxos_request) -> (get_utxos_response) composite_query;
   bitcoin_send_transaction: (send_transaction_request) -> ();
   bitcoin_get_current_fee_percentiles: (get_current_fee_percentiles_request) -> (vec millisatoshi_per_byte);
 

--- a/spec/_attachments/ic.did
+++ b/spec/_attachments/ic.did
@@ -180,9 +180,9 @@ service ic : {
 
   // bitcoin interface
   bitcoin_get_balance: (get_balance_request) -> (satoshi);
-  bitcoin_get_balance_query: (get_balance_request) -> (satoshi) composite_query;
+  bitcoin_get_balance_query: (get_balance_request) -> (satoshi) query;
   bitcoin_get_utxos: (get_utxos_request) -> (get_utxos_response);
-  bitcoin_get_utxos_query: (get_utxos_request) -> (get_utxos_response) composite_query;
+  bitcoin_get_utxos_query: (get_utxos_request) -> (get_utxos_response) query;
   bitcoin_send_transaction: (send_transaction_request) -> ();
   bitcoin_get_current_fee_percentiles: (get_current_fee_percentiles_request) -> (vec millisatoshi_per_byte);
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -2084,7 +2084,18 @@ The recommended workflow is to issue a request with the desired number of confir
 ### IC method `bitcoin_get_utxos_query` {#ic-bitcoin_get_utxos_query}
 
 This method is identical to [`bitcoin_get_utxos`](#ic-bitcoin_get_utxos), but exposed as a query.
-Note that the response of a query comes from a single replica, and is therefore not appropriate for security-sensitive applications.
+
+:::note
+
+This query is only accessible in non-replicated mode. Calls in replicated mode are rejected.
+
+:::
+
+:::warning
+
+The response of a query comes from a single replica, and is therefore not appropriate for security-sensitive applications.
+
+:::
 
 ### IC method `bitcoin_get_balance` {#ic-bitcoin_get_balance}
 
@@ -2099,7 +2110,18 @@ Given an address and the optional `min_confirmations` parameter, `bitcoin_get_ba
 ### IC method `bitcoin_get_balance_query` {#ic-bitcoin_get_balance_query}
 
 This method is identical to [`bitcoin_get_balance`](#ic-bitcoin_get_balance), but exposed as a query.
-Note that the response of a query comes from a single replica, and is therefore not appropriate for security-sensitive applications.
+
+:::note
+
+This query is only accessible in non-replicated mode. Calls in replicated mode are rejected.
+
+:::
+
+:::warning
+
+The response of a query comes from a single replica, and is therefore not appropriate for security-sensitive applications.
+
+:::
 
 ### IC method `bitcoin_send_transaction` {#ic-bitcoin_send_transaction}
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -2081,9 +2081,10 @@ A `get_utxos_request` without the optional `filter` results in a request that co
 
 The recommended workflow is to issue a request with the desired number of confirmations. If the `next_page` field in the response is not empty, there are more UTXOs than in the returned vector. In that case, the `page` field should be set to the `next_page` bytes in the subsequent request to obtain the next batch of UTXOs.
 
-### IC method `bitcoin_get_utxos_untrusted` {#ic-bitcoin_get_utxos_untrusted}
+### IC method `bitcoin_get_utxos_query` {#ic-bitcoin_get_utxos_query}
 
-This method is identical to [`bitcoin_get_utxos`](#ic-bitcoin_get_utxos). The only difference is that it is exposed as an uncertified query call, and its results can therefore not be trusted.
+This method is identical to [`bitcoin_get_utxos`](#ic-bitcoin_get_utxos), but exposed as a query.
+Note that the response of a query comes from a single replica, and is therefore not appropriate for security-sensitive applications.
 
 ### IC method `bitcoin_get_balance` {#ic-bitcoin_get_balance}
 
@@ -2095,9 +2096,10 @@ The optional `min_confirmations` parameter can be used to limit the set of consi
 
 Given an address and the optional `min_confirmations` parameter, `bitcoin_get_balance` iterates over all UTXOs, i.e., the same balance is returned as when calling [`bitcoin_get_utxos`](#ic-bitcoin_get_utxos) for the same address and the same number of confirmations and, if necessary, using pagination to get all UTXOs for the same tip hash.
 
-### IC method `bitcoin_get_balance_untrusted` {#ic-bitcoin_get_balance_untrusted}
+### IC method `bitcoin_get_balance_query` {#ic-bitcoin_get_balance_query}
 
-This method is identical to [`bitcoin_get_balance`](#ic-bitcoin_get_balance). The only difference is that it is exposed as an uncertified query call, and its results can therefore not be trusted.
+This method is identical to [`bitcoin_get_balance`](#ic-bitcoin_get_balance), but exposed as a query.
+Note that the response of a query comes from a single replica, and is therefore not appropriate for security-sensitive applications.
 
 ### IC method `bitcoin_send_transaction` {#ic-bitcoin_send_transaction}
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -2081,6 +2081,10 @@ A `get_utxos_request` without the optional `filter` results in a request that co
 
 The recommended workflow is to issue a request with the desired number of confirmations. If the `next_page` field in the response is not empty, there are more UTXOs than in the returned vector. In that case, the `page` field should be set to the `next_page` bytes in the subsequent request to obtain the next batch of UTXOs.
 
+### IC method `bitcoin_get_utxos_untrusted` {#ic-bitcoin_get_utxos_untrusted}
+
+This method is identical to [`bitcoin_get_utxos`](#ic-bitcoin_get_utxos). The only difference is that it is exposed as an uncertified query call, and its results can therefore not be trusted.
+
 ### IC method `bitcoin_get_balance` {#ic-bitcoin_get_balance}
 
 Given a `get_balance_request`, which must specify a Bitcoin address and a Bitcoin network (`mainnet` or `testnet`), the function returns the current balance of this address in `Satoshi` (10^8 Satoshi = 1 Bitcoin) in the specified Bitcoin network. The same address formats as for [`bitcoin_get_utxos`](#ic-bitcoin_get_utxos) are supported.
@@ -2090,6 +2094,10 @@ If the address is malformed, the call is rejected.
 The optional `min_confirmations` parameter can be used to limit the set of considered UTXOs for the calculation of the balance to those with at least the provided number of confirmations in the same manner as for the [`bitcoin_get_utxos`](#ic-bitcoin_get_utxos) call.
 
 Given an address and the optional `min_confirmations` parameter, `bitcoin_get_balance` iterates over all UTXOs, i.e., the same balance is returned as when calling [`bitcoin_get_utxos`](#ic-bitcoin_get_utxos) for the same address and the same number of confirmations and, if necessary, using pagination to get all UTXOs for the same tip hash.
+
+### IC method `bitcoin_get_balance_untrusted` {#ic-bitcoin_get_balance_untrusted}
+
+This method is identical to [`bitcoin_get_balance`](#ic-bitcoin_get_balance). The only difference is that it is exposed as an uncertified query call, and its results can therefore not be trusted.
 
 ### IC method `bitcoin_send_transaction` {#ic-bitcoin_send_transaction}
 


### PR DESCRIPTION
There are a number of applications, particularly frontends, that require some signal as to whether or not some event on the Bitcoin chain has happened. For example, a frontend can allow you to make a Bitcoin transaction, and it wants to auto-refresh and display a signal once the transaction has been mined.

Currently, frontends cannot query the Bitcoin API because it requires cycles. They'd either need to proxy their requests via their own canister, or rely on a block explorer. The former is expensive and slow, while the latter is unideal given that the IC provides its own Bitcoin API.

This commit adds query endpoints to the Bitcoin API. They are query methods enforcing that they can only be called in non-replicated mode. The query endpoints allow frontends to query information about the Bitcoin state. These queries are fast and free for callers, knowing that they cannot fully trust the information being returned and should not be used for anything sensitive.
