### PR TITLE
use asset canisters for PR preview deployments

### DIFF
--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -1,0 +1,35 @@
+name: PR Cleanup
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  release_preview_canister:
+    # do not run in forks
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - run: |
+          pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+          pip install ic-py
+          python3 .github/workflows/scripts/release-canister.py $pull_number
+        env:
+          DFX_IDENTITY_PREVIEW: ${{ secrets.DFX_IDENTITY_PREVIEW }}
+          POOL_CANISTER_ID: ${{ secrets.POOL_CANISTER_ID }}
+
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const comments = require('./.github/workflows/scripts/comments.js');
+            const maybeComment = await comments.get(context, github);
+            if (maybeComment) {
+              await comments.delete(context, github, maybeComment.id);
+            }

--- a/.github/workflows/preview-deployment.yml
+++ b/.github/workflows/preview-deployment.yml
@@ -1,0 +1,90 @@
+name: PR Preview Deployment
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  build_and_deploy:
+    # do not run in forks
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const comments = require('./.github/workflows/scripts/comments.js');
+            const maybeComment = await comments.get(context, github);
+            if (maybeComment) {
+              await comments.update(context, github, maybeComment.id,  `🤖 Your PR preview is being built...`);
+            } else {
+              await comments.create(context, github, `🤖 Your PR preview is being built...`);
+            }
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install DFX
+        run: sh -ci "$(curl -fsSL https://internetcomputer.org/install.sh)"
+
+      - name: "Build & Deploy"
+        run: |
+          mkdir -p ~/.config/dfx/identity/default
+
+          echo $DFX_IDENTITY_PREVIEW | base64 -d > ~/.config/dfx/identity/default/identity.pem
+          sed -i 's/\\r\\n/\r\n/g' ~/.config/dfx/identity/default/identity.pem
+
+          # request preview canister from the pool
+          pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+          pip install ic-py
+          canister_id=$(python3 .github/workflows/scripts/request-canister.py $pull_number)
+
+          # overwrite canister id in dfx.json
+          echo "{\"portal\":{\"ic\":\"$canister_id\"}}" > canister_ids.json
+
+          echo "PREVIEW_CANISTER_ID=$canister_id" >> $GITHUB_ENV
+
+          # install and deploy
+          git submodule update --init
+          npm install
+
+          export PREVIEW_CANISTER_ID=$canister_id
+
+          dfx deploy --network=ic --no-wallet portal --yes
+
+        env:
+          DFX_IDENTITY_PREVIEW: ${{ secrets.DFX_IDENTITY_PREVIEW }}
+          POOL_CANISTER_ID: ${{ secrets.POOL_CANISTER_ID }}
+
+      - name: Report build error
+        uses: actions/github-script@v6
+        if: ${{ failure() }}
+        with:
+          script: |
+            const comments = require('./.github/workflows/scripts/comments.js');
+            const maybeComment = await comments.get(context, github);
+            if (maybeComment) {
+              await comments.update(context, github, maybeComment.id,  `🤖 Preview build failed.`);
+            } else {
+              await comments.create(context, github, `🤖 Preview build failed.`);
+            }
+
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const comments = require('./.github/workflows/scripts/comments.js');
+            const maybeComment = await comments.get(context, github);
+            if (maybeComment) {
+              await comments.update(context, github, maybeComment.id,  `🤖 Here's your preview: https://${process.env.PREVIEW_CANISTER_ID}.ic0.app`);
+            } else {
+              await comments.create(context, github, `🤖 Here's your preview: https://${process.env.PREVIEW_CANISTER_ID}.ic0.app`);
+            }

--- a/.github/workflows/scripts/comments.js
+++ b/.github/workflows/scripts/comments.js
@@ -1,0 +1,37 @@
+exports.get = async function (context, github) {
+  const comments = await github.rest.issues.listComments({
+    issue_number: context.issue.number,
+    repo: context.repo.repo,
+    owner: context.repo.owner,
+  });
+
+  return comments.data.find(
+    (c) => c.user.login === 'github-actions[bot]' && c.user.type === 'Bot'
+  );
+};
+
+exports.create = function (context, github, body) {
+  return github.rest.issues.createComment({
+    issue_number: context.issue.number,
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    body,
+  });
+};
+
+exports.update = function (context, github, id, body) {
+  return github.rest.issues.updateComment({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    comment_id: id,
+    body,
+  });
+};
+
+exports.delete = function (context, github, id) {
+  return github.rest.issues.deleteComment({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    comment_id: id,
+  });
+};

--- a/.github/workflows/scripts/pool.py
+++ b/.github/workflows/scripts/pool.py
@@ -1,0 +1,30 @@
+from ic.client import Client
+from ic.identity import Identity
+from ic.agent import Agent
+import os
+import sys
+import base64
+from ic.candid import encode, Types
+
+
+#
+# Interact with preview canister pool: https://github.com/dfinity/preview-canister-pool
+#
+
+private_key = base64.b64decode(os.environ["DFX_IDENTITY_PREVIEW"]).decode("utf-8")
+pool_id = os.environ["POOL_CANISTER_ID"]
+
+identity = Identity.from_pem(private_key)
+client = Client()
+agent = Agent(identity, client)
+
+def release_canister():
+  res = agent.update_raw(
+      pool_id, "release_canister", encode([{'type': Types.Text, 'value': sys.argv[1]}]))
+  return res
+
+
+def request_canister():
+  res = agent.update_raw(
+      pool_id, "request_canister", encode([{'type': Types.Text, 'value': sys.argv[1]}]), Types.Principal)
+  return res

--- a/.github/workflows/scripts/release-canister.py
+++ b/.github/workflows/scripts/release-canister.py
@@ -1,0 +1,16 @@
+import os
+import sys
+
+if len(sys.argv) != 2:
+  print("Usage: python3 release-canister.py <ref>")
+  exit(1)
+
+for v in ["DFX_IDENTITY_PREVIEW","POOL_CANISTER_ID"]:
+  if not v in os.environ:
+    print(f"release-canister.py: {v} env variable missing")
+    exit(1)
+
+
+from pool import release_canister
+
+release_canister()

--- a/.github/workflows/scripts/request-canister.py
+++ b/.github/workflows/scripts/request-canister.py
@@ -1,0 +1,16 @@
+import os
+import sys
+
+if len(sys.argv) != 2:
+  print("Usage: python3 request_canister.py <ref>")
+  exit(1)
+
+for v in ["DFX_IDENTITY_PREVIEW","POOL_CANISTER_ID"]:
+  if not v in os.environ:
+    print(f"request-canister.py: {v} env variable missing")
+    exit(1)
+
+from pool import request_canister
+
+canister_id = request_canister()[0]['value'].to_str()
+print(canister_id)


### PR DESCRIPTION
This PR uses assets canisters for PR preview deployments to serve as a replacement for Netlify deployments.