### PR TITLE
feat: add api boundary nodes to state tree

### DIFF
--- a/spec/_attachments/interface-spec-changelog.md
+++ b/spec/_attachments/interface-spec-changelog.md
@@ -1,6 +1,7 @@
 ## Changelog {#changelog}
 
 ### ∞ (unreleased)
+* Add API boundary nodes into the certified state tree and new HTTP endpoints for retrieving them.
 * The maximum length of a nonce in an ingress message is 32 bytes.
 * Update specification of responses from the endpoint `/api/v2/status`.
 * Stop canister calls might be rejected upon timeout.

--- a/spec/_attachments/interface-spec-changelog.md
+++ b/spec/_attachments/interface-spec-changelog.md
@@ -11,7 +11,7 @@
 * Set the maximum depth of a delegation in a read_state response/certified variable certificate to 1.
 * Canister version is guaranteed to increase if the canister's running status changes.
 * Calls to frozen canisters are rejected with `SYS_TRANSIENT` instead of `CANISTER_ERROR`.
-* Add API boundary nodes into the certified state tree and new HTTP endpoints for retrieving them.
+* Add API boundary nodes information into the certified state tree.
 
 ### 0.22.0 (2023-11-15) {#0_22_0}
 * Add metrics on subnet usage into the certified state tree and a new HTTP endpoint `/api/v2/subnet/<subnet_id>/read_state` for retrieving them.

--- a/spec/_attachments/interface-spec-changelog.md
+++ b/spec/_attachments/interface-spec-changelog.md
@@ -1,7 +1,6 @@
 ## Changelog {#changelog}
 
 ### ∞ (unreleased)
-* Add API boundary nodes into the certified state tree and new HTTP endpoints for retrieving them.
 * The maximum length of a nonce in an ingress message is 32 bytes.
 * Update specification of responses from the endpoint `/api/v2/status`.
 * Stop canister calls might be rejected upon timeout.
@@ -12,6 +11,7 @@
 * Set the maximum depth of a delegation in a read_state response/certified variable certificate to 1.
 * Canister version is guaranteed to increase if the canister's running status changes.
 * Calls to frozen canisters are rejected with `SYS_TRANSIENT` instead of `CANISTER_ERROR`.
+* Add API boundary nodes into the certified state tree and new HTTP endpoints for retrieving them.
 
 ### 0.22.0 (2023-11-15) {#0_22_0}
 * Add metrics on subnet usage into the certified state tree and a new HTTP endpoint `/api/v2/subnet/<subnet_id>/read_state` for retrieving them.

--- a/spec/index.md
+++ b/spec/index.md
@@ -450,6 +450,7 @@ The state tree contains information about all API boundary nodes, which can comm
 
     Public IPv6 address of a node in the hexadecimal notation with colons.
     Example: `3002:0bd6:0000:0000:0000:ee00:0033:6778`.
+
 ### Subnet information {#state-tree-subnet}
 
 The state tree contains information about the topology of the Internet Computer.

--- a/spec/index.md
+++ b/spec/index.md
@@ -435,6 +435,8 @@ This section specifies the publicly relevant paths in the tree.
 The state tree contains information about all API boundary nodes, which can communicate with the Internet Computer (replica nodes). The source of truth for these API boundary node records is stored in the registry canister and can be added/modified/removed via proposals.
 - `/api_boundary_nodes/<node_id>/domain` (text)
 - `/api_boundary_nodes/<node_id>/ipv4_address` (text)
+  
+    If the `ipv4_address` is empty, this path does not exist.
 - `/api_boundary_nodes/<node_id>/ipv6_address` (text)
 
     The domain name associated with a node, e.g., `api-bn1.example.com`.

--- a/spec/index.md
+++ b/spec/index.md
@@ -445,6 +445,7 @@ The state tree contains information about all API boundary nodes, which can comm
     Public IPv4 address of a node in the dotted-decimal notation.
     If the `ipv4_address` is empty, this path does not exist.  
     Example: `192.168.10.150`.
+
 - `/api_boundary_nodes/<node_id>/ipv6_address` (text)
 
     Public IPv6 address of a node in the hexadecimal notation with colons.

