### PR TITLE
feat(sync-call): [IC-1666] Endpoint for synchronous call requests

### DIFF
--- a/spec/_attachments/ic.did
+++ b/spec/_attachments/ic.did
@@ -177,8 +177,8 @@ service ic : {
       module_hash: opt blob;
       memory_size: nat;
       cycles: nat;
-      idle_cycles_burned_per_day: nat;
       reserved_cycles: nat;
+      idle_cycles_burned_per_day: nat;
   });
   canister_info : (record {
       canister_id : canister_id;

--- a/spec/_attachments/interface-spec-changelog.md
+++ b/spec/_attachments/interface-spec-changelog.md
@@ -2,6 +2,7 @@
 
 ### ∞ (unreleased)
 * EXPERIMENTAL: Management canister API to fetch Bitcoin block headers.
+* Synchronous update call API at `/api/v3/canister/.../call`.
 
 ### 0.26.0 (2024-07-23) {#0_26_0}
 * EXPERIMENTAL: Management canister API for threshold Schnorr signatures.

--- a/spec/index.md
+++ b/spec/index.md
@@ -643,7 +643,7 @@ When asking the IC about the state or call of a request, the user uses the reque
 
 #### Synchronous canister calling {#http-sync-call-overview}
 
-A synchronous update call, also known as a "call and await", is a type of update call where the replica will attempt to respond with a certificate of the state of the call to the HTTPS request. If the returned certificate indicates that the update call is in a terminal state (`replied`, `rejected`, or `done`), then the user __does not need to poll__ (using [`read_state`](#http-read-state) requests) to determine the result of the call. A terminal state means the call has completed its execution.
+A synchronous update call, also known as a "call and await", is a type of update call where the replica will attempt to respond to the HTTPS request with a certificate of the call status. If the returned certificate indicates that the update call is in a terminal state (`replied`, `rejected`, or `done`), then the user __does not need to poll__ (using [`read_state`](#http-read-state) requests) to determine the result of the call. A terminal state means the call has completed its execution.
 
 The synchronous call endpoint is useful for users as it removes the networking overhead of polling the IC to determine the status of their call.
 
@@ -671,17 +671,17 @@ In order to call a canister, the user makes a POST request to `/api/v3/canister/
 
 -   `arg` (`blob`): Argument to pass to the canister method.
 
-The HTTP response to this request can have the following responses:
+The HTTP response to this request can have the following forms:
 
--   200 HTTP status with a non-empty body. This status is returned if the replica received the message.
+-   200 HTTP status with a non-empty body. This status is returned if the replica successfully received the message.
     
-    -   A certificate for the state of the update call is produced, and returned as a CBOR (see [CBOR](#cbor)) map with the fields below. The user should use the certificate to determine the state of the call:
+    -   A certificate for the state of the update call is produced, and returned in a CBOR (see [CBOR](#cbor)) map with the fields specified below. The user should use the certificate to determine the state of the call:
 
         -   `status` (`text`): `"certified_state"`
 
-        -   `reply` (`blob`):  A certificate (see [Certification](#certification)) with subtrees at `/request_status/<request_id>` and `/time`. See [Request status](#state-tree-request-status) for more details on the request status.
+        -   `reply` (`blob`):  A certificate (see [Certification](#certification)) with subtrees at `/request_status/<request_id>` and `/time`, where `<request_id>` is the [request ID](#request-id) of the update call. See [Request status](#state-tree-request-status) for more details on the request status.
 
-    -   If a non-replicated pre-processing error occurred due to the [canister inspect message](#system-api-inspect-message), then a body with information about the IC specific error encountered is returned. The body is a CBOR map with the following fields:
+    -   If a non-replicated pre-processing error occurred (e.g., due to the [canister inspect message](#system-api-inspect-message)), then a body with information about the IC specific error encountered is returned. The body is a CBOR map with the following fields:
 
         -   `status` (`text`): `"canister_inspect_message_rejected"`
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -683,7 +683,7 @@ The HTTP response to this request can have the following forms:
 
     -   If a non-replicated pre-processing error occurred (e.g., due to the [canister inspect message](#system-api-inspect-message)), then a body with information about the IC specific error encountered is returned. The body is a CBOR map with the following fields:
 
-        -   `status` (`text`): `"canister_inspect_message_rejected"`
+        -   `status` (`text`): `"non_replicated_rejection"`
 
         -   `reject_code` (`nat`): The reject code (see [Reject codes](#reject-codes)).
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -623,7 +623,7 @@ When asking the IC about the state or call of a request, the user uses the reque
 
 #### Synchronous canister calling {#http-sync-call}
 
-Unlike asynchronous canister calling, synchronous canister calling does not require the user to poll the Internet Computer for the status of the request. Instead, the user waits for a certified response from the Internet Computer for the initial call. Still, the state transitions and semantics of the call itself are the same as for asynchronous canister calling.
+Unlike asynchronous canister calling, synchronous canister calling does not initially require the user to poll the Internet Computer for the status of the request. Instead, the user waits for a certified response from the Internet Computer for the initial call. However, if a certified response is not received (due to a timeout or pre-execution error), the user must poll the Internet Computer for the status. Still, the state transitions and semantics of the call itself are the same as for asynchronous canister calling.
 
 1.  A user submits a synchronous call via the [HTTPS Interface](#http-interface).
 
@@ -696,10 +696,12 @@ In order to make a synchronous update call to a canister, the user makes a POST 
 
 The HTTP response to this request can have the following responses:
 
--   202 HTTP status with a non-empty body. Implying the request was processed.
+-   201 HTTP status with a non-empty body. Implying the request was processed.
     -   `response` (`blob`): A certificate (see [Certification](#certification)).
 
     The returned certificate includes the subtree at `/request_status/<request_id>` and `/time`.
+
+-   202 HTTP status with empty body. Implying the request was accepted by the IC for further processing. Users should use [`read_state`](#http-read-state) to determine the status of the call.
 
 -   200 HTTP status with a non-empty body. Implying an execution pre-processing error occurred. The body of the response contains more information about the IC specific error encountered. The body is a CBOR map with the following fields:
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -623,11 +623,11 @@ When asking the IC about the state or call of a request, the user uses the reque
 
 #### Synchronous canister calling {#http-sync-call-overview}
 
-A synchronous update call, also known as a "call and await", is a type of update call where the replica will attempt to respond with a certificate to the HTTPS request. If the returned certificate indicates the that the update call is in a terminal state, `replied`, `rejected`, or `done`, then the user __does not need to poll__ (using [`read_state`](#http-read-state) requests) to determine the result of the call.
+A synchronous update call, also known as a "call and await", is a type of update call where the replica will attempt to respond with a certificate to the HTTPS request. If the returned certificate indicates that the update call is in a terminal state, `replied`, `rejected`, or `done`, then the user __does not need to poll__ (using [`read_state`](#http-read-state) requests) to determine the result of the call.
 
 The synchronous call endpoint is useful for users as it removes the networking overhead of polling the IC to determine the status of their call.
 
-The replica will keep the HTTPS connection for the request alive and respond once the state transitions to a terminal state. If a timeout for the request is reached while waiting for the terminal state to be reached,  then the replica will reply before the call completes, meaning a certificate with the state in in `unknown`, `received`, or `processing` is returned.
+The replica will maintain the HTTPS connection for the request and will respond once the state transitions to a terminal state. If a timeout for the request is reached while waiting for the terminal state to be reached,  then the replica will reply before the call completes, meaning a certificate with the state in `unknown`, `received`, or `processing` is returned.
 
 The user should take the following actions for the returned certificate states:
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -673,7 +673,7 @@ In order to call a canister, the user makes a POST request to `/api/v3/canister/
 
 The HTTP response to this request can have the following responses:
 
--   200 HTTP status with a non-empty body. This status is returned if the canister call completed or was rejected.
+-   200 HTTP status with a non-empty body. This status is returned if the canister call completed or was rejected within an implementation-specific timeout.
     
     -   If the update call completes, meaning the call state is in `reply`, `reject`, or `done`, then the response is a CBOR (see [CBOR](#cbor)) map with the following fields:
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -558,27 +558,9 @@ This document does not yet explain how to find the location and port of the Inte
 
 Users interact with the Internet Computer by calling canisters. By the very nature of a blockchain protocol, they cannot be acted upon immediately, but only with a delay. Moreover, the actual node that the user talks to may not be honest or, for other reasons, may fail to get the request on the way.
 
-The Internet Computer therefore has a two models for canister calling:
-- [*Synchronous*](#http-sync-call) canister calling, where the user waits for a certified response from the Internet Computer for the initial call.
+The Internet Computer has two HTTPS APIs for canister calling:
 - [*Asynchronous*](#http-async-call) canister calling, where the user must poll the Internet Computer for the status of the request.
-
-#### Synchronous canister calling {#http-sync-call}
-
-1.  A user submits a synchronous call via the [HTTPS Interface](#http-interface).
-
-2.  The IC asks the targeted canister if it is willing to accept this message and be charged for the expense of processing it. This uses the [Ingress message inspection](#system-api-inspect-message) API for normal calls. For calls to the management canister, the rules in [The IC management canister](#ic-management-canister) apply.
-
-3.  At some point, the IC may accept the call for processing and set its status to `received`. This indicates that the IC as a whole has received the call and plans on processing it (although it may still not get processed if the IC is under high load).
-
-4.  If the call is processed (sufficient resources, call not yet expired), it will be executed, for some calls this may be atomic, for others this involves multiple internal steps.
-
-5.  Eventually, a response will be produced which will be replied the user. The response can be a `reply`, indicating success, a `reject`, indicating some form of error.
-
-6.  In the case that the call has been retained for long enough before a response is generated, but the request has not expired yet, the IC can forget the response data and only remember the call as `done`, to prevent a replay attack.
-
-7. The user can also afterwards retrieve the state of the request via the [HTTPS Interface](#http-interface) for a certain amount of time.
-
-8.  Once the expiry time is past, the IC can prune the call and its response, and completely forget about it.
+- [*Synchronous*](#http-sync-call) canister calling, where the user waits for a certified response from the Internet Computer for the initial call.
 
 #### Asynchronous canister calling {#http-async-call}
 
@@ -638,6 +620,27 @@ To avoid replay attacks, the transition from `done` or `received` to `pruned` mu
 Calls must stay in `replied` or `rejected` long enough for polling users to catch the response.
 
 When asking the IC about the state or call of a request, the user uses the request id (see [Request ids](#request-id)) to read the request status (see [Request status](#state-tree-request-status)) from the state tree (see [Request: Read state](#http-read-state)).
+
+#### Synchronous canister calling {#http-sync-call}
+
+Unlike asynchronous canister calling, synchronous canister calling does not require the user to poll the Internet Computer for the status of the request. Instead, the user waits for a certified response from the Internet Computer for the initial call. However, The state transitions and semantics of the call are the same as for asynchronous canister calling.
+
+1.  A user submits a synchronous call via the [HTTPS Interface](#http-interface).
+
+2.  The IC asks the targeted canister if it is willing to accept this message and be charged for the expense of processing it. This uses the [Ingress message inspection](#system-api-inspect-message) API for normal calls. For calls to the management canister, the rules in [The IC management canister](#ic-management-canister) apply.
+
+3.  At some point, the IC may accept the call for processing and set its status to `received`. This indicates that the IC as a whole has received the call and plans on processing it (although it may still not get processed if the IC is under high load).
+
+4.  If the call is processed (sufficient resources, call not yet expired), it will be executed, for some calls this may be atomic, for others this involves multiple internal steps.
+
+5.  Eventually, a response will be produced which will be replied the user. The response can be a `reply`, indicating success, a `reject`, indicating some form of error.
+
+6.  In the case that the call has been retained for long enough before a response is generated, but the request has not expired yet, the IC can forget the response data and only remember the call as `done`, to prevent a replay attack.
+
+7. The user can also afterwards retrieve the state of the request via the [HTTPS Interface](#http-interface) for a certain amount of time.
+
+8.  Once the expiry time is past, the IC can prune the call and its response, and completely forget about it.
+
 
 ### Request: Call {#http-call}
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -623,13 +623,13 @@ When asking the IC about the state or call of a request, the user uses the reque
 
 #### Synchronous canister calling {#http-sync-call}
 
-Unlike asynchronous canister calling, synchronous canister calling does not require the user to poll the Internet Computer for the status of the request. Instead, the user waits for a certified response from the Internet Computer for the initial call. However, The state transitions and semantics of the call are the same as for asynchronous canister calling.
+Unlike asynchronous canister calling, synchronous canister calling does not require the user to poll the Internet Computer for the status of the request. Instead, the user waits for a certified response from the Internet Computer for the initial call. Still, the state transitions and semantics of the call itself are the same as for asynchronous canister calling.
 
 1.  A user submits a synchronous call via the [HTTPS Interface](#http-interface).
 
-2.  The IC asks the targeted canister if it is willing to accept this message and be charged for the expense of processing it. This uses the [Ingress message inspection](#system-api-inspect-message) API for normal calls. For calls to the management canister, the rules in [The IC management canister](#ic-management-canister) apply.
+2.  The IC asks the targeted canister if it is willing to accept this message and be charged for the expense of processing it. This uses the [Ingress message inspection](#system-api-inspect-message) API for calls to regular canisters. For calls to the management canister, the rules in [The IC management canister](#ic-management-canister) apply.
 
-3.  At some point, the IC may accept the call for processing and set its status to `received`. This indicates that the IC as a whole has received the call and plans on processing it (although it may still not get processed if the IC is under high load).
+3.  At some point, the IC may accept the call for processing and set its status to `received`. This indicates that the IC as a whole has received the call and plans on processing it (although the IC may still not start processing the request if it is under high load).
 
 4.  If the call is processed (sufficient resources, call not yet expired), it will be executed, for some calls this may be atomic, for others this involves multiple internal steps.
 
@@ -699,7 +699,7 @@ The HTTP response to this request can have the following responses:
 -   202 HTTP status with a non-empty body. Implying the request was processed.
     -   `response` (`blob`): A certificate (see [Certification](#certification)).
 
-The returned certificate includes the subtree at `/request_status/<request_id>` and `/time`.
+    The returned certificate includes the subtree at `/request_status/<request_id>` and `/time`.
 
 -   200 HTTP status with a non-empty body. Implying an execution pre-processing error occurred. The body of the response contains more information about the IC specific error encountered. The body is a CBOR map with the following fields:
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -693,7 +693,7 @@ The HTTP response to this request can have the following responses:
 
         -   `status` (`text`): `"replied"`
 
-        -   `reply` (`blob`):  A certificate (see [Certification](#certification)) with the subtree at `/request_status/<request_id>` and `/time`.
+        -   `reply` (`blob`):  A certificate (see [Certification](#certification)) with the subtree at `/request_status/<request_id>` and `/time`. See [Request status](#state-tree-request-status) for more details on the request status.
 
     -   If the update call resulted in a reject, the response is a CBOR map with the following fields:
 
@@ -710,8 +710,6 @@ The HTTP response to this request can have the following responses:
 -   5xx HTTP status when the server has encountered an error or is otherwise incapable of performing the request. The request might succeed if retried at a later time.
 
 This request type can *also* be used to call a query method (but not a composite query method). A user may choose to go this way, instead of via the faster and cheaper [Request: Query call](#http-query) below, if they want to get a *certified* response. Note that the canister state will not be changed by sending a call request type for a query method (except for cycle balance change due to message execution).
-
-See [Request status](#state-tree-request-status) for details on the request status.
 
 ### Request: Read state {#http-read-state}
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -625,7 +625,7 @@ When asking the IC about the state or call of a request, the user uses the reque
 
 A synchronous update call, also known as a "call and await", is a type of update call where the replica will respond with a certificate if the call completes within one execution round.
 
-The purpose of the synchronous call endpoint is to allow the user to get a certificate with response from the IC. This means that if a certificate is returned, the user __does not need to poll__ (using [`read_state`](#http-read-state) requests) to determine the result of the call.
+The purpose of the synchronous call endpoint is to give the user a certified response for their canister call. This means that if a certificate is returned, then the user __does not need to poll__ (using [`read_state`](#http-read-state) requests) to determine the result of the call.
 
 A certificate is returned by the IC to the user if:
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -559,7 +559,7 @@ This document does not yet explain how to find the location and port of the Inte
 Users interact with the Internet Computer by calling canisters. By the very nature of a blockchain protocol, they cannot be acted upon immediately, but only with a delay. Moreover, the actual node that the user talks to may not be honest or, for other reasons, may fail to get the request on the way.
 
 The Internet Computer therefore has a two models for canister calling:
--  [*Synchronous*](#http-sync-call) canister calling, where the user waits for a certified response from the Internet Computer.
+- [*Synchronous*](#http-sync-call) canister calling, where the user waits for a certified response from the Internet Computer for the initial call.
 - [*Asynchronous*](#http-async-call) canister calling, where the user must poll the Internet Computer for the status of the request.
 
 #### Synchronous canister calling {#http-sync-call}

--- a/spec/index.md
+++ b/spec/index.md
@@ -627,7 +627,7 @@ A synchronous update call, also known as a "call and await", is a type of update
 
 The synchronous call endpoint is useful for users as it removes the networking overhead of polling the IC to determine the status of their call.
 
-The replica will maintain the HTTPS connection for the request and will respond once the state transitions to a terminal state. If a timeout for the request is reached while waiting for the terminal state, then the replica will reply before the call completes, meaning a certificate with the state in `unknown`, `received`, or `processing` is returned.
+The replica will maintain the HTTPS connection for the request and will respond once the state transitions to a terminal state. If an implementation specific timeout for the request is reached while the replica waits for the terminal state, then the replica will reply before the call completes, meaning a certificate for the call state in `unknown`, `received`, or `processing` is returned.
 
 The user should take the following actions for the returned certificate states:
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -691,6 +691,7 @@ In order to make a synchronous update call to a canister, the user makes a POST 
 The HTTP response to this request can have the following responses:
 
 -   201 HTTP status with a non-empty body. Implying the request was processed.
+
     -   `response` (`blob`): A certificate (see [Certification](#certification)).
 
     The returned certificate includes the subtree at `/request_status/<request_id>` and `/time`.
@@ -717,7 +718,7 @@ The functionality exposed via the [The IC management canister](#ic-management-ca
 
 :::
 
-See [The system state tree](#state-tree) for details on the state tree.
+See [Request status](#state-tree-request-status) for details on the request status.
 
 
 ### Request: Read state {#http-read-state}

--- a/spec/index.md
+++ b/spec/index.md
@@ -227,7 +227,7 @@ Dapps on the Internet Computer are called *canisters*. Conceptually, they consis
 
 -   A cycle balance
 
--   A reserved cycle balance, which are cycles set aside from the main cycle balance for resource payments.
+-   A reserved cycles balance, which are cycles set aside from the main cycle balance for resource payments.
 
 -   The *canister status*, which is one of `running`, `stopping` or `stopped`.
 
@@ -249,7 +249,7 @@ If an empty canister receives a response, that response is dropped, as if the ca
 
 The IC relies on *cycles*, a utility token, to manage its resources. A canister pays for the resources it uses from its *cycle balances*. A *cycle\_balance* is stored as 128-bit unsigned integers and operations on them are saturating. In particular, if *cycles* are added to a canister that would bring its main cycle balance beyond 2<sup>128</sup>-1, then the balance will be capped at 2<sup>128</sup>-1 and any additional cycles will be lost.
 
-When both the main and the reserved cycle balances of a canister fall to zero, the canister is *deallocated*. This has the same effect as
+When both the main and the reserved cycles balances of a canister fall to zero, the canister is *deallocated*. This has the same effect as
 
 -   uninstalling the canister (as described in [IC method](#ic-uninstall_code))
 
@@ -2045,13 +2045,25 @@ Indicates various information about the canister. It contains:
 
 -   The status of the canister. It could be one of `running`, `stopping` or `stopped`.
 
+-   The "settings" of the canister containing:
+
+    -   The controllers of the canister. The order of returned controllers may vary depending on the implementation.
+
+    -   The compute and memory allocation of the canister.
+
+    -   The freezing threshold of the canister in seconds.
+
+    -   The reserved cycles limit of the canister, i.e., the maximum number of cycles that can be in the canister's reserved balance after increasing the canister's memory allocation and/or actual memory usage.
+
 -   A SHA256 hash of the module installed on the canister. This is `null` if the canister is empty.
 
--   The controllers of the canister. The order of returned controllers may vary depending on the implementation.
-
--   The memory size taken by the canister.
+-   The actual memory usage of the canister.
 
 -   The cycle balance of the canister.
+
+-   The reserved cycles balance of the canister, i.e., the number of cycles reserved when increasing the canister's memory allocation and/or actual memory usage.
+
+-   The idle cycle consumption of the canister, i.e., the number of cycles burned by the canister per day due to its compute and memory allocation and actual memory usage.
 
 Only the controllers of the canister or the canister itself can request its status.
 
@@ -3975,9 +3987,9 @@ S with
 
 #### IC Management Canister: Canister status
 
-The controllers of a canister can obtain information about the canister.
+The controllers of a canister can obtain detailed information about the canister.
 
-The `Memory_size` is the (in this specification underspecified) total size of storage in bytes.
+The `Memory_usage` is the (in this specification underspecified) total size of storage in bytes.
 
 The `idle_cycles_burned_per_day` is the idle consumption of resources in cycles per day.
 
@@ -4004,15 +4016,20 @@ S with
         origin = M.origin
         response = candid({
           status = simple_status(S.canister_status[A.canister_id]);
+          settings = {
+            controllers = S.controllers[A.canister_id];
+            compute_allocation = S.compute_allocation[A.canister_id];
+            memory_allocation = S.memory_allocation[A.canister_id];
+            freezing_threshold = S.freezing_threshold[A.canister_id];
+            reserved_cycles_limit = S.reserved_balance_limit[A.canister_id];
+          }
           module_hash =
             if S.canisters[A.canister_id] = EmptyCanister
             then null
             else opt (SHA-256(S.canisters[A.canister_id].raw_module));
-          controllers = S.controllers[A.canister_id];
-          memory_size = Memory_size;
+          memory_size = Memory_usage;
           cycles = S.balances[A.canister_id];
           reserved_cycles = S.reserved_balances[A.canister_id]
-          freezing_threshold = S.freezing_threshold[A.canister_id];
           idle_cycles_burned_per_day = idle_cycles_burned_rate(
             S.compute_allocation[A.canister_id],
             S.memory_allocation[A.canister_id],

--- a/spec/index.md
+++ b/spec/index.md
@@ -652,10 +652,11 @@ The functionality exposed via the [The IC management canister](#ic-management-ca
 :::
 
 ### Request: Sync Call {#http-sync-call}
+Synchronous update calls, or `call and await`, are a form of update calls (See [Call]{#http-call}) where the replica will wait with replying to the user until the call
+has been processed by execution. This means the user will receive the result the call and *do not* need to poll [`read_state`](#http-read-state) to determine the status of the call.
+In order to make a synchronous update call to a canister, the user makes a POST request to `/api/v2/canister/<effective_canister_id>/sync_call`. The request body consists of an authentication envelope with a `content` map with the following fields:
 
-In order to call a canister, the user makes a POST request to `/api/v2/canister/<effective_canister_id>/sync_call`. The request body consists of an authentication envelope with a `content` map with the following fields:
-
--   `request_type` (`text`): Always `call`
+-   `request_type` (`text`): Always `sync-call`
 
 -   `sender`, `nonce`, `ingress_expiry`: See [Authentication](#authentication)
 
@@ -668,7 +669,9 @@ In order to call a canister, the user makes a POST request to `/api/v2/canister/
 The HTTP response to this request can have the following responses:
 
 -   202 HTTP status with a non-empty body. Implying the request was accepted by the IC for further processing.
-    -   `reject code`
+    -   `certificate` (`blob`): A certificate (see [Certification](#certification)).
+
+The returned certificate includes the subtree at `/request_status/<request_id>` and `/time`.
 
 -   200 HTTP status with a non-empty body. Implying an execution pre-processing error occurred. The body of the response contains more information about the IC specific error encountered. The body is a CBOR map with the following fields:
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -623,11 +623,11 @@ When asking the IC about the state or call of a request, the user uses the reque
 
 #### Synchronous canister calling {#http-sync-call-overview}
 
-A synchronous update call, also known as a "call and await", is a type of update call where the replica will respond with a certificate if the call completes within a timeout.
+A synchronous update call, also known as a "call and await", is a type of update call where the replica will respond with a certificate if the call completes. The purpose of the synchronous call endpoint is to give the user a certified response for their canister call.
 
-The purpose of the synchronous call endpoint is to give the user a certified response for their canister call. This means that if a certificate is returned with the status of the update call in a terminal state, i.e. `replied`, `rejected`, or `done`, then the user __does not need to poll__ (using [`read_state`](#http-read-state) requests) to determine the result of the call.
+If the returned certificate for the status of the update call is in a terminal state, i.e. `replied`, `rejected`, or `done`, then the user __does not need to poll__ (using [`read_state`](#http-read-state) requests) to determine the result of the call.
 
-Replicas will reply back to users' submitted update calls with a certificate of the state of the call. A replica will keep the HTTPS connection for the request alive and respond once the state transitions to `replied`, `rejected`, or `done`. If a timeout for the request is reached,  then the replica will reply before the call completes, meaning a certificate with the state in in `unknown`, `received`, or `processing` is returned. In such cases, the user should poll the IC to determine the terminal state of the update call.
+A replica will keep the HTTPS connection for the request alive and respond once the state transitions to a terminal state. If a timeout for the request is reached while waiting for the terminal state to be reached,  then the replica will reply before the call completes, meaning a certificate with the state in in `unknown`, `received`, or `processing` is returned. In such cases, the user should poll the IC to determine the terminal state of the update call.
 
 The synchronous call endpoint is useful for users as it removes the networking overhead of polling the IC to determine the status of their call.
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -673,17 +673,17 @@ In order to call a canister, the user makes a POST request to `/api/v3/canister/
 
 The HTTP response to this request can have the following responses:
 
--   200 HTTP status with a non-empty body. The response contains the canister response, which is either a `reply` or a `reject`.
+-   200 HTTP status with a non-empty body. This status is returned if the canister call completed or was rejected.
     
-    -   If the update call completes, then the response is a CBOR (see [CBOR](#cbor)) map with the following fields:
+    -   If the update call completes, meaning the call state is in `reply`, `reject`, or `done`, then the response is a CBOR (see [CBOR](#cbor)) map with the following fields:
 
         -   `status` (`text`): `"certified_state"`
 
         -   `reply` (`blob`):  A certificate (see [Certification](#certification)) with subtrees at `/request_status/<request_id>` and `/time`. See [Request status](#state-tree-request-status) for more details on the request status.
 
-    -   If the update call resulted in a non-replicated reject, the response is a CBOR map with the following fields:
+    -   If a non-replicated pre-processing error occurred due to [canister inspect message](#system-api-inspect-message), then the body of the response contains information about the IC specific error encountered. The body is a CBOR map with the following fields:
 
-        -   `status` (`text`): `"non_replicated_rejection"`
+        -   `status` (`text`): `"canister_inspect_message_rejected"`
 
         -   `reject_code` (`nat`): The reject code (see [Reject codes](#reject-codes)).
 
@@ -691,7 +691,7 @@ The HTTP response to this request can have the following responses:
 
         -   `error_code` (`text`): an optional implementation-specific textual error code (see [Error codes](#error-codes)).
 
--   202 HTTP status with non-empty body. This status is returned if the replica times out while waiting for the canister call to complete. Users should poll [`read_state`](#http-read-state) for the result of the call. The response is a CBOR (see [CBOR](#cbor)) map with the following fields.
+-   202 HTTP status with non-empty body. This status is returned if the replica times out while waiting for the canister call to complete. The returned call state will be in `unknown`, `received`, or `done`. Users should poll [`read_state`](#http-read-state) for the result of the call. The response is a CBOR (see [CBOR](#cbor)) map with the following fields.
 
     -   `status` (`text`): `"certified_state"`
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -673,9 +673,9 @@ In order to call a canister, the user makes a POST request to `/api/v3/canister/
 
 The HTTP response to this request can have the following responses:
 
--   200 HTTP status with a non-empty body. This status is returned if the canister call completed or was rejected within an implementation-specific timeout.
+-   200 HTTP status with a non-empty body. This status is returned if the replica received the message.
     
-    -   If the update call completed, meaning the call state in `replied`, `rejected`, or `done`, then the response is a CBOR (see [CBOR](#cbor)) map with the following fields:
+    -   A certificate for the state of the update call is produced, and returned as a CBOR (see [CBOR](#cbor)) map with the following fields:
 
         -   `status` (`text`): `"certified_state"`
 
@@ -690,12 +690,6 @@ The HTTP response to this request can have the following responses:
         -   `reject_message` (`text`): a textual diagnostic message.
 
         -   `error_code` (`text`): an optional implementation-specific textual error code (see [Error codes](#error-codes)).
-
--   202 HTTP status with non-empty body. This status is returned if an implementation-specific timeout is reached before the canister call completes. The returned call state will be in `unknown`, `received`, or `processing`. Users should poll [`read_state`](#http-read-state) for the result of the call. The response is a CBOR (see [CBOR](#cbor)) map with the following fields.
-
-    -   `status` (`text`): `"certified_state"`
-
-    -   `reply` (`blob`): A certificate (see [Certification](#certification)) with subtrees at `/request_status/<request_id>` and `/time`. See [Request status](#state-tree-request-status) for more details on the request status.
 
 -   4xx HTTP status for client errors (e.g. malformed request). Except for 429 HTTP status, retrying the request will likely have the same outcome.
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -651,6 +651,48 @@ The functionality exposed via the [The IC management canister](#ic-management-ca
 
 :::
 
+### Request: Sync Call {#http-sync-call}
+
+In order to call a canister, the user makes a POST request to `/api/v2/canister/<effective_canister_id>/sync_call`. The request body consists of an authentication envelope with a `content` map with the following fields:
+
+-   `request_type` (`text`): Always `call`
+
+-   `sender`, `nonce`, `ingress_expiry`: See [Authentication](#authentication)
+
+-   `canister_id` (`blob`): The principal of the canister to call.
+
+-   `method_name` (`text`): Name of the canister method to call
+
+-   `arg` (`blob`): Argument to pass to the canister method
+
+The HTTP response to this request can have the following responses:
+
+-   202 HTTP status with a non-empty body. Implying the request was accepted by the IC for further processing.
+    -   `reject code`
+
+-   200 HTTP status with a non-empty body. Implying an execution pre-processing error occurred. The body of the response contains more information about the IC specific error encountered. The body is a CBOR map with the following fields:
+
+    -   `reject_code` (`nat`): The reject code (see [Reject codes](#reject-codes)).
+
+    -   `reject_message` (`text`): a textual diagnostic message.
+
+    -   `error_code` (`text`): an optional implementation-specific textual error code (see [Error codes](#error-codes)).
+
+-   4xx HTTP status for client errors (e.g. malformed request). Except for 429 HTTP status, retrying the request will likely have the same outcome.
+
+-   5xx HTTP status when the server has encountered an error or is otherwise incapable of performing the request. The request might succeed if retried at a later time.
+
+This request type can *also* be used to call a query method (but not a composite query method). A user may choose to go this way, instead of via the faster and cheaper [Request: Query call](#http-query) below, if they want to get a *certified* response. Note that the canister state will not be changed by sending a call request type for a query method (except for cycle balance change due to message execution).
+
+:::note
+
+The functionality exposed via the [The IC management canister](#ic-management-canister) can be used this way.
+
+:::
+
+See [The system state tree](#state-tree) for details on the state tree.
+
+
 ### Request: Read state {#http-read-state}
 
 :::note

--- a/spec/index.md
+++ b/spec/index.md
@@ -623,13 +623,19 @@ When asking the IC about the state or call of a request, the user uses the reque
 
 #### Synchronous canister calling {#http-sync-call-overview}
 
-A synchronous update call, also known as a "call and await", is a type of update call where the replica will respond with a certificate if the call completes. The purpose of the synchronous call endpoint is to give the user a certified response for their canister call.
-
-If the returned certificate for the status of the update call is in a terminal state, i.e. `replied`, `rejected`, or `done`, then the user __does not need to poll__ (using [`read_state`](#http-read-state) requests) to determine the result of the call.
-
-A replica will keep the HTTPS connection for the request alive and respond once the state transitions to a terminal state. If a timeout for the request is reached while waiting for the terminal state to be reached,  then the replica will reply before the call completes, meaning a certificate with the state in in `unknown`, `received`, or `processing` is returned. In such cases, the user should poll the IC to determine the terminal state of the update call.
+A synchronous update call, also known as a "call and await", is a type of update call where the replica will attempt to respond with a certificate to the HTTPS request. If the returned certificate indicates the that the update call is in a terminal state, `replied`, `rejected`, or `done`, then the user __does not need to poll__ (using [`read_state`](#http-read-state) requests) to determine the result of the call.
 
 The synchronous call endpoint is useful for users as it removes the networking overhead of polling the IC to determine the status of their call.
+
+The replica will keep the HTTPS connection for the request alive and respond once the state transitions to a terminal state. If a timeout for the request is reached while waiting for the terminal state to be reached,  then the replica will reply before the call completes, meaning a certificate with the state in in `unknown`, `received`, or `processing` is returned.
+
+The user should take the following actions for the returned certificate states:
+
+-    `processing`: The call is being executed. The user should poll the IC using [`read_state`](#http-read-state) requests to determine the result of the call.
+
+-    `received`: The call has been received by the IC. The user should poll the IC using [`read_state`](#http-read-state) requests to determine the result of the call.
+
+-    `unknown`: The user can conclude that the message was not received by the IC at the attached timestamp. The user can retry the call, or poll the IC using [`read_state`](#http-read-state) requests to determine the result of the call.
 
 ### Request: Call {#http-call}
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -709,7 +709,6 @@ This request type can *also* be used to call a query method (but not a composite
 
 See [Request status](#state-tree-request-status) for details on the request status.
 
-
 ### Request: Read state {#http-read-state}
 
 :::note

--- a/spec/index.md
+++ b/spec/index.md
@@ -647,7 +647,7 @@ A synchronous update call, also known as a "call and await", is a type of update
 
 The synchronous call endpoint is useful for users as it removes the networking overhead of polling the IC to determine the status of their call.
 
-The replica will maintain the HTTPS connection for the request and will respond once the state transitions to a terminal state. If an implementation specific timeout for the request is reached while the replica waits for the terminal state, then the replica will reply before the call completes, meaning a certificate for the call state in `unknown`, `received`, or `processing` is returned.
+The replica will maintain the HTTPS connection for the request and will respond once the call status transitions to a terminal state. If an implementation specific timeout for the request is reached while the replica waits for the terminal state, then the replica will reply before the call completes, meaning a certificate for the call state in `unknown`, `received`, or `processing` is returned.
 
 The user should take the following actions for the returned certificate states:
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -673,7 +673,7 @@ In order to call a canister, the user makes a POST request to `/api/v3/canister/
 
 The HTTP response to this request can have the following forms:
 
--   200 HTTP status with a non-empty body. This status is returned if the canister call completed or was rejected within an implementation-specific timeout.
+-   200 HTTP status with a non-empty body. This status is returned if the canister call completed within an implementation-specific timeout or was rejected within an implementation-specific timeout.
     
     -   If the update call completed, a certificate for the state of the update call is produced, and returned in a CBOR (see [CBOR](#cbor)) map with the fields specified below:
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -681,7 +681,7 @@ The HTTP response to this request can have the following responses:
 
 -   5xx HTTP status when the server has encountered an error or is otherwise incapable of performing the request. The request might succeed if retried at a later time.
 
-This request type can *also* be used to call a query method (but not a composite query method). A user may choose to go this way, instead of via the faster and cheaper [Request: Query call](#http-query) below, if they want to get a *certified* response. Note that the canister state will not be changed by sending an update call request type for a query method (except for cycle balance change due to message execution).
+This request type can *also* be used to call a query method (but not a composite query method). A user may choose to go this way, instead of via the faster and cheaper [Request: Query call](#http-query) below, if they want to get a *certified* response. Note that the canister state will not be changed by sending a call request type for a query method (except for cycle balance change due to message execution).
 
 ### Request: Asynchronous Call {#http-async-call}
 
@@ -702,8 +702,6 @@ The HTTP response to this request can have the following responses:
 -   202 HTTP status with empty body. Implying the request was accepted by the IC for further processing. Users should use [`read_state`](#http-read-state) to determine the status of the call.
 
 -   200 HTTP status with non-empty body. Implying an execution pre-processing error occurred. The body of the response contains more information about the IC specific error encountered. The body is a CBOR map with the following fields:
-    
-    -   `status` (`text`): `"non_replicated_rejection"`
 
     -   `reject_code` (`nat`): The reject code (see [Reject codes](#reject-codes)).
 
@@ -715,7 +713,7 @@ The HTTP response to this request can have the following responses:
 
 -   5xx HTTP status when the server has encountered an error or is otherwise incapable of performing the request. The request might succeed if retried at a later time.
 
-This request type can *also* be used to call a query method (but not a composite query method). A user may choose to go this way, instead of via the faster and cheaper [Request: Query call](#http-query) below, if they want to get a *certified* response. Note that the canister state will not be changed by sending an update call request type for a query method (except for cycle balance change due to message execution).
+This request type can *also* be used to call a query method (but not a composite query method). A user may choose to go this way, instead of via the faster and cheaper [Request: Query call](#http-query) below, if they want to get a *certified* response. Note that the canister state will not be changed by sending a call request type for a query method (except for cycle balance change due to message execution).
 
 :::note
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -652,7 +652,7 @@ The functionality exposed via the [The IC management canister](#ic-management-ca
 :::
 
 ### Request: Sync Call {#http-sync-call}
-Synchronous update calls, or `call and await`, are a form of update calls (See [Call]{#http-call}) where the replica will wait with replying to the user until the call has been processed by execution. This means the user will receive a certified result of the call, and thus *do not* need to poll [`read_state`](#http-read-state) to determine the status of the call.
+A synchronous update call, or "call and await", is a type of update [call](#http-call) where the replica will wait with replying to the user until the call has been processed and the result has been added to the replicated state. This means the user will receive a certified result of the call, and thus __do not need to poll__ [`read_state`](#http-read-state) to determine the status of the call.
 In order to make a synchronous update call to a canister, the user makes a POST request to `/api/v2/canister/<effective_canister_id>/sync_call`. The request body consists of an authentication envelope with a `content` map with the following fields:
 
 -   `request_type` (`text`): Always `sync-call`

--- a/spec/index.md
+++ b/spec/index.md
@@ -691,7 +691,7 @@ The HTTP response to this request can have the following responses:
 
         -   `error_code` (`text`): an optional implementation-specific textual error code (see [Error codes](#error-codes)).
 
--   202 HTTP status with non-empty body. This status is returned if an implementation-specific timeout is reached before the canister call completes. The returned call state will be in `unknown`, `received`, or `done`. Users should poll [`read_state`](#http-read-state) for the result of the call. The response is a CBOR (see [CBOR](#cbor)) map with the following fields.
+-   202 HTTP status with non-empty body. This status is returned if an implementation-specific timeout is reached before the canister call completes. The returned call state will be in `unknown`, `received`, or `processing`. Users should poll [`read_state`](#http-read-state) for the result of the call. The response is a CBOR (see [CBOR](#cbor)) map with the following fields.
 
     -   `status` (`text`): `"certified_state"`
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -675,7 +675,7 @@ The HTTP response to this request can have the following responses:
 
 -   200 HTTP status with a non-empty body. This status is returned if the replica received the message.
     
-    -   A certificate for the state of the update call is produced, and returned as a CBOR (see [CBOR](#cbor)) map with the following fields:
+    -   A certificate for the state of the update call is produced, and returned as a CBOR (see [CBOR](#cbor)) map with the fields below. The user should use the certificate to determine the state of the call:
 
         -   `status` (`text`): `"certified_state"`
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -559,8 +559,8 @@ This document does not yet explain how to find the location and port of the Inte
 Users interact with the Internet Computer by calling canisters. By the very nature of a blockchain protocol, they cannot be acted upon immediately, but only with a delay. Moreover, the actual node that the user talks to may not be honest or, for other reasons, may fail to get the request on the way.
 
 The Internet Computer has two HTTPS APIs for canister calling:
-- [*Asynchronous*](#http-async-call) canister calling, where the user must poll the Internet Computer for the status of the request.
-- [*Synchronous*](#http-sync-call) canister calling, where the user waits for a certified response from the Internet Computer for the initial call.
+- [*Asynchronous*](#http-async-call) canister calling, where the user must poll the Internet Computer for the status of the canister call by _separate_ HTTPS requests.
+- [*Synchronous*](#http-sync-call) canister calling, where the Internet Computer serves the response of the canister call as the response to the original HTTPS request.
 
 #### Asynchronous canister calling {#http-async-call}
 
@@ -631,9 +631,9 @@ Unlike asynchronous canister calling, synchronous canister calling does not init
 
 3.  At some point, the IC may accept the call for processing and set its status to `received`. This indicates that the IC as a whole has received the call and plans on processing it (although the IC may still not start processing the request if it is under high load).
 
-4.  If the call is processed (sufficient resources, call not yet expired), it will be executed, for some calls this may be atomic, for others this involves multiple internal steps.
+4.  If the call is processed (sufficient resources, call not yet expired), it will be executed. For some calls this may be atomic, for others this involves multiple internal steps.
 
-5.  Eventually, a response will be produced which will be replied the user. The response can be a `reply`, indicating success, a `reject`, indicating some form of error.
+5.  Eventually, a response will be produced and returned to the user. The response can be a `reply`, indicating success, or a `reject`, indicating some form of error.
 
 6.  In the case that the call has been retained for long enough before a response is generated, but the request has not expired yet, the IC can forget the response data and only remember the call as `done`, to prevent a replay attack.
 
@@ -675,7 +675,7 @@ The HTTP response to this request can have the following responses:
 This request type can *also* be used to call a query method (but not a composite query method). A user may choose to go this way, instead of via the faster and cheaper [Request: Query call](#http-query) below, if they want to get a *certified* response. Note that the canister state will not be changed by sending a call request type for a query method (except for cycle balance change due to message execution).
 
 ### Request: Sync Call {#http-sync-call}
-A synchronous update call, or "call and await", is a type of update [call](#http-call) where the replica will wait with replying to the user until the call has been processed and the result has been added to the replicated state. This means the user will receive a certified result of the call, and thus __do not need to poll__ [`read_state`](#http-read-state) to determine the status of the call.
+A synchronous update call, or "call and await", is a type of update [call](#http-call) where the replica will wait with replying to the user until the call has been processed and the result has been added to the certified state. This means the user will receive a certified result of the call, and thus __does not need to poll__ (using [`read_state`](#http-read-state) requests) to determine the status of the call.
 In order to make a synchronous update call to a canister, the user makes a POST request to `/api/v2/canister/<effective_canister_id>/sync_call`. The request body consists of an authentication envelope with a `content` map with the following fields:
 
 -   `request_type` (`text`): Always `sync-call`

--- a/spec/index.md
+++ b/spec/index.md
@@ -651,11 +651,11 @@ The replica will maintain the HTTPS connection for the request and will respond 
 
 The user should take the following actions for the returned certificate states:
 
--    `processing`: The call is being executed. The user should poll the IC using [`read_state`](#http-read-state) requests to determine the result of the call.
+-    `processing`: The call is being executed by the IC. The user should poll the IC using [`read_state`](#http-read-state) requests to determine the result of the call.
 
 -    `received`: The call has been received by the IC. The user should poll the IC using [`read_state`](#http-read-state) requests to determine the result of the call.
 
--    `unknown`: The user can conclude that the message was not received by the IC at the attached timestamp. The user can retry the call, or poll the IC using [`read_state`](#http-read-state) requests to determine the result of the call.
+-    `unknown`: The user can conclude that the message was not received by the IC at the attached timestamp. The user can retry the call, or poll the IC using [`read_state`](#http-read-state) requests.
 
 ### Request: Call {#http-call}
 
@@ -675,13 +675,13 @@ The HTTP response to this request can have the following responses:
 
 -   200 HTTP status with a non-empty body. This status is returned if the canister call completed or was rejected within an implementation-specific timeout.
     
-    -   If the update call completes, meaning the call state is in `replied`, `rejected`, or `done`, then the response is a CBOR (see [CBOR](#cbor)) map with the following fields:
+    -   If the update call completed, meaning the call state in `replied`, `rejected`, or `done`, then the response is a CBOR (see [CBOR](#cbor)) map with the following fields:
 
         -   `status` (`text`): `"certified_state"`
 
         -   `reply` (`blob`):  A certificate (see [Certification](#certification)) with subtrees at `/request_status/<request_id>` and `/time`. See [Request status](#state-tree-request-status) for more details on the request status.
 
-    -   If a non-replicated pre-processing error occurred due to [canister inspect message](#system-api-inspect-message), then the body of the response contains information about the IC specific error encountered. The body is a CBOR map with the following fields:
+    -   If a non-replicated pre-processing error occurred due to the [canister inspect message](#system-api-inspect-message), then a body with information about the IC specific error encountered is returned. The body is a CBOR map with the following fields:
 
         -   `status` (`text`): `"canister_inspect_message_rejected"`
 
@@ -691,7 +691,7 @@ The HTTP response to this request can have the following responses:
 
         -   `error_code` (`text`): an optional implementation-specific textual error code (see [Error codes](#error-codes)).
 
--   202 HTTP status with non-empty body. This status is returned if the replica times out while waiting for the canister call to complete. The returned call state will be in `unknown`, `received`, or `done`. Users should poll [`read_state`](#http-read-state) for the result of the call. The response is a CBOR (see [CBOR](#cbor)) map with the following fields.
+-   202 HTTP status with non-empty body. This status is returned if an implementation-specific timeout is reached before the canister call completes. The returned call state will be in `unknown`, `received`, or `done`. Users should poll [`read_state`](#http-read-state) for the result of the call. The response is a CBOR (see [CBOR](#cbor)) map with the following fields.
 
     -   `status` (`text`): `"certified_state"`
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -643,7 +643,7 @@ When asking the IC about the state or call of a request, the user uses the reque
 
 #### Synchronous canister calling {#http-sync-call-overview}
 
-A synchronous update call, also known as a "call and await", is a type of update call where the replica will attempt to respond with a certificate to the HTTPS request. If the returned certificate indicates that the update call is in a terminal state (`replied`, `rejected`, or `done`), then the user __does not need to poll__ (using [`read_state`](#http-read-state) requests) to determine the result of the call. A terminal state means the call has completed its execution.
+A synchronous update call, also known as a "call and await", is a type of update call where the replica will attempt to respond with a certificate of the state of the call to the HTTPS request. If the returned certificate indicates that the update call is in a terminal state (`replied`, `rejected`, or `done`), then the user __does not need to poll__ (using [`read_state`](#http-read-state) requests) to determine the result of the call. A terminal state means the call has completed its execution.
 
 The synchronous call endpoint is useful for users as it removes the networking overhead of polling the IC to determine the status of their call.
 
@@ -675,7 +675,7 @@ The HTTP response to this request can have the following responses:
 
 -   200 HTTP status with a non-empty body. This status is returned if the canister call completed or was rejected within an implementation-specific timeout.
     
-    -   If the update call completes, meaning the call state is in `reply`, `reject`, or `done`, then the response is a CBOR (see [CBOR](#cbor)) map with the following fields:
+    -   If the update call completes, meaning the call state is in `replied`, `rejected`, or `done`, then the response is a CBOR (see [CBOR](#cbor)) map with the following fields:
 
         -   `status` (`text`): `"certified_state"`
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -652,8 +652,7 @@ The functionality exposed via the [The IC management canister](#ic-management-ca
 :::
 
 ### Request: Sync Call {#http-sync-call}
-Synchronous update calls, or `call and await`, are a form of update calls (See [Call]{#http-call}) where the replica will wait with replying to the user until the call
-has been processed by execution. This means the user will receive the result the call and *do not* need to poll [`read_state`](#http-read-state) to determine the status of the call.
+Synchronous update calls, or `call and await`, are a form of update calls (See [Call]{#http-call}) where the replica will wait with replying to the user until the call has been processed by execution. This means the user will receive a certified result of the call, and thus *do not* need to poll [`read_state`](#http-read-state) to determine the status of the call.
 In order to make a synchronous update call to a canister, the user makes a POST request to `/api/v2/canister/<effective_canister_id>/sync_call`. The request body consists of an authentication envelope with a `content` map with the following fields:
 
 -   `request_type` (`text`): Always `sync-call`

--- a/spec/index.md
+++ b/spec/index.md
@@ -650,6 +650,8 @@ The HTTP response to this request can have the following responses:
 -   202 HTTP status with empty body. Implying the request was accepted by the IC for further processing. Users should use [`read_state`](#http-read-state) to determine the status of the call.
 
 -   200 HTTP status with non-empty body. Implying an execution pre-processing error occurred. The body of the response contains more information about the IC specific error encountered. The body is a CBOR map with the following fields:
+    
+    -   `status` (`text`): `"rejected"`
 
     -   `reject_code` (`nat`): The reject code (see [Reject codes](#reject-codes)).
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -674,12 +674,6 @@ The HTTP response to this request can have the following responses:
 
 This request type can *also* be used to call a query method (but not a composite query method). A user may choose to go this way, instead of via the faster and cheaper [Request: Query call](#http-query) below, if they want to get a *certified* response. Note that the canister state will not be changed by sending a call request type for a query method (except for cycle balance change due to message execution).
 
-:::note
-
-The functionality exposed via the [The IC management canister](#ic-management-canister) can be used this way.
-
-:::
-
 ### Request: Sync Call {#http-sync-call}
 A synchronous update call, or "call and await", is a type of update [call](#http-call) where the replica will wait with replying to the user until the call has been processed and the result has been added to the replicated state. This means the user will receive a certified result of the call, and thus __do not need to poll__ [`read_state`](#http-read-state) to determine the status of the call.
 In order to make a synchronous update call to a canister, the user makes a POST request to `/api/v2/canister/<effective_canister_id>/sync_call`. The request body consists of an authentication envelope with a `content` map with the following fields:

--- a/spec/index.md
+++ b/spec/index.md
@@ -663,6 +663,12 @@ The HTTP response to this request can have the following responses:
 
 This request type can *also* be used to call a query method (but not a composite query method). A user may choose to go this way, instead of via the faster and cheaper [Request: Query call](#http-query) below, if they want to get a *certified* response. Note that the canister state will not be changed by sending a call request type for a query method (except for cycle balance change due to message execution).
 
+:::note
+
+The functionality exposed via the [The IC management canister](#ic-management-canister) can be used this way.
+
+:::
+
 ### Request: Sync Call {#http-sync-call}
 
 In order to make a synchronous update call to a canister, the user makes a POST request to `/api/v2/canister/<effective_canister_id>/sync_call`. The request body consists of an authentication envelope with a `content` map with the following fields:
@@ -700,12 +706,6 @@ The HTTP response to this request can have the following responses:
 -   5xx HTTP status when the server has encountered an error or is otherwise incapable of performing the request. The request might succeed if retried at a later time.
 
 This request type can *also* be used to call a query method (but not a composite query method). A user may choose to go this way, instead of via the faster and cheaper [Request: Query call](#http-query) below, if they want to get a *certified* response. Note that the canister state will not be changed by sending a call request type for a query method (except for cycle balance change due to message execution).
-
-:::note
-
-The functionality exposed via the [The IC management canister](#ic-management-canister) can be used this way.
-
-:::
 
 See [Request status](#state-tree-request-status) for details on the request status.
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -623,11 +623,11 @@ When asking the IC about the state or call of a request, the user uses the reque
 
 #### Synchronous canister calling {#http-sync-call-overview}
 
-A synchronous update call, also known as a "call and await", is a type of update call where the replica will attempt to respond with a certificate to the HTTPS request. If the returned certificate indicates that the update call is in a terminal state, `replied`, `rejected`, or `done`, then the user __does not need to poll__ (using [`read_state`](#http-read-state) requests) to determine the result of the call.
+A synchronous update call, also known as a "call and await", is a type of update call where the replica will attempt to respond with a certificate to the HTTPS request. If the returned certificate indicates that the update call is in a terminal state (`replied`, `rejected`, or `done`), then the user __does not need to poll__ (using [`read_state`](#http-read-state) requests) to determine the result of the call. A terminal state means the call has completed its execution.
 
 The synchronous call endpoint is useful for users as it removes the networking overhead of polling the IC to determine the status of their call.
 
-The replica will maintain the HTTPS connection for the request and will respond once the state transitions to a terminal state. If a timeout for the request is reached while waiting for the terminal state to be reached,  then the replica will reply before the call completes, meaning a certificate with the state in `unknown`, `received`, or `processing` is returned.
+The replica will maintain the HTTPS connection for the request and will respond once the state transitions to a terminal state. If a timeout for the request is reached while waiting for the terminal state, then the replica will reply before the call completes, meaning a certificate with the state in `unknown`, `received`, or `processing` is returned.
 
 The user should take the following actions for the returned certificate states:
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -562,7 +562,7 @@ The Internet Computer therefore has a two models for canister calling:
 -  [*Synchronous*](#http-sync-call) canister calling, where the user waits for a certified response from the Internet Computer.
 - [*Asynchronous*](#http-async-call) canister calling, where the user must poll the Internet Computer for the status of the request.
 
-## Synchronous canister calling {#http-sync-call}
+#### Synchronous canister calling {#http-sync-call}
 
 1.  A user submits a synchronous call via the [HTTPS Interface](#http-interface).
 
@@ -580,7 +580,7 @@ The Internet Computer therefore has a two models for canister calling:
 
 8.  Once the expiry time is past, the IC can prune the call and its response, and completely forget about it.
 
-## Asynchronous canister calling {#http-async-call}
+#### Asynchronous canister calling {#http-async-call}
 
 1.  A user submits a call via the [HTTPS Interface](#http-interface). No useful information is returned in the immediate response (as such information cannot be trustworthy anyways).
 


### PR DESCRIPTION
As part of [IC-1666](https://dfinity.atlassian.net/browse/IC-1666) the proposal introduces a new HTTPS endpoint for synchronous update calls, or "call and await", where users can send call requests to the replica and get the response back in the same request. This differs from the current call approach where users have to continuously poll the status of a call request to get the response.

Adding a synchronous endpoint for update calls will significantly decrease the end-to-end (client-observed) latency for update calls. An initial prototype shows that the client-observed latency can be reduced by a minimum of 1 second which is ~40% improvement.

[IC-1666]: https://dfinity.atlassian.net/browse/IC-1666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