### PR TITLE
fix: make allowed callers of fetch_canister_logs unambiguous

### DIFF
--- a/spec/index.md
+++ b/spec/index.md
@@ -2554,7 +2554,7 @@ The [standard nearest-rank estimation method](https://en.wikipedia.org/wiki/Perc
 
 ### IC method `fetch_canister_logs` {#ic-fetch_canister_logs}
 
-This method can only be called by external users via non-replicated calls, i.e., it cannot be called by canisters, as replicated calls, and from composite query calls.
+This method can only be called by external users via non-replicated calls, i.e., it cannot be called by canisters, cannot be called via replicated calls, and cannot be called from composite query calls.
 
 :::note
 


### PR DESCRIPTION
This PR fixes the sentence "can only be called by ..., i.e., it cannot be called by ..., ..., and ..." by "can only be called by ..., i.e., it cannot be called by ..., cannot be called ..., and cannot be called ..." to make it unambiguous.