--- a/spec/index.md
+++ b/spec/index.md
@@ -714,6 +714,7 @@ canister developers that aim at keeping data confidential are advised to add a s
 All requested paths must have the following form:
 
 -   `/time`. Can always be requested.
+
 - `/api_boundary_nodes`, `/api_boundary_nodes/<node_id>`, `/api_boundary_nodes/<node_id>/domain`,  `/api_boundary_nodes/<node_id>/ipv4_address`, `/api_boundary_nodes/<node_id>/ipv6_address`. Can always be requested.
 
 -   `/subnet`, `/subnet/<subnet_id>`, `/subnet/<subnet_id>/public_key`, `/subnet/<subnet_id>/canister_ranges`, `/subnet/<subnet_id>/metrics`, `/subnet/<subnet_id>/node`, `/subnet/<subnet_id>/node/<node_id>`, `/subnet/<subnet_id>/node/<node_id>/public_key`. Can always be requested.

--- a/spec/index.md
+++ b/spec/index.md
@@ -704,7 +704,7 @@ canister developers that aim at keeping data confidential are advised to add a s
 All requested paths must have the following form:
 
 -   `/time`. Can always be requested.
-- `/api_boundary_nodes`, `/api_boundary_nodes/<node_id>`, `/api_boundary_nodes/<node_id>/domain`, `/api_boundary_nodes/<node_id>/pub_key`, `/api_boundary_nodes/<node_id>/ipv4_address`, `/api_boundary_nodes/<node_id>/ipv6_address`. Can always be requested.
+- `/api_boundary_nodes`, `/api_boundary_nodes/<node_id>`, `/api_boundary_nodes/<node_id>/domain`,  `/api_boundary_nodes/<node_id>/ipv4_address`, `/api_boundary_nodes/<node_id>/ipv6_address`. Can always be requested.
 
 -   `/subnet`, `/subnet/<subnet_id>`, `/subnet/<subnet_id>/public_key`, `/subnet/<subnet_id>/canister_ranges`, `/subnet/<subnet_id>/metrics`, `/subnet/<subnet_id>/node`, `/subnet/<subnet_id>/node/<node_id>`, `/subnet/<subnet_id>/node/<node_id>/public_key`. Can always be requested.
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -432,7 +432,9 @@ This section specifies the publicly relevant paths in the tree.
     All partial state trees include a timestamp, indicating the time at which the state is current.
 
 ### Api boundary bodes information {#state-tree-subnet}
-The state tree contains information about all API boundary nodes, which can communicate with the Internet Computer (replica nodes). The source of truth for these API boundary node records is stored in the registry canister.
+
+The state tree contains information about all API boundary nodes, which can communicate with the Internet Computer (its replica nodes). The source of truth for these API boundary node records is stored in the NNS registry canister.
+
 - `/api_boundary_nodes/<node_id>/domain` (text)
 - `/api_boundary_nodes/<node_id>/ipv4_address` (text)
   

--- a/spec/index.md
+++ b/spec/index.md
@@ -434,6 +434,9 @@ This section specifies the publicly relevant paths in the tree.
 ### Api boundary bodes information {#state-tree-subnet}
 The state tree contains information about all API boundary nodes, which can communicate with the Internet Computer (replica nodes). The source of truth for these API boundary node records is stored in the registry canister and can be added/modified/removed via proposals.
 - `/api_boundary_nodes/<node_id>/domain` (text)
+- `/api_boundary_nodes/<node_id>/public_key` (text)
+- `/api_boundary_nodes/<node_id>/ipv4_address` (text)
+- `/api_boundary_nodes/<node_id>/ipv6_address` (text)
 
     The domain name associated with a node, e.g., `api-bn1.example.com`.
 ### Subnet information {#state-tree-subnet}
@@ -702,7 +705,7 @@ canister developers that aim at keeping data confidential are advised to add a s
 All requested paths must have the following form:
 
 -   `/time`. Can always be requested.
