### PR TITLE
ingress messages to canisters that are not running cannot be received

### DIFF
--- a/spec/_attachments/interface-spec-changelog.md
+++ b/spec/_attachments/interface-spec-changelog.md
@@ -2,6 +2,7 @@
 
 ### ∞ (unreleased)
 * Add metrics on subnet usage into the certified state tree and a new HTTP endpoint `/api/v2/subnet/<subnet_id>/read_state` for retrieving them.
+* Add a check that a canister receiving an ingress message is Running before the ingress message is marked as Received.
 
 ### 0.21.0 (2023-09-18) {#0_21_0}
 * Canister cycle balance cannot decrease below the freezing limit after executing `install_code` on the management canister.

--- a/spec/index.md
+++ b/spec/index.md
@@ -3038,11 +3038,15 @@ is_effective_canister_id(E.content, ECID)
   E.content.sender ∈ S.controllers[CanisterId]
   E.content.method_name ∈
     { "install_code", "uninstall_code", "update_settings", "start_canister", "stop_canister",
-      "canister_status", "delete_canister",
-      "provisional_create_canister_with_cycles", "provisional_top_up_canister" }
+      "canister_status", "delete_canister" }
+) ∨ (
+  E.content.canister_id = ic_principal
+  E.content.method_name ∈
+    { "provisional_create_canister_with_cycles", "provisional_top_up_canister" }
 ) ∨ (
   E.content.canister_id ≠ ic_principal
   S.canisters[E.content.canister_id] ≠ EmptyCanister
+  S.canister_status[E.content.canister_id] = Running
   Env = {
     time = S.time[E.content.canister_id];
     controllers = S.controllers[E.content.canister_id];


### PR DESCRIPTION
This MR adds a check that a canister receiving an ingress message is Running before the ingress message is marked as `Received`. This is because update calls to Stopping/Stopped canisters are rejected anyway and thus it doesn't make sense to accept such an ingress message.

This MR also cleans up the conditions on ingress messages to provisional API (controller check is dropped for the provisional API).