### PR TITLE
Increase max number of WASM globals

### DIFF
--- a/spec/_attachments/interface-spec-changelog.md
+++ b/spec/_attachments/interface-spec-changelog.md
@@ -6,6 +6,7 @@
 * Add a system API method to determine if the canister is running in replicated or non-replicated mode.
 * Add a system API method to burn cycles of the canister that calls this method.
 * Add a check that a canister receiving an ingress message is Running before the ingress message is marked as Received.
+* Increase the maximum number of globals in a canister's WASM.
 
 ### 0.21.0 (2023-09-18) {#0_21_0}
 * Canister cycle balance cannot decrease below the freezing limit after executing `install_code` on the management canister.

--- a/spec/index.md
+++ b/spec/index.md
@@ -1154,7 +1154,7 @@ In order for a WebAssembly module to be usable as the code for the canister, it 
 
     -   declare more than 50,000 functions, or
 
-    -   declare more than 300 globals, or
+    -   declare more than 1,000 globals, or
 
     -   declare more than 16 exported custom sections (the custom section names with prefix `icp:`), or
 


### PR DESCRIPTION
The current limit is not enough for C++ and Python languages as discussed on the forum: https://forum.dfinity.org/t/wasm-module-defined-globals-which-exceeds-the-maximum-number-allowed-200/