### PR TITLE
feat: allow System API method in_replicated_execution to run during canister_start

### DIFF
--- a/spec/_attachments/interface-spec-changelog.md
+++ b/spec/_attachments/interface-spec-changelog.md
@@ -7,7 +7,7 @@
 * The IC sends a `user-agent` header with the value `ic/1.0` in canister HTTPS outcalls if the canister does not provide one.
 * Add a management canister method for retrieving node metrics.
 * Specify the resource reservation mechanism.
-* Allow `in_replicated_execution` system API method to be executed during `canister_start`
+* Allow `in_replicated_execution` system API method to be executed during `canister_start`.
 
 ### 0.22.0 (2023-11-15) {#0_22_0}
 * Add metrics on subnet usage into the certified state tree and a new HTTP endpoint `/api/v2/subnet/<subnet_id>/read_state` for retrieving them.

--- a/spec/_attachments/interface-spec-changelog.md
+++ b/spec/_attachments/interface-spec-changelog.md
@@ -7,6 +7,7 @@
 * The IC sends a `user-agent` header with the value `ic/1.0` in canister HTTPS outcalls if the canister does not provide one.
 * Add a management canister method for retrieving node metrics.
 * Specify the resource reservation mechanism.
+* Allow `in_replicated_execution` system API method to be executed during `canister_start`
 
 ### 0.22.0 (2023-11-15) {#0_22_0}
 * Add metrics on subnet usage into the certified state tree and a new HTTP endpoint `/api/v2/subnet/<subnet_id>/read_state` for retrieving them.

--- a/spec/index.md
+++ b/spec/index.md
@@ -6470,7 +6470,6 @@ The pseudo-code below does *not* explicitly enforce the restrictions of which im
         Trap {cycles_used = es.cycles_used;}
 
     ic0.in_replicated_execution<es>() : i32 =
-      if es.context = s then Trap {cycles_used = es.cycles_used;}
       if es.params.sysenv.certificate = NoCertificate
       then return 1
       else return 0

--- a/spec/index.md
+++ b/spec/index.md
@@ -1344,7 +1344,7 @@ The following sections describe various System API functions, also referred to a
     ic0.global_timer_set : (timestamp : i64) -> i64;                            // I G U Ry Rt C T
     ic0.performance_counter : (counter_type : i32) -> (counter : i64);          // * s
     ic0.is_controller: (src: i32, size: i32) -> ( result: i32);                 // * s
-    ic0.in_replicated_execution: () -> (result: i32);                           // * 
+    ic0.in_replicated_execution: () -> (result: i32);                           // * s
 
     ic0.debug_print : (src : i32, size : i32) -> ();                            // * s
     ic0.trap : (src : i32, size : i32) -> ();                                   // * s


### PR DESCRIPTION
This PR allows a system API method `in_replicated_execution` to be executed during `canister_start`.