### PR TITLE
feat: add root_subnet_id to HTTP status endpoint

### DIFF
--- a/spec/index.md
+++ b/spec/index.md
@@ -1034,6 +1034,8 @@ For this endpoint, the user performs a GET request, and receives a CBOR (see [CB
 
 -   `root_key` (blob, only in development instances): The public key (a DER-encoded BLS key) of the root key of this development instance of the Internet Computer Protocol. This *must* be present in short-lived development instances, to allow the agent to fetch the public key. For the Internet Computer, agents must have an independent trustworthy source for this data, and must not be tempted to fetch it from this insecure location.
 
+-   `root_subnet_id` (blob, optional): The subnet ID of the root subnet of this instance of the Internet Computer Protocol.
+
 See [CBOR encoding of requests and responses](#api-cbor) for details on the precise CBOR encoding of this object.
 
 :::note


### PR DESCRIPTION
This PR adds the `root_subnet_id` as an additional field returned by the HTTP `/api/v2/status` endpoint. This is useful to obtain the root subnet ID along with the root subnet's public key in development instances. However, we propose to not restrict the field to development instances only so that the IC mainnet does not deviate from test instances.