-- `/api_boundary_nodes`, `/api_boundary_nodes/<node_id>`, `/api_boundary_nodes/<node_id>/domain`. Can always be requested.
+- `/api_boundary_nodes`, `/api_boundary_nodes/<node_id>`, `/api_boundary_nodes/<node_id>/domain`, `/api_boundary_nodes/<node_id>/pub_key`, `/api_boundary_nodes/<node_id>/ip4_address`, `/api_boundary_nodes/<node_id>/ipv6_address`. Can always be requested.
 
 -   `/subnet`, `/subnet/<subnet_id>`, `/subnet/<subnet_id>/public_key`, `/subnet/<subnet_id>/canister_ranges`, `/subnet/<subnet_id>/metrics`, `/subnet/<subnet_id>/node`, `/subnet/<subnet_id>/node/<node_id>`, `/subnet/<subnet_id>/node/<node_id>/public_key`. Can always be requested.
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -435,7 +435,7 @@ This section specifies the publicly relevant paths in the tree.
 The state tree contains information about all API Boundary Nodes, which can communicate with the Internet Computer (replica nodes). The source of truth for these Api boundary node records is stored in the registry canister and can be added/modified/removed via proposals.
 - `api_boundary_nodes/<node_id>/domain` (text)
 
-    The domain name associated with a node, e.g., `api-bn1.dfinity.org`.
+    The domain name associated with a node, e.g., `api-bn1.example.com`.
 ### Subnet information {#state-tree-subnet}
 
 The state tree contains information about the topology of the Internet Computer.

--- a/spec/index.md
+++ b/spec/index.md
@@ -432,7 +432,7 @@ This section specifies the publicly relevant paths in the tree.
     All partial state trees include a timestamp, indicating the time at which the state is current.
 
 ### Api boundary bodes information {#state-tree-subnet}
-The state tree contains information about all API boundary nodes, which can communicate with the Internet Computer (replica nodes). The source of truth for these API boundary node records is stored in the registry canister and can be added/modified/removed via proposals.
+The state tree contains information about all API boundary nodes, which can communicate with the Internet Computer (replica nodes). The source of truth for these API boundary node records is stored in the registry canister.
 - `/api_boundary_nodes/<node_id>/domain` (text)
 - `/api_boundary_nodes/<node_id>/ipv4_address` (text)
   

--- a/spec/index.md
+++ b/spec/index.md
@@ -433,7 +433,7 @@ This section specifies the publicly relevant paths in the tree.
 
 ### Api boundary nodes information {#state-tree-api-bn}
 
-The state tree contains information about all API boundary nodes, which can communicate with the Internet Computer (its replica nodes). The source of truth for these API boundary node records is stored in the NNS registry canister.
+The state tree contains information about all API boundary nodes. The source of truth for these API boundary node records is stored in the NNS registry canister.
 
 - `/api_boundary_nodes/<node_id>/domain` (text)
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -705,7 +705,7 @@ canister developers that aim at keeping data confidential are advised to add a s
 All requested paths must have the following form:
 
 -   `/time`. Can always be requested.
-- `/api_boundary_nodes`, `/api_boundary_nodes/<node_id>`, `/api_boundary_nodes/<node_id>/domain`, `/api_boundary_nodes/<node_id>/pub_key`, `/api_boundary_nodes/<node_id>/ip4_address`, `/api_boundary_nodes/<node_id>/ipv6_address`. Can always be requested.
+- `/api_boundary_nodes`, `/api_boundary_nodes/<node_id>`, `/api_boundary_nodes/<node_id>/domain`, `/api_boundary_nodes/<node_id>/pub_key`, `/api_boundary_nodes/<node_id>/ipv4_address`, `/api_boundary_nodes/<node_id>/ipv6_address`. Can always be requested.
 
 -   `/subnet`, `/subnet/<subnet_id>`, `/subnet/<subnet_id>/public_key`, `/subnet/<subnet_id>/canister_ranges`, `/subnet/<subnet_id>/metrics`, `/subnet/<subnet_id>/node`, `/subnet/<subnet_id>/node/<node_id>`, `/subnet/<subnet_id>/node/<node_id>/public_key`. Can always be requested.
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -434,7 +434,6 @@ This section specifies the publicly relevant paths in the tree.
 ### Api boundary bodes information {#state-tree-subnet}
 The state tree contains information about all API boundary nodes, which can communicate with the Internet Computer (replica nodes). The source of truth for these API boundary node records is stored in the registry canister and can be added/modified/removed via proposals.
 - `/api_boundary_nodes/<node_id>/domain` (text)
