### PR TITLE
point out that stable memory is cleared during reinstall

### DIFF
--- a/spec/index.md
+++ b/spec/index.md
@@ -1836,7 +1836,7 @@ Only controllers of the canister can install code.
 
 -   If `mode = install`, the canister must be empty before. This will instantiate the canister module and invoke its `canister_init` method (if present), as explained in Section "[Canister initialization](#system-api-init)", passing the `arg` to the canister.
 
--   If `mode = reinstall`, if the canister was not empty, its existing code and state is removed before proceeding as for `mode = install`.
+-   If `mode = reinstall`, if the canister was not empty, its existing code and state (including stable memory) is removed before proceeding as for `mode = install`.
 
     Note that this is different from `uninstall_code` followed by `install_code`, as `uninstall_code` generates a synthetic reject response to all callers of the uninstalled canister that the uninstalled canister did not yet reply to and ensures that callbacks to outstanding calls made by the uninstalled canister won't be executed (i.e., upon receiving a response from a downstream call made by the uninstalled canister, the cycles attached to the response are refunded, but no callbacks are executed).
 


### PR DESCRIPTION
This PR points out explicitly that stable memory is cleared during reinstall. Currently, this is only apparent when reading the formal part of the specification (Abstract transitions).