### PR TITLE
fix: add note on cycles for sign_with_ecdsa

### DIFF
--- a/spec/index.md
+++ b/spec/index.md
@@ -2161,6 +2161,8 @@ The signatures are encoded as the concatenation of the [SEC1](https://www.secg.o
 
 This call requires that the ECDSA feature is enabled, the caller is a canister, and `message_hash` is 32 bytes long. Otherwise it will be rejected.
 
+Cycles to pay for the call must be explicitly transferred with the call, i.e., they are not deducted from the caller's balance implicitly (e.g., as for inter-canister calls).
+
 ### IC method `http_request` {#ic-http_request}
 
 This method makes an HTTP request to a given URL and returns the HTTP response, possibly after a transformation.


### PR DESCRIPTION
This PR adds a note that cycles must be attached to calls to `sign_with_ecdsa`.