-- `/api_boundary_nodes/<node_id>/public_key` (text)
 - `/api_boundary_nodes/<node_id>/ipv4_address` (text)
 - `/api_boundary_nodes/<node_id>/ipv6_address` (text)
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -439,6 +439,7 @@ The state tree contains information about all API boundary nodes, which can comm
 
     Domain name associated with a node. All domains are unique across nodes.
     Example: `api-bn1.example.com`.
+
 - `/api_boundary_nodes/<node_id>/ipv4_address` (text)
   
     Public IPv4 address of a node in the dotted-decimal notation.

--- a/spec/index.md
+++ b/spec/index.md
@@ -432,7 +432,7 @@ This section specifies the publicly relevant paths in the tree.
     All partial state trees include a timestamp, indicating the time at which the state is current.
 
 ### Api boundary bodes information {#state-tree-subnet}
-The state tree contains information about all API Boundary Nodes, which can communicate with the Internet Computer (replica nodes). The source of truth for these Api boundary node records is stored in the registry canister and can be added/modified/removed via proposals.
+The state tree contains information about all API boundary nodes, which can communicate with the Internet Computer (replica nodes). The source of truth for these API boundary node records is stored in the registry canister and can be added/modified/removed via proposals.
 - `api_boundary_nodes/<node_id>/domain` (text)
 
     The domain name associated with a node, e.g., `api-bn1.example.com`.

--- a/spec/index.md
+++ b/spec/index.md
@@ -431,17 +431,23 @@ This section specifies the publicly relevant paths in the tree.
 
     All partial state trees include a timestamp, indicating the time at which the state is current.
 
-### Api boundary bodes information {#state-tree-subnet}
+### Api boundary nodes information {#state-tree-subnet}
 
 The state tree contains information about all API boundary nodes, which can communicate with the Internet Computer (its replica nodes). The source of truth for these API boundary node records is stored in the NNS registry canister.
 
 - `/api_boundary_nodes/<node_id>/domain` (text)
+
+    Domain name associated with a node. All domains are unique across nodes.
+    Example: `api-bn1.example.com`.
 - `/api_boundary_nodes/<node_id>/ipv4_address` (text)
   
-    If the `ipv4_address` is empty, this path does not exist.
+    Public IPv4 address of a node in the dotted-decimal notation.
+    If the `ipv4_address` is empty, this path does not exist.  
+    Example: `192.168.10.150`.
 - `/api_boundary_nodes/<node_id>/ipv6_address` (text)
 
-    The domain name associated with a node, e.g., `api-bn1.example.com`.
+    Public IPv6 address of a node in the hexadecimal notation with colons.
+    Example: `3002:0bd6:0000:0000:0000:ee00:0033:6778`.
 ### Subnet information {#state-tree-subnet}
 
 The state tree contains information about the topology of the Internet Computer.

--- a/spec/index.md
+++ b/spec/index.md
@@ -433,7 +433,7 @@ This section specifies the publicly relevant paths in the tree.
 
 ### Api boundary nodes information {#state-tree-api-bn}
 
-The state tree contains information about all API boundary nodes. The source of truth for these API boundary node records is stored in the NNS registry canister.
+The state tree contains information about all API boundary nodes (the source of truth for these API boundary node records is stored in the NNS registry canister).
 
 - `/api_boundary_nodes/<node_id>/domain` (text)
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -431,6 +431,11 @@ This section specifies the publicly relevant paths in the tree.
 
     All partial state trees include a timestamp, indicating the time at which the state is current.
 
+### Api boundary bodes information {#state-tree-subnet}
+The state tree contains information about all API Boundary Nodes, which can communicate with the Internet Computer (replica nodes). The source of truth for these Api boundary node records is stored in the registry canister and can be added/modified/removed via proposals.
+- `api_boundary_nodes/<node_id>/domain` (text)
+
+    The domain name associated with a node, e.g., `api-bn1.dfinity.org`.
 ### Subnet information {#state-tree-subnet}
 
 The state tree contains information about the topology of the Internet Computer.
@@ -697,7 +702,7 @@ canister developers that aim at keeping data confidential are advised to add a s
 All requested paths must have the following form:
 
 -   `/time`. Can always be requested.
