### PR TITLE
feat: drop impl_version from status endpoint spec

### DIFF
--- a/spec/index.md
+++ b/spec/index.md
@@ -1024,8 +1024,6 @@ Additionally, the Internet Computer provides an API endpoint to obtain various s
 
 For this endpoint, the user performs a GET request, and receives a CBOR (see [CBOR](#cbor)) value with the following fields. The IC may include additional implementation-specific fields.
 
--   `impl_version` (string, optional): The precise git revision of the Internet Computer Protocol implementation
-
 -   `root_key` (blob, optional): The public key (a DER-encoded BLS key) of the root key of this instance of the Internet Computer Protocol. This *must* be present in short-lived development instances, to allow the agent to fetch the public key. For the Internet Computer, agents must have an independent trustworthy source for this data, and must not be tempted to fetch it from this insecure location.
 
 See [CBOR encoding of requests and responses](#api-cbor) for details on the precise CBOR encoding of this object.


### PR DESCRIPTION
BNs do not serve the field `impl_version` in their response to `/api/v2/status` since subnets might have various `impl_version`s and it's not clear which one should be picked by a BN. So it makes sense to remove this field from the specification.