### PR TITLE
chore: note on canister logs not collected in non-replicated mode

### DIFF
--- a/spec/index.md
+++ b/spec/index.md
@@ -2563,7 +2563,7 @@ The canister logs management canister API is considered EXPERIMENTAL. Canister d
 :::
 
 Given a canister ID as input, this method returns a vector of logs of that canister including its trap messages.
-The canister logs are *not* collected in canister methods running in non-replicated mode (NRQ, CQ, CRy, CRt, CC, and F modes, as defined in [Overview of imports](#overview-of-imports)).
+The canister logs are *not* collected in canister methods running in non-replicated mode (NRQ, CQ, CRy, CRt, CC, and F modes, as defined in [Overview of imports](#overview-of-imports)) and the canister logs are *purged* when the canister is reinstalled or uninstalled.
 The total size of all returned logs does not exceed 4KiB.
 If new logs are added resulting in exceeding the maximum total log size of 4KiB, the oldest logs will be removed.
 Logs persist across canister upgrades and they are deleted if the canister is reinstalled or uninstalled.

--- a/spec/index.md
+++ b/spec/index.md
@@ -2563,7 +2563,7 @@ The canister logs management canister API is considered EXPERIMENTAL. Canister d
 :::
 
 Given a canister ID as input, this method returns a vector of logs of that canister including its trap messages.
-The canister logs are *not* collected in canister methods running in non-replicated mode (NRQ, CQ, CRy, CRt, CC, and F modes, as defined in in [Overview of imports](#system-api-imports)).
+The canister logs are *not* collected in canister methods running in non-replicated mode (NRQ, CQ, CRy, CRt, CC, and F modes, as defined in [Overview of imports](#overview-of-imports)).
 The total size of all returned logs does not exceed 4KiB.
 If new logs are added resulting in exceeding the maximum total log size of 4KiB, the oldest logs will be removed.
 Logs persist across canister upgrades and they are deleted if the canister is reinstalled or uninstalled.

--- a/spec/index.md
+++ b/spec/index.md
@@ -2563,6 +2563,7 @@ The canister logs management canister API is considered EXPERIMENTAL. Canister d
 :::
 
 Given a canister ID as input, this method returns a vector of logs of that canister including its trap messages.
+The canister logs are *not* collected in canister methods running in non-replicated mode (NRQ, CQ, CRy, CRt, CC, and F modes, as defined in in [Overview of imports](#system-api-imports)).
 The total size of all returned logs does not exceed 4KiB.
 If new logs are added resulting in exceeding the maximum total log size of 4KiB, the oldest logs will be removed.
 Logs persist across canister upgrades and they are deleted if the canister is reinstalled or uninstalled.


### PR DESCRIPTION
This MR adds a note on the mgmt canister fetch logs API that no logs are collected for methods running in non-replicated mode.