### PR TITLE
update status endpoint spec

### DIFF
--- a/spec/_attachments/interface-spec-changelog.md
+++ b/spec/_attachments/interface-spec-changelog.md
@@ -11,6 +11,7 @@
 * Update the computation of the representation-independent hash for the case of maps with nested maps.
 * Remove `senders` field from user delegations.
 * The maximum length of a nonce in an ingress message is 32 bytes.
+* Update specification of responses from the endpoint `/api/v2/status`.
 
 ### 0.21.0 (2023-09-18) {#0_21_0}
 * Canister cycle balance cannot decrease below the freezing limit after executing `install_code` on the management canister.

--- a/spec/index.md
+++ b/spec/index.md
@@ -1024,6 +1024,8 @@ Additionally, the Internet Computer provides an API endpoint to obtain various s
 
 For this endpoint, the user performs a GET request, and receives a CBOR (see [CBOR](#cbor)) value with the following fields. The IC may include additional implementation-specific fields.
 
+-   `ic_api_version` (string, mandatory): Identifies the interface version supported, i.e. the version of the present document that the Internet Computer aims to support, e.g. `0.8.1`. The implementation may also return `unversioned` to indicate that it does *not* comply to a particular version, e.g. in between releases.
+
 -   `impl_version` (string, optional): The precise git revision of the Internet Computer Protocol implementation
 
 -   `root_key` (blob, optional): The public key (a DER-encoded BLS key) of the root key of this instance of the Internet Computer Protocol. This *must* be present in short-lived development instances, to allow the agent to fetch the public key. For the Internet Computer, agents must have an independent trustworthy source for this data, and must not be tempted to fetch it from this insecure location.

--- a/spec/index.md
+++ b/spec/index.md
@@ -1024,8 +1024,6 @@ Additionally, the Internet Computer provides an API endpoint to obtain various s
 
 For this endpoint, the user performs a GET request, and receives a CBOR (see [CBOR](#cbor)) value with the following fields. The IC may include additional implementation-specific fields.
 
--   `ic_api_version` (string, mandatory): Identifies the interface version supported, i.e. the version of the present document that the Internet Computer aims to support, e.g. `0.8.1`. The implementation may also return `unversioned` to indicate that it does *not* comply to a particular version, e.g. in between releases.
-
 -   `impl_version` (string, optional): The precise git revision of the Internet Computer Protocol implementation
 
 -   `root_key` (blob, optional): The public key (a DER-encoded BLS key) of the root key of this instance of the Internet Computer Protocol. This *must* be present in short-lived development instances, to allow the agent to fetch the public key. For the Internet Computer, agents must have an independent trustworthy source for this data, and must not be tempted to fetch it from this insecure location.

--- a/spec/index.md
+++ b/spec/index.md
@@ -1010,7 +1010,7 @@ For this endpoint, the user performs a GET request, and receives a CBOR (see [CB
 
 -   `impl_version` (string, optional): The precise git revision of the Internet Computer Protocol implementation
 
--   `root_key` (blob): The public key (a DER-encoded BLS key) of the root key of this instance of the Internet Computer Protocol. This *must* be present in short-lived development instances, to allow the agent to fetch the public key. For the Internet Computer, agents must have an independent trustworthy source for this data, and should not fetch it from this insecure location.
+-   `root_key` (blob, only in development instances): The public key (a DER-encoded BLS key) of the root key of this development instance of the Internet Computer Protocol. This *must* be present in short-lived development instances, to allow the agent to fetch the public key. For the Internet Computer, agents must have an independent trustworthy source for this data, and must not be tempted to fetch it from this insecure location.
 
 See [CBOR encoding of requests and responses](#api-cbor) for details on the precise CBOR encoding of this object.
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -1019,7 +1019,7 @@ For this endpoint, the user performs a GET request, and receives a CBOR (see [CB
 
 -   `impl_version` (string, optional): The precise git revision of the Internet Computer Protocol implementation
 
--   `root_key` (blob): The public key (a DER-encoded BLS key) of the root key of this instance of the Internet Computer Protocol. This *must* be present in short-lived development instances, to allow the agent to fetch the public key. For the Internet Computer, agents must have an independent trustworthy source for this data, and must not be tempted to fetch it from this insecure location.
+-   `root_key` (blob, mandatory): The public key (a DER-encoded BLS key) of the root key of this instance of the Internet Computer Protocol. This *must* be present in short-lived development instances, to allow the agent to fetch the public key. For the Internet Computer, agents must have an independent trustworthy source for this data, and must not be tempted to fetch it from this insecure location.
 
 See [CBOR encoding of requests and responses](#api-cbor) for details on the precise CBOR encoding of this object.
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -1019,7 +1019,7 @@ For this endpoint, the user performs a GET request, and receives a CBOR (see [CB
 
 -   `impl_version` (string, optional): The precise git revision of the Internet Computer Protocol implementation
 
--   `root_key` (blob, only in development instances): The public key (a DER-encoded BLS key) of the root key of this development instance of the Internet Computer Protocol. This *must* be present in short-lived development instances, to allow the agent to fetch the public key. For the Internet Computer, agents must have an independent trustworthy source for this data, and must not be tempted to fetch it from this insecure location.
+-   `root_key` (blob): The public key (a DER-encoded BLS key) of the root key of this instance of the Internet Computer Protocol. This *must* be present in short-lived development instances, to allow the agent to fetch the public key. For the Internet Computer, agents must have an independent trustworthy source for this data, and must not be tempted to fetch it from this insecure location.
 
 See [CBOR encoding of requests and responses](#api-cbor) for details on the precise CBOR encoding of this object.
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -1015,8 +1015,6 @@ Additionally, the Internet Computer provides an API endpoint to obtain various s
 
 For this endpoint, the user performs a GET request, and receives a CBOR (see [CBOR](#cbor)) value with the following fields. The IC may include additional implementation-specific fields.
 
--   `impl_source` (string, optional): Identifies the implementation of the Internet Computer Protocol, by convention with the canonical location of the source code (e.g. `https://github.com/dfinity/ic`).
-
 -   `impl_version` (string, optional): The precise git revision of the Internet Computer Protocol implementation
 
 -   `root_key` (blob, mandatory): The public key (a DER-encoded BLS key) of the root key of this instance of the Internet Computer Protocol. This *must* be present in short-lived development instances, to allow the agent to fetch the public key. For the Internet Computer, agents must have an independent trustworthy source for this data, and must not be tempted to fetch it from this insecure location.

--- a/spec/index.md
+++ b/spec/index.md
@@ -1006,15 +1006,11 @@ Additionally, the Internet Computer provides an API endpoint to obtain various s
 
 For this endpoint, the user performs a GET request, and receives a CBOR (see [CBOR](#cbor)) value with the following fields. The IC may include additional implementation-specific fields.
 
--   `ic_api_version` (string, mandatory): Identifies the interface version supported, i.e. the version of the present document that the Internet Computer aims to support, e.g. `0.8.1`. The implementation may also return `unversioned` to indicate that it does *not* comply to a particular version, e.g. in between releases.
-
 -   `impl_source` (string, optional): Identifies the implementation of the Internet Computer Protocol, by convention with the canonical location of the source code (e.g. `https://github.com/dfinity/ic`).
 
--   `impl_version` (string, optional): If the user is talking to a released version of an Internet Computer Protocol implementation, this is the version number. For non-released versions, output of `git describe` like `0.1.13-13-g2414721` would also be very suitable.
+-   `impl_version` (string, optional): The precise git revision of the Internet Computer Protocol implementation
 
--   `impl_revision` (string, optional): The precise git revision of the Internet Computer Protocol implementation
-
--   `root_key` (blob, only in development instances): The public key (a DER-encoded BLS key) of the root key of this development instance of the Internet Computer Protocol. This *must* be present in short-lived development instances, to allow the agent to fetch the public key. For the Internet Computer, agents must have an independent trustworthy source for this data, and must not be tempted to fetch it from this insecure location.
+-   `root_key` (blob): The public key (a DER-encoded BLS key) of the root key of this instance of the Internet Computer Protocol. This *must* be present in short-lived development instances, to allow the agent to fetch the public key. For the Internet Computer, agents must have an independent trustworthy source for this data, and should not fetch it from this insecure location.
 
 See [CBOR encoding of requests and responses](#api-cbor) for details on the precise CBOR encoding of this object.
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -1017,7 +1017,7 @@ For this endpoint, the user performs a GET request, and receives a CBOR (see [CB
 
 -   `impl_version` (string, optional): The precise git revision of the Internet Computer Protocol implementation
 
--   `root_key` (blob, mandatory): The public key (a DER-encoded BLS key) of the root key of this instance of the Internet Computer Protocol. This *must* be present in short-lived development instances, to allow the agent to fetch the public key. For the Internet Computer, agents must have an independent trustworthy source for this data, and must not be tempted to fetch it from this insecure location.
+-   `root_key` (blob, optional): The public key (a DER-encoded BLS key) of the root key of this instance of the Internet Computer Protocol. This *must* be present in short-lived development instances, to allow the agent to fetch the public key. For the Internet Computer, agents must have an independent trustworthy source for this data, and must not be tempted to fetch it from this insecure location.
 
 See [CBOR encoding of requests and responses](#api-cbor) for details on the precise CBOR encoding of this object.
 


### PR DESCRIPTION
This MR updates the specification of the `/api/v2/status` endpoint:
- drop `ic_api_version` field that does not reflect the actual specification version implemented by the replica;
- drop `impl_source` field that is not populated by the replica implementation;
- rename `impl_revision` into `impl_version` (dropping the current `impl_version`);
- do not specify `root_key` to be only present in development instances.

The last three changes are catching up with the actual behavior of the IC mainnet.