### PR TITLE
feat: drop senders field from user delegations

### DIFF
--- a/spec/_attachments/interface-spec-changelog.md
+++ b/spec/_attachments/interface-spec-changelog.md
@@ -9,6 +9,7 @@
 * Increase the maximum number of globals in a canister's WASM.
 * Add per-call context performance counter.
 * Update the computation of the representation-independent hash for the case of maps with nested maps.
+* Remove `senders` field from user delegations.
 
 ### 0.21.0 (2023-09-18) {#0_21_0}
 * Canister cycle balance cannot decrease below the freezing limit after executing `install_code` on the management canister.

--- a/spec/_attachments/requests.cddl
+++ b/spec/_attachments/requests.cddl
@@ -88,7 +88,6 @@ signed-delegation = {
     pubkey: bytes
     expiration: timestamp
     ? targets: [* principal]
-    ? senders: [* principal]
   }
   signature: bytes
 }


### PR DESCRIPTION
The `senders` field in user delegations is not (going to be) supported in the replica implementation and thus this PR removes this field from the specification.