### PR TITLE
fix: Correct the naming of the trustworthy metric: node num_blocks_total

### DIFF
--- a/spec/_attachments/ic.did
+++ b/spec/_attachments/ic.did
@@ -146,7 +146,7 @@ type millisatoshi_per_byte = nat64;
 
 type node_metrics = record {
     node_id : principal;
-    num_blocks_total : nat64;
+    num_blocks_proposed_total : nat64;
     num_block_failures_total : nat64;
 };
 

--- a/spec/_attachments/interface-spec-changelog.md
+++ b/spec/_attachments/interface-spec-changelog.md
@@ -3,6 +3,7 @@
 ### ∞ (unreleased)
 * Query call statistics.
 * New `wasm_memory_persistence` option for canister upgrades.
+* Rename `num_blocks_total` to `num_blocks_proposed_total` in node metrics served by the management canister.
 
 ### 0.24.0 (2024-04-23) {#0_24_0}
 * Wrap chunk hash for install chunked code in a record and rename `storage_canister` to `store_canister`.

--- a/spec/index.md
+++ b/spec/index.md
@@ -2256,7 +2256,7 @@ A single metric entry is a record with the following fields:
 
 - `node_id` (`principal`): the principal characterizing a node;
 
-- `num_blocks_total` (`nat64`): the number of blocks proposed by this node;
+- `num_blocks_proposed_total` (`nat64`): the number of blocks proposed by this node;
 
 - `num_block_failures_total` (`nat64`): the number of failed block proposals by this node.
 


### PR DESCRIPTION
The current name is confusing not only for me but also for the community member(s). I propose we change it to make it more specific.

![image](https://github.com/dfinity/interface-spec/assets/34031969/317206b8-a088-4e14-ad65-d1a9cdc70f76)

link: https://matrix.to/#/!jUsknEqNdJobySpXuN:matrix.org/$wmamJVHU4QTXBWvNx-Rbq8NubEfHyAymhfdjMDsrWfU?via=matrix.org&via=greensteps.cn&via=rudd-o.com
