### PR TITLE
fix: bound delegation depth in verify_response

### DIFF
--- a/spec/index.md
+++ b/spec/index.md
@@ -802,7 +802,7 @@ Given a query (the `content` map from the request body) `Q`, a response `R`, and
     verify_response(Q, R, Cert)
       = verify_cert(Cert) ∧
         ((Cert.delegation = NoDelegation ∧ SubnetId = RootSubnetId ∧ lookup(["subnet",SubnetId,"canister_ranges"], Cert) = Found Ranges) ∨
-         (SubnetId = Cert.delegation.subnet_id ∧ lookup(["subnet",SubnetId,"canister_ranges"], Cert.delegation.certificate) = Found Ranges)) ∧
+         (SubnetId = Cert.delegation.subnet_id ∧ Cert.delegation.certificate.delegation = NoDelegation ∧ lookup(["subnet",SubnetId,"canister_ranges"], Cert.delegation.certificate) = Found Ranges)) ∧
         effective_canister_id ∈ Ranges ∧
         ∀ {timestamp: T, signature: Sig, identity: NodeId} ∈ R.signatures.
           lookup(["subnet",SubnetId,"node",NodeId,"public_key"], Cert) = Found PK ∧


### PR DESCRIPTION
The current definition of `verify_response` for replica-signed queries allows for nested delegations in which case the canister ranges fetched from the delegation might not be signed by the root subnet. This PR fixes this security vulnerability by limiting the delegation depth to one.

There's a separate [PR](https://github.com/dfinity/interface-spec/pull/239) bounding the delegation depth to one globally. This PR is void if the delegation depth is bounded globally.