### PR TITLE
cleanup netlify.toml and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
 # IDEs
 .vscode/
 .idea/
-
-# Build and Test Output
-theories/code

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,0 @@
-[build]
-  command = "cd docusaurus && yarn install && yarn build"
-  publish = "docusaurus/build"


### PR DESCRIPTION
This PR removes the netlify.toml file which is not needed anymore (since we aren't using Netlify anymore) and removes Isabelle/HOL formal model paths from .gitignore (since we aren't developing this model anymore).