### PR TITLE
System API method in_replicated_execution

### DIFF
--- a/spec/index.md
+++ b/spec/index.md
@@ -1308,6 +1308,7 @@ The following sections describe various System API functions, also referred to a
     ic0.global_timer_set : (timestamp : i64) -> i64;                            // I G U Ry Rt C T
     ic0.performance_counter : (counter_type : i32) -> (counter : i64);          // * s
     ic0.is_controller: (src: i32, size: i32) -> ( result: i32);                 // * s
+    ic0.in_replicated_execution: () -> (result: i32);                           // * 
 
     ic0.debug_print : (src : i32, size : i32) -> ();                            // * s
     ic0.trap : (src : i32, size : i32) -> ();                                   // * s
@@ -1756,6 +1757,14 @@ In the future, we might expose more performance counters.
 The system resets the counter at the beginning of each [Entry points](#entry-points) invocation.
 
 The main purpose of this counter is to facilitate in-canister performance profiling.
+
+### Replicated execution check {#system-api-replicated-execution-check}
+
+The canister can check whether it is currently running in replicated or non replicated execution. 
+
+`ic0.in_replicated_execution : () -> (result: i32)`
+
+Returns 1 if the canister is being run in replicated mode and 0 otherwise. 
 
 ### Controller check {#system-api-controller-check}
 
@@ -5920,6 +5929,12 @@ The pseudo-code below does *not* explicitly enforce the restrictions of which im
         else return 1
       else
         Trap {cycles_used = es.cycles_used;}
+
+    ic0.in_replicated_execution<es>() : i32 =
+      if es.context = s then Trap {cycles_used = es.cycles_used;}
+      if es.params.sysenv.certificate = NoCertificate
+      then return 1
+      else return 0
 
     ic0.debug_print<es>(src : i32, size : i32) =
       return


### PR DESCRIPTION
This PR adds a system API method to determine if the canister is running in replicated or non replicated mode. 