### PR TITLE
chore: avoid canister install mode candid duplication

### DIFF
--- a/spec/_attachments/ic.did
+++ b/spec/_attachments/ic.did
@@ -176,14 +176,16 @@ type stored_chunks_args = record {
     canister_id : canister_id;
 };
 
-type install_code_args = record {
-    mode : variant {
-        install;
-        reinstall;
-        upgrade : opt record {
-            skip_pre_upgrade : opt bool;
-        };
+type canister_install_mode = variant {
+    install;
+    reinstall;
+    upgrade : opt record {
+        skip_pre_upgrade : opt bool;
     };
+};
+
+type install_code_args = record {
+    mode : canister_install_mode;
     canister_id : canister_id;
     wasm_module : wasm_module;
     arg : blob;
@@ -191,13 +193,7 @@ type install_code_args = record {
 };
 
 type install_chunked_code_args = record {
-    mode : variant {
-        install;
-        reinstall;
-        upgrade : opt record {
-            skip_pre_upgrade : opt bool;
-        };
-    };
+    mode : canister_install_mode;
     target_canister : canister_id;
     storage_canister : opt canister_id;
     chunk_hashes_list : vec chunk_hash;


### PR DESCRIPTION
This PR factors out the canister install mode from install_code and install_chunked_code argument definitions in the candid definitions.