### PR TITLE
feat: update representation-independent hash computation

### DIFF
--- a/spec/_attachments/interface-spec-changelog.md
+++ b/spec/_attachments/interface-spec-changelog.md
@@ -8,6 +8,7 @@
 * Add a check that a canister receiving an ingress message is Running before the ingress message is marked as Received.
 * Increase the maximum number of globals in a canister's WASM.
 * Add per-call context performance counter.
+* Update the computation of the representation-independent hash for the case of maps with nested maps.
 
 ### 0.21.0 (2023-09-18) {#0_21_0}
 * Canister cycle balance cannot decrease below the freezing limit after executing `install_code` on the management canister.

--- a/spec/index.md
+++ b/spec/index.md
@@ -809,7 +809,7 @@ Given a query (the `content` map from the request body) `Q`, a response `R`, and
           if R.status = "replied" then
             verify_signature PK Sig ("\x0Bic-response" · hash_of_map({
               status: "replied",
-              reply: R.reply,
+              reply: hash_of_map(R.reply),
               timestamp: T,
               request_id: hash_of_map(Q)}))
           else

--- a/spec/index.md
+++ b/spec/index.md
@@ -932,6 +932,17 @@ The following encodings of field values as blobs are used
 
 -   Maps (`sender_delegation`) are encoded by recursively computing the representation-independent hash.
 
+:::tip
+
+Example calculation (where `H` denotes SHA-256 and `·` denotes blob concatenation) of a representation independent hash
+for a map with a nested map in a field value:
+
+    hash_of_map({ "reply": { "arg": "DIDL\x00\x00" } })
+      = H(concat (sort [ H("reply") · H(hash_of_map({ "arg": "DIDL\x00\x00" })) ]))
+      = H(concat (sort [ H("reply") · H(H(concat (sort [ H("arg") · H("DIDL\x00\x00") ]))) ]))
+
+:::
+
 ### Request ids {#request-id}
 
 When signing requests or querying the status of a request (see [Request status](#state-tree-request-status)) in the state tree, the user identifies the request using a *request id*, which is the [representation-independent hash](#hash-of-map) of the `content` map of the original request. A request id must have length of 32 bytes.


### PR DESCRIPTION
This MR updates the specification of the representation-independent hash computation for the case of maps with nested maps.