### PR TITLE
Fix the ordering guarantees claim.

### DIFF
--- a/spec/index.md
+++ b/spec/index.md
@@ -1089,7 +1089,7 @@ The order in which the various messages between canisters are delivered and exec
 
 More precisely:
 
--   Method calls between any *two* canisters, if delivered, start executing in order. Note that function call delivery can fail for arbitrary reasons (e.g., high system load).
+-   Messages between any *two* canisters, if delivered to the canister, start executing in order. Note that message delivery can fail for arbitrary reasons (e.g., high system load).
 
 -   If a WebAssembly function, within a single invocation, makes multiple calls to the same canister, they are queued in the order of invocations to `ic0.call_perform`.
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -1085,11 +1085,11 @@ This section summarizes the format of the CBOR data passed to and from the entry
 
 ### Ordering guarantees
 
-The order in which the various messages between canisters are delivered and executed is not fully specified. The guarantee provided by the IC is that function calls between two canisters are executed in order, so that a canister that requires in-order execution need not wait for the response from an earlier message to a canister before sending a later message to that same canister.
+The order in which the various messages between canisters are delivered and executed is not fully specified. The guarantee provided by the IC is that successful function calls between two canisters are executed in order.
 
 More precisely:
 
--   Method calls between any *two* canisters are delivered in order, as if they were communicating over a single simple FIFO queue.
+-   Successful method calls between any *two* canisters are delivered in order. Note that function calls can fail for arbitrary reasons (e.g., high system load). Thus, canisters that need to ensure that two function calls are both executed, and moreover executed in a particular order, must wait for the completion of the first function call.
 
 -   If a WebAssembly function, within a single invocation, makes multiple calls to the same canister, they are queued in the order of invocations to `ic0.call_perform`.
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -1089,7 +1089,7 @@ The order in which the various messages between canisters are delivered and exec
 
 More precisely:
 
--   Successful method calls between any *two* canisters are delivered in order. Note that function calls can fail for arbitrary reasons (e.g., high system load).
+-   Method calls between any *two* canisters, if delivered, start executing in order. Note that function call delivery can fail for arbitrary reasons (e.g., high system load).
 
 -   If a WebAssembly function, within a single invocation, makes multiple calls to the same canister, they are queued in the order of invocations to `ic0.call_perform`.
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -1085,7 +1085,7 @@ This section summarizes the format of the CBOR data passed to and from the entry
 
 ### Ordering guarantees
 
-The order in which the various messages between canisters are delivered and executed is not fully specified. The guarantee provided by the IC is that successful function calls between two canisters are executed in order.
+The order in which the various messages between canisters are delivered and executed is not fully specified. The guarantee provided by the IC is that if a canister sends two messages to a canister and they both start being executed by the receiving canister, then they do so in the order in which the messages were sent.
 
 More precisely:
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -1089,7 +1089,7 @@ The order in which the various messages between canisters are delivered and exec
 
 More precisely:
 
--   Successful method calls between any *two* canisters are delivered in order. Note that function calls can fail for arbitrary reasons (e.g., high system load). Thus, canisters that need to ensure that two function calls are both executed, and moreover executed in a particular order, must wait for the completion of the first function call.
+-   Successful method calls between any *two* canisters are delivered in order. Note that function calls can fail for arbitrary reasons (e.g., high system load).
 
 -   If a WebAssembly function, within a single invocation, makes multiple calls to the same canister, they are queued in the order of invocations to `ic0.call_perform`.
 


### PR DESCRIPTION
The ordering guarantees specified in the spec are overpromising. The sender can't rely on the function calls being executed in order, and the calls are not really just like a FIFO queue, because there's no delivery guarantee for requests (the system can fail them at any time).