### PR TITLE
feat: on low wasm memory hook

### DIFF
--- a/spec/_attachments/ic.did
+++ b/spec/_attachments/ic.did
@@ -14,7 +14,7 @@ type canister_settings = record {
     reserved_cycles_limit : opt nat;
     log_visibility : opt log_visibility;
     wasm_memory_limit : opt nat;
-    low_wasm_memory_threshold : opt nat;
+    wasm_memory_threshold : opt nat;
 };
 
 type definite_canister_settings = record {
@@ -25,7 +25,7 @@ type definite_canister_settings = record {
     reserved_cycles_limit : nat;
     log_visibility : log_visibility;
     wasm_memory_limit : nat;
-    low_wasm_memory_threshold: nat;
+    wasm_memory_threshold: nat;
 };
 
 type change_origin = variant {

--- a/spec/_attachments/ic.did
+++ b/spec/_attachments/ic.did
@@ -7,6 +7,7 @@ type canister_settings = record {
     memory_allocation : opt nat;
     freezing_threshold : opt nat;
     reserved_cycles_limit : opt nat;
+    low_wasm_memory_threshold : opt nat;
 };
 
 type definite_canister_settings = record {
@@ -15,6 +16,7 @@ type definite_canister_settings = record {
     memory_allocation : nat;
     freezing_threshold : nat;
     reserved_cycles_limit : nat;
+    low_wasm_memory_threshold: nat;
 };
 
 type change_origin = variant {

--- a/spec/index.md
+++ b/spec/index.md
@@ -1295,7 +1295,7 @@ While an implementation will likely try to keep the interval between the value o
 
 #### On Low Wasm Memory {#on-low-wasm-memory}
 
-A canister can export a function with the name `canister_on_low_wasm_memory`, which is scheduled whenever the canister's wasm memory size in bytes grows from below a threshold `t` to >= t.
+A canister can export a function with the name `canister_on_low_wasm_memory`, which is scheduled whenever the canister's wasm memory size in bytes grows from below a threshold `t` to >= `t`.
 The threshold `t` can be defined in the [canister's settings](#ic-canister_status) and by default it is set to 2<sup>64</sup> − 1.
 
 :::note
@@ -2093,7 +2093,7 @@ Indicates various information about the canister. It contains:
 
     -   The reserved cycles limit of the canister, i.e., the maximum number of cycles that can be in the canister's reserved balance after increasing the canister's memory allocation and/or actual memory usage.
 
-    -   The "low wasm memory" threshold, which is used to determine when the `on_low_wasm_memory` function is executed. See {#on-low-wasm-memory}.
+    -   The "low wasm memory" threshold, which is used to determine when the [canister_on_low_wasm_memory](#on-low-wasm-memory) function is executed.
 
 -   A SHA256 hash of the module installed on the canister. This is `null` if the canister is empty.
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -1354,7 +1354,7 @@ While an implementation will likely try to keep the interval between the value o
 
 #### On Low Wasm Memory {#on-low-wasm-memory}
 
-A canister can export a function with the name `canister_on_low_wasm_memory`, which is scheduled whenever the canister's wasm memory size in bytes grows from below a threshold `t` to >= `t`.
+A canister can export a function with the name `canister_on_low_wasm_memory`, which is scheduled whenever the canister's remaining wasm memory size in bytes falls from above a threshold `t` to < `t`.
 The threshold `t` can be defined in the [canister's settings](#ic-canister_status) and by default it is set to 2<sup>64</sup> − 1.
 
 :::note

--- a/spec/index.md
+++ b/spec/index.md
@@ -1415,7 +1415,7 @@ The comment after each function lists from where these functions may be invoked:
 
 -   `F`: from `canister_inspect_message`
 
--   `T`: from *system task* (`canister_heartbeat` or `canister_global_timer` `canister_on_low_wasm_memory`)
+-   `T`: from *system task* (`canister_heartbeat` or `canister_global_timer` or `canister_on_low_wasm_memory`)
 
 -   `*` = `I G U Q CQ Ry Rt CRy CRt C CC F T` (NB: Not `(start)`)
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -1355,7 +1355,7 @@ While an implementation will likely try to keep the interval between the value o
 #### On Low Wasm Memory {#on-low-wasm-memory}
 
 A canister can export a function with the name `canister_on_low_wasm_memory`, which is scheduled whenever the canister's remaining wasm memory size in bytes falls from above a threshold `t` to < `t`.
-The threshold `t` can be defined in the [canister's settings](#ic-canister_status) and by default it is set to 2<sup>64</sup> − 1.
+The threshold `t` can be defined in the [canister's settings](#ic-canister_status) and by default it is set to 0.
 
 :::note
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -3979,7 +3979,7 @@ S with
 
 *Call context creation: On low wasm memory*
 
-If canister `C` exports a method with name `canister_on_low_wasm_memory` and `S.on_low_wasm_memory_hook_status[C]` is `Ready`, the IC will create the corresponding call context and set `S.on_low_wasm_memory_hook_status[C]` to `Executed`.
+If `S.on_low_wasm_memory_hook_status[C]` is `Ready` for a canister `C`, the IC will create the corresponding call context and set `S.on_low_wasm_memory_hook_status[C]` to `Executed`.
 
 Conditions
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -1295,7 +1295,7 @@ The canister provides entry points which are invoked by the IC under various cir
 
 -   The canister may export functions with name `canister_composite_query <name>` and type `() -> ()`.
 
--   The canister may export functions with name `canister_on_low_wasm_memory` and type `() -> ()`.
+-   The canister may export a function with the name `canister_on_low_wasm_memory` and type `() -> ()`.
 
 -   The canister table may contain functions of type `(env : i32) -> ()` which may be used as callbacks for inter-canister calls and composite query methods.
 
@@ -1373,7 +1373,7 @@ While an implementation will likely try to keep the interval between the value o
 
 #### On Low Wasm Memory {#on-low-wasm-memory}
 
-A canister can export a function with the name `canister_on_low_wasm_memory`, which is scheduled whenever the canister's remaining wasm memory size in bytes falls from above a threshold `t` to < `t`.
+A canister can export a function with the name `canister_on_low_wasm_memory`, which is scheduled whenever the canister's remaining wasm memory size in bytes falls from above a threshold `t` to strictly less than `t`.
 The threshold `t` can be defined in the [canister's settings](#ic-canister_status) and by default it is set to 0.
 
 :::note


### PR DESCRIPTION
This proposal is based on this [forum post](https://forum.dfinity.org/t/canister-lifecycle-hooks/17089) and has already been approved by [motion proposal 106146](https://dashboard.internetcomputer.org/proposal/106146).

Canister developers have to actively monitor their canisters to know if they are low on wasm memory. If detected too late, a canister can be completely stuck and forever un-upgradable.

To address this, we introduce a hook called `on_low_wasm_memory`. When defined, it is triggered whenever the canister's memory usage exceeds some developer-defined threshold.