### PR TITLE
fix: specify time unit of path /time

### DIFF
--- a/spec/index.md
+++ b/spec/index.md
@@ -431,7 +431,7 @@ This section specifies the publicly relevant paths in the tree.
 
 -   `/time` (natural):
 
-    All partial state trees include a timestamp, indicating the time at which the state is current.
+    All partial state trees include a timestamp, expressed in nanoseconds since 1970-01-01, indicating the time at which the state is current.
 
 ### Api boundary nodes information {#state-tree-api-bn}
 


### PR DESCRIPTION
This PR specifies the time unit of the IC time stored at the path `/time` in the system state tree.