### PR TITLE
query call ingress_expiry is ignored in query call signatures

### DIFF
--- a/spec/index.md
+++ b/spec/index.md
@@ -780,7 +780,14 @@ Given a query (the `content` map from the request body) `Q`, a response `R`, and
               status: "replied",
               reply: R.reply,
               timestamp: T,
-              request_id: hash_of_map(Q)}))
+              request_id: hash_of_map({
+                request_type: "query",
+                sender: Q.sender,
+                nonce: Q.nonce,
+                canister_id: Q.canister_id,
+                method_name: Q.method_name,
+                arg: Q.arg
+              })}))
           else
             verify_signature PK Sig ("\x0Bic-response" · hash_of_map({
               status: "rejected",
@@ -788,9 +795,16 @@ Given a query (the `content` map from the request body) `Q`, a response `R`, and
               reject_message: R.reject_message,
               error_code: R.error_code,
               timestamp: T,
-              request_id: hash_of_map(Q)}))
+              request_id: hash_of_map({
+                request_type: "query",
+                sender: Q.sender,
+                nonce: Q.nonce,
+                canister_id: Q.canister_id,
+                method_name: Q.method_name,
+                arg: Q.arg
+              })}))
 
-where `RootSubnetId` is the a priori known principal of the root subnet. Moreover, all timestamps in `R.signatures`, the certificate `Cert`, and its optional delegation must be "recent enough".
+where `RootSubnetId` is the a priori known principal of the root subnet. Moreover, all timestamps in `R.signatures`, the certificate `Cert`, and its optional delegation must be "recent enough". The optional nonce is ignored in the `hash_of_map` computation if no nonce is provided in the query call request.
 
 :::note
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -780,7 +780,7 @@ Given a query (the `content` map from the request body) `Q`, a response `R`, and
               status: "replied",
               reply: R.reply,
               timestamp: T,
-              request_id: hash_of_map(Q - {ingress_expiry: Q.ingress_expiry})
+              request_id: hash_of_map(Q \ {ingress_expiry: Q.ingress_expiry})
             }))
           else
             verify_signature PK Sig ("\x0Bic-response" · hash_of_map({
@@ -789,7 +789,7 @@ Given a query (the `content` map from the request body) `Q`, a response `R`, and
               reject_message: R.reject_message,
               error_code: R.error_code,
               timestamp: T,
-              request_id: hash_of_map(Q - {ingress_expiry: Q.ingress_expiry})
+              request_id: hash_of_map(Q \ {ingress_expiry: Q.ingress_expiry})
             }))
 
 where `RootSubnetId` is the a priori known principal of the root subnet and `hash_of_map(Q - {ingress_expiry: Q.ingress_expiry})` denotes the [representation-independent hash](#hash-of-map) of the query's content with its `ingress_expiry` field ignored. Moreover, all timestamps in `R.signatures`, the certificate `Cert`, and its optional delegation must be "recent enough".

--- a/spec/index.md
+++ b/spec/index.md
@@ -792,7 +792,7 @@ Given a query (the `content` map from the request body) `Q`, a response `R`, and
               request_id: hash_of_map(Q \ {ingress_expiry: Q.ingress_expiry})
             }))
 
-where `RootSubnetId` is the a priori known principal of the root subnet and `hash_of_map(Q - {ingress_expiry: Q.ingress_expiry})` denotes the [representation-independent hash](#hash-of-map) of the query's content with its `ingress_expiry` field ignored. Moreover, all timestamps in `R.signatures`, the certificate `Cert`, and its optional delegation must be "recent enough".
+where `RootSubnetId` is the a priori known principal of the root subnet and `hash_of_map(Q \ {ingress_expiry: Q.ingress_expiry})` denotes the [representation-independent hash](#hash-of-map) of the query's content with its `ingress_expiry` field ignored. Moreover, all timestamps in `R.signatures`, the certificate `Cert`, and its optional delegation must be "recent enough".
 
 :::note
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -780,14 +780,8 @@ Given a query (the `content` map from the request body) `Q`, a response `R`, and
               status: "replied",
               reply: R.reply,
               timestamp: T,
-              request_id: hash_of_map({
-                request_type: "query",
-                sender: Q.sender,
-                nonce: Q.nonce,
-                canister_id: Q.canister_id,
-                method_name: Q.method_name,
-                arg: Q.arg
-              })}))
+              request_id: hash_of_map(Q - {ingress_expiry: Q.ingress_expiry})
+            }))
           else
             verify_signature PK Sig ("\x0Bic-response" · hash_of_map({
               status: "rejected",
@@ -795,16 +789,10 @@ Given a query (the `content` map from the request body) `Q`, a response `R`, and
               reject_message: R.reject_message,
               error_code: R.error_code,
               timestamp: T,
-              request_id: hash_of_map({
-                request_type: "query",
-                sender: Q.sender,
-                nonce: Q.nonce,
-                canister_id: Q.canister_id,
-                method_name: Q.method_name,
-                arg: Q.arg
-              })}))
+              request_id: hash_of_map(Q - {ingress_expiry: Q.ingress_expiry})
+            }))
 
-where `RootSubnetId` is the a priori known principal of the root subnet. Moreover, all timestamps in `R.signatures`, the certificate `Cert`, and its optional delegation must be "recent enough". The optional nonce is ignored in the `hash_of_map` computation if no nonce is provided in the query call request.
+where `RootSubnetId` is the a priori known principal of the root subnet and `hash_of_map(Q - {ingress_expiry: Q.ingress_expiry})` denotes the [representation-independent hash](#hash-of-map) of the query's content with its `ingress_expiry` field ignored. Moreover, all timestamps in `R.signatures`, the certificate `Cert`, and its optional delegation must be "recent enough".
 
 :::note
 


### PR DESCRIPTION
To facilitate BN query caching of signed query call responses, this PR makes the query call signatures ignore the query call ingress_expiry which is expected to vary for every query call.