### PR TITLE
chore: deprecate 32-bit stable memory System API

### DIFF
--- a/spec/_attachments/interface-spec-changelog.md
+++ b/spec/_attachments/interface-spec-changelog.md
@@ -5,6 +5,7 @@
 * New `wasm_memory_persistence` option for canister upgrades.
 * Rename `num_blocks_total` to `num_blocks_proposed_total` in node metrics served by the management canister.
 * Management canister query call to fetch canister logs.
+* 32-bit stable memory System API is marked DEPRECATED.
 
 ### 0.24.0 (2024-04-23) {#0_24_0}
 * Wrap chunk hash for install chunked code in a record and rename `storage_canister` to `store_canister`.

--- a/spec/index.md
+++ b/spec/index.md
@@ -1325,6 +1325,12 @@ The following table captures the modes that different canister methods can be ex
 
 ### Overview of imports {#system-api-imports}
 
+:::note
+
+The 32-bit stable memory System API (`ic0.stable_size`, `ic0.stable_grow`, `ic0.stable_write`, and `ic0.stable_read`) is DEPRECATED. Canister developers are advised to use the 64-bit stable memory System API instead.
+
+:::
+
 The following sections describe various System API functions, also referred to as system calls, which we summarize here.
 
     ic0.msg_arg_data_size : () -> i32;                                          // I U RQ NRQ CQ Ry CRy F
@@ -1757,6 +1763,12 @@ This call traps if the amount of cycles refunded does not fit into a 64-bit valu
     This function can only be used in a callback handler (reply or reject), and indicates the amount of cycles that came back with the response as a refund. The refund has already been added to the canister balance automatically.
 
 ### Stable memory {#system-api-stable-memory}
+
+:::note
+
+The 32-bit stable memory System API (`ic0.stable_size`, `ic0.stable_grow`, `ic0.stable_write`, and `ic0.stable_read`) is DEPRECATED. Canister developers are advised to use the 64-bit stable memory System API instead.
+
+:::
 
 Canisters have the ability to store and retrieve data from a secondary memory. The purpose of this *stable memory* is to provide space to store data beyond upgrades. The interface mirrors roughly the memory-related instructions of WebAssembly, and tries to be forward compatible with exposing this feature as an additional memory.
 


### PR DESCRIPTION
This PR deprecates the 32-bit stable memory System API which could make canisters trap if their stable memory size exceeds the 32-bit range.