### PR TITLE
feat: remove bitcoin_get_balance_query and bitcoin_get_utxos_query

### DIFF
--- a/spec/_attachments/interface-spec-changelog.md
+++ b/spec/_attachments/interface-spec-changelog.md
@@ -7,6 +7,7 @@
 * Management canister query call to fetch canister logs.
 * WASM heap memory limit in canisters settings.
 * 32-bit stable memory System API is marked DEPRECATED.
+* Remove the management canister query calls `bitcoin_get_balance_query` and `bitcoin_get_utxos_query`.
 
 ### 0.24.0 (2024-04-23) {#0_24_0}
 * Wrap chunk hash for install chunked code in a record and rename `storage_canister` to `store_canister`.

--- a/spec/index.md
+++ b/spec/index.md
@@ -870,9 +870,7 @@ It must be contained in the canister ranges of a subnet, otherwise the correspon
 
 -   If the request is a query call to the Management Canister (`aaaaa-aa`), then:
 
-    -   If the call is to the `bitcoin_get_balance_query` or `bitcoin_get_utxos_query` method, then the effective canister id for this call must be the Management Canister (`aaaaa-aa`).
-
-    -   Otherwise, if the `arg` is a Candid-encoded record with a `canister_id` field of type `principal`, then the effective canister id must be that principal.
+    -   If the `arg` is a Candid-encoded record with a `canister_id` field of type `principal`, then the effective canister id must be that principal.
 
     -   Otherwise, the call is rejected by the system independently of the effective canister id.
 
@@ -2357,22 +2355,6 @@ A `get_utxos_request` without the optional `filter` results in a request that co
 
 The recommended workflow is to issue a request with the desired number of confirmations. If the `next_page` field in the response is not empty, there are more UTXOs than in the returned vector. In that case, the `page` field should be set to the `next_page` bytes in the subsequent request to obtain the next batch of UTXOs.
 
-### IC method `bitcoin_get_utxos_query` {#ic-bitcoin_get_utxos_query}
-
-This method is identical to [`bitcoin_get_utxos`](#ic-bitcoin_get_utxos), but exposed as a query.
-
-:::note
-
-This query is only accessible in non-replicated mode. Calls in replicated mode are rejected.
-
-:::
-
-:::warning
-
-The response of a query comes from a single replica, and is therefore not appropriate for security-sensitive applications.
-
-:::
-
 ### IC method `bitcoin_get_balance` {#ic-bitcoin_get_balance}
 
 Given a `get_balance_request`, which must specify a Bitcoin address and a Bitcoin network (`mainnet` or `testnet`), the function returns the current balance of this address in `Satoshi` (10^8 Satoshi = 1 Bitcoin) in the specified Bitcoin network. The same address formats as for [`bitcoin_get_utxos`](#ic-bitcoin_get_utxos) are supported.
@@ -2382,22 +2364,6 @@ If the address is malformed, the call is rejected.
 The optional `min_confirmations` parameter can be used to limit the set of considered UTXOs for the calculation of the balance to those with at least the provided number of confirmations in the same manner as for the [`bitcoin_get_utxos`](#ic-bitcoin_get_utxos) call.
 
 Given an address and the optional `min_confirmations` parameter, `bitcoin_get_balance` iterates over all UTXOs, i.e., the same balance is returned as when calling [`bitcoin_get_utxos`](#ic-bitcoin_get_utxos) for the same address and the same number of confirmations and, if necessary, using pagination to get all UTXOs for the same tip hash.
-
-### IC method `bitcoin_get_balance_query` {#ic-bitcoin_get_balance_query}
-
-This method is identical to [`bitcoin_get_balance`](#ic-bitcoin_get_balance), but exposed as a query.
-
-:::note
-
-This query is only accessible in non-replicated mode. Calls in replicated mode are rejected.
-
-:::
-
-:::warning
-
-The response of a query comes from a single replica, and is therefore not appropriate for security-sensitive applications.
-
-:::
 
 ### IC method `bitcoin_send_transaction` {#ic-bitcoin_send_transaction}
 


### PR DESCRIPTION
This PR removes the management canister query calls `bitcoin_get_balance_query` and `bitcoin_get_utxos_query`. According to the metrics, they are not being used and the query call signature verification cannot be performed according to the specification (the read state request to fetch the replica public keys is gonna fail).