### PR TITLE
fix: chunk_store is not part of CanState in this spec

### DIFF
--- a/spec/index.md
+++ b/spec/index.md
@@ -2921,7 +2921,6 @@ Finally, we can describe the state of the IC as a record having the following fi
     CanState
      = EmptyCanister | {
       wasm_state : WasmState;
-      chunk_store: ChunkStore;
       module : CanisterModule;
       raw_module : Blob;
       public_custom_sections: Text ↦ Blob;


### PR DESCRIPTION
The chunk store is not part of `CanState` in this specification and thus this MR removes it from the definition of `CanState`.