-
+- `/api_boundary_nodes`, `/api_boundary_nodes/<node_id>`, `/api_boundary_nodes/<node_id>/domain`. Can always be requested.
 -   `/subnet`, `/subnet/<subnet_id>`, `/subnet/<subnet_id>/public_key`, `/subnet/<subnet_id>/canister_ranges`, `/subnet/<subnet_id>/metrics`, `/subnet/<subnet_id>/node`, `/subnet/<subnet_id>/node/<node_id>`, `/subnet/<subnet_id>/node/<node_id>/public_key`. Can always be requested.
 
 -   `/request_status/<request_id>`, `/request_status/<request_id>/status`, `/request_status/<request_id>/reply`, `/request_status/<request_id>/reject_code`, `/request_status/<request_id>/reject_message`, `/request_status/<request_id>/error_code`. Can be requested if no path with such a prefix exists in the state tree or

--- a/spec/index.md
+++ b/spec/index.md
@@ -443,7 +443,7 @@ The state tree contains information about all API boundary nodes, which can comm
 - `/api_boundary_nodes/<node_id>/ipv4_address` (text)
   
     Public IPv4 address of a node in the dotted-decimal notation.
-    If the `ipv4_address` is empty, this path does not exist.  
+    If no `ipv4_address` is available for the corresponding node, then this path does not exist.  
     Example: `192.168.10.150`.
 
 - `/api_boundary_nodes/<node_id>/ipv6_address` (text)

--- a/spec/index.md
+++ b/spec/index.md
@@ -703,6 +703,7 @@ All requested paths must have the following form:
 
 -   `/time`. Can always be requested.
 - `/api_boundary_nodes`, `/api_boundary_nodes/<node_id>`, `/api_boundary_nodes/<node_id>/domain`. Can always be requested.
+
 -   `/subnet`, `/subnet/<subnet_id>`, `/subnet/<subnet_id>/public_key`, `/subnet/<subnet_id>/canister_ranges`, `/subnet/<subnet_id>/metrics`, `/subnet/<subnet_id>/node`, `/subnet/<subnet_id>/node/<node_id>`, `/subnet/<subnet_id>/node/<node_id>/public_key`. Can always be requested.
 
 -   `/request_status/<request_id>`, `/request_status/<request_id>/status`, `/request_status/<request_id>/reply`, `/request_status/<request_id>/reject_code`, `/request_status/<request_id>/reject_message`, `/request_status/<request_id>/error_code`. Can be requested if no path with such a prefix exists in the state tree or

--- a/spec/index.md
+++ b/spec/index.md
@@ -433,7 +433,7 @@ This section specifies the publicly relevant paths in the tree.
 
 ### Api boundary bodes information {#state-tree-subnet}
 The state tree contains information about all API boundary nodes, which can communicate with the Internet Computer (replica nodes). The source of truth for these API boundary node records is stored in the registry canister and can be added/modified/removed via proposals.
-- `api_boundary_nodes/<node_id>/domain` (text)
+- `/api_boundary_nodes/<node_id>/domain` (text)
 
     The domain name associated with a node, e.g., `api-bn1.example.com`.
 ### Subnet information {#state-tree-subnet}

--- a/spec/index.md
+++ b/spec/index.md
@@ -431,7 +431,7 @@ This section specifies the publicly relevant paths in the tree.
 
     All partial state trees include a timestamp, indicating the time at which the state is current.
 
-### Api boundary nodes information {#state-tree-subnet}
+### Api boundary nodes information {#state-tree-api-bn}
 
 The state tree contains information about all API boundary nodes, which can communicate with the Internet Computer (its replica nodes). The source of truth for these API boundary node records is stored in the NNS registry canister.
 


### PR DESCRIPTION
In the scope of the [IC-720: BN Decentralization Feature](https://forum.dfinity.org/t/boundary-node-roadmap/15562) we will need to be able to retrieve certified API boundary node domain names in a quick and easy way. The proposal is to modify the `State Tree` by introducing an `api_boundary_nodes` subtree (akin to [subnet-information](https://internetcomputer.org/docs/current/references/ic-interface-spec#state-tree-subnet)) holding all domain names, ipv4/ipv6 addresses.