### PR TITLE
fix: add spontaneous request rejection

### DIFF
--- a/spec/_attachments/interface-spec-changelog.md
+++ b/spec/_attachments/interface-spec-changelog.md
@@ -1,6 +1,7 @@
 ## Changelog {#changelog}
 
 ### ∞ (unreleased)
+* Fix: allow inter-canister calls (requests) to be spontaneously rejected in the abstract spec.
 * Wrap chunk hash for install chunked code in a record and rename `storage_canister` to `store_canister`.
 * Update subnet read state request conditions on requested paths.
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -3752,6 +3752,29 @@ The functions `query_as_update` and `system_task_as_update` turns a query functi
 
 Note that by construction, a query function will either trap or return with a response; it will never send calls, and it will never change the state of the canister.
 
+#### Spontaneous request rejection {#request-rejection}
+
+The system can reject a request at any point in time, e.g., because it is overloaded.
+
+Condition:
+```html
+S.messages = Older_messages · CallMessage CM · Younger_messages
+(CM.queue = Unordered) or (∀ msg ∈ Older_messages. msg.queue ≠ CM.queue)
+reject_code ∈ { SYS_FATAL, SYS_TRANSIENT, DESTINATION_INVALID }
+```
+
+State after:
+```html
+S.messages =
+    Older_messages ·
+    ResponseMessage {
+        origin = CM.origin;
+        response = Reject (reject_code, <implementation-specific>);
+        refunded_cycles = CM.transferred_cycles;
+    } ·
+    Younger_messages
+```
+
 #### Call context starvation {#rule-starvation}
 
 If the call context needs to respond (in particular, if the call context is not for a system task) and there is no call, downstream call context, or response that references a call context, then a reject is synthesized. The error message below is *not* indicative. In particular, if the IC has an idea about *why* this starved, it can put that in there (e.g. the initial message handler trapped with an out-of-memory access).

--- a/spec/index.md
+++ b/spec/index.md
@@ -3760,10 +3760,9 @@ Condition:
 ```html
 S.messages = Older_messages · CallMessage CM · Younger_messages
 (CM.queue = Unordered) or (∀ msg ∈ Older_messages. msg.queue ≠ CM.queue)
-reject_code ∈ { SYS_FATAL, SYS_TRANSIENT, DESTINATION_INVALID }
 ```
 
-State after:
+State after, with `reject_code` being an arbitrary reject code:
 ```html
 S.messages =
     Older_messages

--- a/spec/index.md
+++ b/spec/index.md
@@ -3759,7 +3759,6 @@ The system can reject a request at any point in time, e.g., because it is overlo
 Condition:
 ```html
 S.messages = Older_messages · CallMessage CM · Younger_messages
-(CM.queue = Unordered) or (∀ msg ∈ Older_messages. msg.queue ≠ CM.queue)
 ```
 
 State after, with `reject_code` being an arbitrary reject code:

--- a/spec/index.md
+++ b/spec/index.md
@@ -3766,13 +3766,13 @@ reject_code ∈ { SYS_FATAL, SYS_TRANSIENT, DESTINATION_INVALID }
 State after:
 ```html
 S.messages =
-    Older_messages ·
-    ResponseMessage {
+    Older_messages
+    · Younger_messages
+    · ResponseMessage {
         origin = CM.origin;
         response = Reject (reject_code, <implementation-specific>);
         refunded_cycles = CM.transferred_cycles;
-    } ·
-    Younger_messages
+      }
 ```
 
 #### Call context starvation {#rule-starvation}


### PR DESCRIPTION
The IC can currently reject requests at any point in time (e.g., because it's overloaded). But there is no corresponding transition in the spec currently.