### PR TITLE
chore: always run PR cleanup job

### DIFF
--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -8,9 +8,6 @@ jobs:
     # do not run in forks
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-    concurrency:
-      group: ${{ github.ref }}
-      cancel-in-progress: true
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This PR removes the concurrency group for the PR cleanup job so that this job is not cancelled by the master preview deployment job.