### PR TITLE
chore: fix broken links in headings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 # IDEs
 .vscode/
 .idea/
+
+node_modules
+docusaurus/build
+docusaurus/.docusaurus

--- a/docusaurus/package-lock.json
+++ b/docusaurus/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@akebifiky/remark-simple-plantuml": "^1.0.2",
-        "@docusaurus/core": "3.2.0",
-        "@docusaurus/preset-classic": "3.2.0",
+        "@docusaurus/core": "^3.4.0",
+        "@docusaurus/preset-classic": "^3.4.0",
         "@mdx-js/react": "^3.0.1",
         "clsx": "^2.1.0",
         "prism-react-renderer": "^1.3.5",
@@ -19,11 +19,11 @@
         "remark-math": "^6.0.0"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "3.2.0",
+        "@docusaurus/module-type-aliases": "^3.4.0",
         "remark-code-import": "^1.2.0"
       },
       "engines": {
-        "node": ">=16.14"
+        "node": ">=18.0"
       }
     },
     "node_modules/@akebifiky/remark-simple-plantuml": {
@@ -77,74 +77,74 @@
       }
     },
     "node_modules/@algolia/cache-browser-local-storage": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.23.2.tgz",
-      "integrity": "sha512-PvRQdCmtiU22dw9ZcTJkrVKgNBVAxKgD0/cfiqyxhA5+PHzA2WDt6jOmZ9QASkeM2BpyzClJb/Wr1yt2/t78Kw==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.24.0.tgz",
+      "integrity": "sha512-t63W9BnoXVrGy9iYHBgObNXqYXM3tYXCjDSHeNwnsc324r4o5UiVKUiAB4THQ5z9U5hTj6qUvwg/Ez43ZD85ww==",
       "dependencies": {
-        "@algolia/cache-common": "4.23.2"
+        "@algolia/cache-common": "4.24.0"
       }
     },
     "node_modules/@algolia/cache-common": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.23.2.tgz",
-      "integrity": "sha512-OUK/6mqr6CQWxzl/QY0/mwhlGvS6fMtvEPyn/7AHUx96NjqDA4X4+Ju7aXFQKh+m3jW9VPB0B9xvEQgyAnRPNw=="
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.24.0.tgz",
+      "integrity": "sha512-emi+v+DmVLpMGhp0V9q9h5CdkURsNmFC+cOS6uK9ndeJm9J4TiqSvPYVu+THUP8P/S08rxf5x2P+p3CfID0Y4g=="
     },
     "node_modules/@algolia/cache-in-memory": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.23.2.tgz",
-      "integrity": "sha512-rfbi/SnhEa3MmlqQvgYz/9NNJ156NkU6xFxjbxBtLWnHbpj+qnlMoKd+amoiacHRITpajg6zYbLM9dnaD3Bczw==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.24.0.tgz",
+      "integrity": "sha512-gDrt2so19jW26jY3/MkFg5mEypFIPbPoXsQGQWAi6TrCPsNOSEYepBMPlucqWigsmEy/prp5ug2jy/N3PVG/8w==",
       "dependencies": {
-        "@algolia/cache-common": "4.23.2"
+        "@algolia/cache-common": "4.24.0"
       }
     },
     "node_modules/@algolia/client-account": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.23.2.tgz",
-      "integrity": "sha512-VbrOCLIN/5I7iIdskSoSw3uOUPF516k4SjDD4Qz3BFwa3of7D9A0lzBMAvQEJJEPHWdVraBJlGgdJq/ttmquJQ==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.24.0.tgz",
+      "integrity": "sha512-adcvyJ3KjPZFDybxlqnf+5KgxJtBjwTPTeyG2aOyoJvx0Y8dUQAEOEVOJ/GBxX0WWNbmaSrhDURMhc+QeevDsA==",
       "dependencies": {
-        "@algolia/client-common": "4.23.2",
-        "@algolia/client-search": "4.23.2",
-        "@algolia/transporter": "4.23.2"
+        "@algolia/client-common": "4.24.0",
+        "@algolia/client-search": "4.24.0",
+        "@algolia/transporter": "4.24.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.23.2.tgz",
-      "integrity": "sha512-lLj7irsAztGhMoEx/SwKd1cwLY6Daf1Q5f2AOsZacpppSvuFvuBrmkzT7pap1OD/OePjLKxicJS8wNA0+zKtuw==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.24.0.tgz",
+      "integrity": "sha512-y8jOZt1OjwWU4N2qr8G4AxXAzaa8DBvyHTWlHzX/7Me1LX8OayfgHexqrsL4vSBcoMmVw2XnVW9MhL+Y2ZDJXg==",
       "dependencies": {
-        "@algolia/client-common": "4.23.2",
-        "@algolia/client-search": "4.23.2",
-        "@algolia/requester-common": "4.23.2",
-        "@algolia/transporter": "4.23.2"
+        "@algolia/client-common": "4.24.0",
+        "@algolia/client-search": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.23.2.tgz",
-      "integrity": "sha512-Q2K1FRJBern8kIfZ0EqPvUr3V29ICxCm/q42zInV+VJRjldAD9oTsMGwqUQ26GFMdFYmqkEfCbY4VGAiQhh22g==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
+      "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
       "dependencies": {
-        "@algolia/requester-common": "4.23.2",
-        "@algolia/transporter": "4.23.2"
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.23.2.tgz",
-      "integrity": "sha512-vwPsgnCGhUcHhhQG5IM27z8q7dWrN9itjdvgA6uKf2e9r7vB+WXt4OocK0CeoYQt3OGEAExryzsB8DWqdMK5wg==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.24.0.tgz",
+      "integrity": "sha512-l5FRFm/yngztweU0HdUzz1rC4yoWCFo3IF+dVIVTfEPg906eZg5BOd1k0K6rZx5JzyyoP4LdmOikfkfGsKVE9w==",
       "dependencies": {
-        "@algolia/client-common": "4.23.2",
-        "@algolia/requester-common": "4.23.2",
-        "@algolia/transporter": "4.23.2"
+        "@algolia/client-common": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.23.2.tgz",
-      "integrity": "sha512-CxSB29OVGSE7l/iyoHvamMonzq7Ev8lnk/OkzleODZ1iBcCs3JC/XgTIKzN/4RSTrJ9QybsnlrN/bYCGufo7qw==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
+      "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
       "dependencies": {
-        "@algolia/client-common": "4.23.2",
-        "@algolia/requester-common": "4.23.2",
-        "@algolia/transporter": "4.23.2"
+        "@algolia/client-common": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
       }
     },
     "node_modules/@algolia/events": {
@@ -153,65 +153,65 @@
       "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ=="
     },
     "node_modules/@algolia/logger-common": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.23.2.tgz",
-      "integrity": "sha512-jGM49Q7626cXZ7qRAWXn0jDlzvoA1FvN4rKTi1g0hxKsTTSReyYk0i1ADWjChDPl3Q+nSDhJuosM2bBUAay7xw=="
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.24.0.tgz",
+      "integrity": "sha512-LLUNjkahj9KtKYrQhFKCzMx0BY3RnNP4FEtO+sBybCjJ73E8jNdaKJ/Dd8A/VA4imVHP5tADZ8pn5B8Ga/wTMA=="
     },
     "node_modules/@algolia/logger-console": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.23.2.tgz",
-      "integrity": "sha512-oo+lnxxEmlhTBTFZ3fGz1O8PJ+G+8FiAoMY2Qo3Q4w23xocQev6KqDTA1JQAGPDxAewNA2VBwWOsVXeXFjrI/Q==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.24.0.tgz",
+      "integrity": "sha512-X4C8IoHgHfiUROfoRCV+lzSy+LHMgkoEEU1BbKcsfnV0i0S20zyy0NLww9dwVHUWNfPPxdMU+/wKmLGYf96yTg==",
       "dependencies": {
-        "@algolia/logger-common": "4.23.2"
+        "@algolia/logger-common": "4.24.0"
       }
     },
     "node_modules/@algolia/recommend": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-4.23.2.tgz",
-      "integrity": "sha512-Q75CjnzRCDzgIlgWfPnkLtrfF4t82JCirhalXkSSwe/c1GH5pWh4xUyDOR3KTMo+YxxX3zTlrL/FjHmUJEWEcg==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-4.24.0.tgz",
+      "integrity": "sha512-P9kcgerfVBpfYHDfVZDvvdJv0lEoCvzNlOy2nykyt5bK8TyieYyiD0lguIJdRZZYGre03WIAFf14pgE+V+IBlw==",
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.23.2",
-        "@algolia/cache-common": "4.23.2",
-        "@algolia/cache-in-memory": "4.23.2",
-        "@algolia/client-common": "4.23.2",
-        "@algolia/client-search": "4.23.2",
-        "@algolia/logger-common": "4.23.2",
-        "@algolia/logger-console": "4.23.2",
-        "@algolia/requester-browser-xhr": "4.23.2",
-        "@algolia/requester-common": "4.23.2",
-        "@algolia/requester-node-http": "4.23.2",
-        "@algolia/transporter": "4.23.2"
+        "@algolia/cache-browser-local-storage": "4.24.0",
+        "@algolia/cache-common": "4.24.0",
+        "@algolia/cache-in-memory": "4.24.0",
+        "@algolia/client-common": "4.24.0",
+        "@algolia/client-search": "4.24.0",
+        "@algolia/logger-common": "4.24.0",
+        "@algolia/logger-console": "4.24.0",
+        "@algolia/requester-browser-xhr": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/requester-node-http": "4.24.0",
+        "@algolia/transporter": "4.24.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.23.2.tgz",
-      "integrity": "sha512-TO9wLlp8+rvW9LnIfyHsu8mNAMYrqNdQ0oLF6eTWFxXfxG3k8F/Bh7nFYGk2rFAYty4Fw4XUtrv/YjeNDtM5og==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.24.0.tgz",
+      "integrity": "sha512-Z2NxZMb6+nVXSjF13YpjYTdvV3032YTBSGm2vnYvYPA6mMxzM3v5rsCiSspndn9rzIW4Qp1lPHBvuoKJV6jnAA==",
       "dependencies": {
-        "@algolia/requester-common": "4.23.2"
+        "@algolia/requester-common": "4.24.0"
       }
     },
     "node_modules/@algolia/requester-common": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.23.2.tgz",
-      "integrity": "sha512-3EfpBS0Hri0lGDB5H/BocLt7Vkop0bTTLVUBB844HH6tVycwShmsV6bDR7yXbQvFP1uNpgePRD3cdBCjeHmk6Q=="
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.24.0.tgz",
+      "integrity": "sha512-k3CXJ2OVnvgE3HMwcojpvY6d9kgKMPRxs/kVohrwF5WMr2fnqojnycZkxPoEg+bXm8fi5BBfFmOqgYztRtHsQA=="
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.23.2.tgz",
-      "integrity": "sha512-SVzgkZM/malo+2SB0NWDXpnT7nO5IZwuDTaaH6SjLeOHcya1o56LSWXk+3F3rNLz2GVH+I/rpYKiqmHhSOjerw==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.24.0.tgz",
+      "integrity": "sha512-JF18yTjNOVYvU/L3UosRcvbPMGT9B+/GQWNWnenIImglzNVGpyzChkXLnrSf6uxwVNO6ESGu6oN8MqcGQcjQJw==",
       "dependencies": {
-        "@algolia/requester-common": "4.23.2"
+        "@algolia/requester-common": "4.24.0"
       }
     },
     "node_modules/@algolia/transporter": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.23.2.tgz",
-      "integrity": "sha512-GY3aGKBy+8AK4vZh8sfkatDciDVKad5rTY2S10Aefyjh7e7UGBP4zigf42qVXwU8VOPwi7l/L7OACGMOFcjB0Q==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.24.0.tgz",
+      "integrity": "sha512-86nI7w6NzWxd1Zp9q3413dRshDqAzSbsQjhcDhPIatEFiZrL1/TjnHL8S7jVKFePlIMzDsZWXAXwXzcok9c5oA==",
       "dependencies": {
-        "@algolia/cache-common": "4.23.2",
-        "@algolia/logger-common": "4.23.2",
-        "@algolia/requester-common": "4.23.2"
+        "@algolia/cache-common": "4.24.0",
+        "@algolia/logger-common": "4.24.0",
+        "@algolia/requester-common": "4.24.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -494,9 +494,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.0.tgz",
-      "integrity": "sha512-9cUznXMG0+FxRuJfvL82QlTqIzhVW9sL0KjMPHhAOOvpQGL8QtdxnBKILjBqxlHyliz0yCa1G903ZXI/FuHy2w==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.7.tgz",
+      "integrity": "sha512-Rq76wjt7yz9AAc1KnlRKNAi/dMSVWgDRx43FHoJEbcYU6xOWaE2dVPwcdTukJrjxS65GITyfbvEYHvkirZ6uEg==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1586,11 +1586,11 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-constant-elements": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.24.1.tgz",
-      "integrity": "sha512-QXp1U9x0R7tkiGB0FOk8o74jhnap0FlZ5gNkRIWdG3eP+SvMFg118e1zaWewDzgABb106QSKpVsD3Wgd8t6ifA==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.24.7.tgz",
+      "integrity": "sha512-7LidzZfUXyfZ8/buRW6qIIHBY8wAZ1OrY9c/wTr8YhZ6vMPo+Uc/CVFLYY1spZrEQlD4w5u8wjqk5NQ3OVqQKA==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.0"
+        "@babel/helper-plugin-utils": "^7.24.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2143,9 +2143,9 @@
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.2.0.tgz",
-      "integrity": "sha512-WTO6vW4404nhTmK9NL+95nd13I1JveFwZ8iOBYxb4xt+N2S3KzY+mm+1YtWw2vV37FbYfH+w+KrlrRaWuy5Hzw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.4.0.tgz",
+      "integrity": "sha512-g+0wwmN2UJsBqy2fQRQ6fhXruoEa62JDeEa5d8IdTJlMoaDaEDfHh7WjwGRn4opuTQWpjAwP/fbcgyHKlE+64w==",
       "dependencies": {
         "@babel/core": "^7.23.3",
         "@babel/generator": "^7.23.3",
@@ -2157,14 +2157,12 @@
         "@babel/runtime": "^7.22.6",
         "@babel/runtime-corejs3": "^7.22.6",
         "@babel/traverse": "^7.22.8",
-        "@docusaurus/cssnano-preset": "3.2.0",
-        "@docusaurus/logger": "3.2.0",
-        "@docusaurus/mdx-loader": "3.2.0",
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "3.2.0",
-        "@docusaurus/utils-common": "3.2.0",
-        "@docusaurus/utils-validation": "3.2.0",
-        "@svgr/webpack": "^6.5.1",
+        "@docusaurus/cssnano-preset": "3.4.0",
+        "@docusaurus/logger": "3.4.0",
+        "@docusaurus/mdx-loader": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-common": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
         "autoprefixer": "^10.4.14",
         "babel-loader": "^9.1.3",
         "babel-plugin-dynamic-import-node": "^2.3.3",
@@ -2178,8 +2176,8 @@
         "copy-webpack-plugin": "^11.0.0",
         "core-js": "^3.31.1",
         "css-loader": "^6.8.1",
-        "css-minimizer-webpack-plugin": "^4.2.2",
-        "cssnano": "^5.1.15",
+        "css-minimizer-webpack-plugin": "^5.0.1",
+        "cssnano": "^6.1.2",
         "del": "^6.1.1",
         "detect-port": "^1.5.1",
         "escape-html": "^1.0.3",
@@ -2199,7 +2197,7 @@
         "prompts": "^2.4.2",
         "react-dev-utils": "^12.0.1",
         "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
+        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
         "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
         "react-router": "^5.3.4",
         "react-router-config": "^5.1.1",
@@ -2258,13 +2256,13 @@
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.2.0.tgz",
-      "integrity": "sha512-H88RXGUia7r/VF3XfyoA4kbwgpUZcKsObF6VvwBOP91EdArTf6lnHbJ/x8Ca79KS/zf98qaWyBGzW+5ez58Iyw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.4.0.tgz",
+      "integrity": "sha512-qwLFSz6v/pZHy/UP32IrprmH5ORce86BGtN0eBtG75PpzQJAzp9gefspox+s8IEOr0oZKuQ/nhzZ3xwyc3jYJQ==",
       "dependencies": {
-        "cssnano-preset-advanced": "^5.3.10",
-        "postcss": "^8.4.26",
-        "postcss-sort-media-queries": "^4.4.1",
+        "cssnano-preset-advanced": "^6.1.2",
+        "postcss": "^8.4.38",
+        "postcss-sort-media-queries": "^5.2.0",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -2272,9 +2270,9 @@
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.2.0.tgz",
-      "integrity": "sha512-Z1R1NcOGXZ8CkIJSvjvyxnuDDSlx/+1xlh20iVTw1DZRjonFmI3T3tTgk40YpXyWUYQpIgAoqqPMpuseMMdgRQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.4.0.tgz",
+      "integrity": "sha512-bZwkX+9SJ8lB9kVRkXw+xvHYSMGG4bpYHKGXeXFvyVc79NMeeBSGgzd4TQLHH+DYeOJoCdl8flrFJVxlZ0wo/Q==",
       "dependencies": {
         "chalk": "^4.1.2",
         "tslib": "^2.6.0"
@@ -2284,13 +2282,13 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.2.0.tgz",
-      "integrity": "sha512-JtkI5o6R/rJSr1Y23cHKz085aBJCvJw3AYHihJ7r+mBX+O8EuQIynG0e6/XpbSCpr7Ino0U50UtxaXcEbFwg9Q==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.4.0.tgz",
+      "integrity": "sha512-kSSbrrk4nTjf4d+wtBA9H+FGauf2gCax89kV8SUSJu3qaTdSIKdWERlngsiHaCFgZ7laTJ8a67UFf+xlFPtuTw==",
       "dependencies": {
-        "@docusaurus/logger": "3.2.0",
-        "@docusaurus/utils": "3.2.0",
-        "@docusaurus/utils-validation": "3.2.0",
+        "@docusaurus/logger": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
         "@mdx-js/mdx": "^3.0.0",
         "@slorber/remark-comment": "^1.0.0",
         "escape-html": "^1.0.3",
@@ -2405,18 +2403,17 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.2.0.tgz",
-      "integrity": "sha512-jRSp9YkvBwwNz6Xgy0RJPsnie+Ebb//gy7GdbkJ2pW2gvvlYKGib2+jSF0pfIzvyZLulfCynS1KQdvDKdSl8zQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.4.0.tgz",
+      "integrity": "sha512-A1AyS8WF5Bkjnb8s+guTDuYmUiwJzNrtchebBHpc0gz0PyHJNMaybUlSrmJjHVcGrya0LKI4YcR3lBDQfXRYLw==",
       "dependencies": {
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "3.2.0",
+        "@docusaurus/types": "3.4.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
         "@types/react-router-dom": "*",
         "react-helmet-async": "*",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
+        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
       },
       "peerDependencies": {
         "react": "*",
@@ -2424,17 +2421,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.2.0.tgz",
-      "integrity": "sha512-MABqwjSicyHmYEfQueMthPCz18JkVxhK3EGhXTSRWwReAZ0UTuw9pG6+Wo+uXAugDaIcJH28rVZSwTDINPm2bw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.4.0.tgz",
+      "integrity": "sha512-vv6ZAj78ibR5Jh7XBUT4ndIjmlAxkijM3Sx5MAAzC1gyv0vupDQNhzuFg1USQmQVj3P5I6bquk12etPV3LJ+Xw==",
       "dependencies": {
-        "@docusaurus/core": "3.2.0",
-        "@docusaurus/logger": "3.2.0",
-        "@docusaurus/mdx-loader": "3.2.0",
-        "@docusaurus/types": "3.2.0",
-        "@docusaurus/utils": "3.2.0",
-        "@docusaurus/utils-common": "3.2.0",
-        "@docusaurus/utils-validation": "3.2.0",
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/logger": "3.4.0",
+        "@docusaurus/mdx-loader": "3.4.0",
+        "@docusaurus/types": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-common": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^11.1.1",
@@ -2499,18 +2496,18 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.2.0.tgz",
-      "integrity": "sha512-uuqhahmsBnirxOz+SXksnWt7+wc+iN4ntxNRH48BUgo7QRNLATWjHCgI8t6zrMJxK4o+QL9DhLaPDlFHs91B3Q==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.4.0.tgz",
+      "integrity": "sha512-HkUCZffhBo7ocYheD9oZvMcDloRnGhBMOZRyVcAQRFmZPmNqSyISlXA1tQCIxW+r478fty97XXAGjNYzBjpCsg==",
       "dependencies": {
-        "@docusaurus/core": "3.2.0",
-        "@docusaurus/logger": "3.2.0",
-        "@docusaurus/mdx-loader": "3.2.0",
-        "@docusaurus/module-type-aliases": "3.2.0",
-        "@docusaurus/types": "3.2.0",
-        "@docusaurus/utils": "3.2.0",
-        "@docusaurus/utils-common": "3.2.0",
-        "@docusaurus/utils-validation": "3.2.0",
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/logger": "3.4.0",
+        "@docusaurus/mdx-loader": "3.4.0",
+        "@docusaurus/module-type-aliases": "3.4.0",
+        "@docusaurus/types": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-common": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
         "@types/react-router-config": "^5.0.7",
         "combine-promises": "^1.1.0",
         "fs-extra": "^11.1.1",
@@ -2529,15 +2526,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.2.0.tgz",
-      "integrity": "sha512-4ofAN7JDsdb4tODO9OIrizWY5DmEJXr0eu+UDIkLqGP+gXXTahJZv8h2mlxO+lPXGXRCVBOfA14OG1hOYJVPwA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.4.0.tgz",
+      "integrity": "sha512-h2+VN/0JjpR8fIkDEAoadNjfR3oLzB+v1qSXbIAKjQ46JAHx3X22n9nqS+BWSQnTnp1AjkjSvZyJMekmcwxzxg==",
       "dependencies": {
-        "@docusaurus/core": "3.2.0",
-        "@docusaurus/mdx-loader": "3.2.0",
-        "@docusaurus/types": "3.2.0",
-        "@docusaurus/utils": "3.2.0",
-        "@docusaurus/utils-validation": "3.2.0",
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/mdx-loader": "3.4.0",
+        "@docusaurus/types": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0",
         "webpack": "^5.88.1"
@@ -2551,13 +2548,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.2.0.tgz",
-      "integrity": "sha512-p6WxtO5XZGz66y6QNQtCJwBefq4S6/w75XaXVvH1/2P9uaijvF7R+Cm2EWQZ5WsvA5wl//DFWblyDHRyVC207Q==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.4.0.tgz",
+      "integrity": "sha512-uV7FDUNXGyDSD3PwUaf5YijX91T5/H9SX4ErEcshzwgzWwBtK37nUWPU3ZLJfeTavX3fycTOqk9TglpOLaWkCg==",
       "dependencies": {
-        "@docusaurus/core": "3.2.0",
-        "@docusaurus/types": "3.2.0",
-        "@docusaurus/utils": "3.2.0",
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/types": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
         "fs-extra": "^11.1.1",
         "react-json-view-lite": "^1.2.0",
         "tslib": "^2.6.0"
@@ -2571,13 +2568,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.2.0.tgz",
-      "integrity": "sha512-//TepJTEyAZSvBwHKEbXHu9xT/VkK3wUil2ZakKvQZYfUC01uWn6A1E3toa8R7WhCy1xPUeIukqmJy1Clg8njQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.4.0.tgz",
+      "integrity": "sha512-mCArluxEGi3cmYHqsgpGGt3IyLCrFBxPsxNZ56Mpur0xSlInnIHoeLDH7FvVVcPJRPSQ9/MfRqLsainRw+BojA==",
       "dependencies": {
-        "@docusaurus/core": "3.2.0",
-        "@docusaurus/types": "3.2.0",
-        "@docusaurus/utils-validation": "3.2.0",
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/types": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -2589,13 +2586,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.2.0.tgz",
-      "integrity": "sha512-3s6zxlaMMb87MW2Rxy6EnSRDs0WDEQPuHilZZH402C8kOrUnIwlhlfjWZ4ZyLDziGl/Eec/DvD0PVqj0qHRomA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.4.0.tgz",
+      "integrity": "sha512-Dsgg6PLAqzZw5wZ4QjUYc8Z2KqJqXxHxq3vIoyoBWiLEEfigIs7wHR+oiWUQy3Zk9MIk6JTYj7tMoQU0Jm3nqA==",
       "dependencies": {
-        "@docusaurus/core": "3.2.0",
-        "@docusaurus/types": "3.2.0",
-        "@docusaurus/utils-validation": "3.2.0",
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/types": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
         "@types/gtag.js": "^0.0.12",
         "tslib": "^2.6.0"
       },
@@ -2608,13 +2605,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-tag-manager": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.2.0.tgz",
-      "integrity": "sha512-rAKtsJ11vPHA7dTAqWCgyIy7AyFRF/lpI77Zd/4HKgqcIvIayVBvL3QtelhUazfYTLTH6ls6kQ9wjMcIFxRiGg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.4.0.tgz",
+      "integrity": "sha512-O9tX1BTwxIhgXpOLpFDueYA9DWk69WCbDRrjYoMQtFHSkTyE7RhNgyjSPREUWJb9i+YUg3OrsvrBYRl64FCPCQ==",
       "dependencies": {
-        "@docusaurus/core": "3.2.0",
-        "@docusaurus/types": "3.2.0",
-        "@docusaurus/utils-validation": "3.2.0",
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/types": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -2626,16 +2623,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.2.0.tgz",
-      "integrity": "sha512-gnWDFt6MStjLkdtt63Lzc+14EPSd8B6mzJGJp9GQMvWDUoMAUijUqpVIHYQq+DPMcI4PJZ5I2nsl5XFf1vOldA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.4.0.tgz",
+      "integrity": "sha512-+0VDvx9SmNrFNgwPoeoCha+tRoAjopwT0+pYO1xAbyLcewXSemq+eLxEa46Q1/aoOaJQ0qqHELuQM7iS2gp33Q==",
       "dependencies": {
-        "@docusaurus/core": "3.2.0",
-        "@docusaurus/logger": "3.2.0",
-        "@docusaurus/types": "3.2.0",
-        "@docusaurus/utils": "3.2.0",
-        "@docusaurus/utils-common": "3.2.0",
-        "@docusaurus/utils-validation": "3.2.0",
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/logger": "3.4.0",
+        "@docusaurus/types": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-common": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
         "fs-extra": "^11.1.1",
         "sitemap": "^7.1.1",
         "tslib": "^2.6.0"
@@ -2649,23 +2646,23 @@
       }
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.2.0.tgz",
-      "integrity": "sha512-t7tXyk8kUgT7hUqEOgSJnPs+Foem9ucuan/a9QVYaVFCDjp92Sb2FpCY8bVasAokYCjodYe2LfpAoSCj5YDYWg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.4.0.tgz",
+      "integrity": "sha512-Ohj6KB7siKqZaQhNJVMBBUzT3Nnp6eTKqO+FXO3qu/n1hJl3YLwVKTWBg28LF7MWrKu46UuYavwMRxud0VyqHg==",
       "dependencies": {
-        "@docusaurus/core": "3.2.0",
-        "@docusaurus/plugin-content-blog": "3.2.0",
-        "@docusaurus/plugin-content-docs": "3.2.0",
-        "@docusaurus/plugin-content-pages": "3.2.0",
-        "@docusaurus/plugin-debug": "3.2.0",
-        "@docusaurus/plugin-google-analytics": "3.2.0",
-        "@docusaurus/plugin-google-gtag": "3.2.0",
-        "@docusaurus/plugin-google-tag-manager": "3.2.0",
-        "@docusaurus/plugin-sitemap": "3.2.0",
-        "@docusaurus/theme-classic": "3.2.0",
-        "@docusaurus/theme-common": "3.2.0",
-        "@docusaurus/theme-search-algolia": "3.2.0",
-        "@docusaurus/types": "3.2.0"
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/plugin-content-blog": "3.4.0",
+        "@docusaurus/plugin-content-docs": "3.4.0",
+        "@docusaurus/plugin-content-pages": "3.4.0",
+        "@docusaurus/plugin-debug": "3.4.0",
+        "@docusaurus/plugin-google-analytics": "3.4.0",
+        "@docusaurus/plugin-google-gtag": "3.4.0",
+        "@docusaurus/plugin-google-tag-manager": "3.4.0",
+        "@docusaurus/plugin-sitemap": "3.4.0",
+        "@docusaurus/theme-classic": "3.4.0",
+        "@docusaurus/theme-common": "3.4.0",
+        "@docusaurus/theme-search-algolia": "3.4.0",
+        "@docusaurus/types": "3.4.0"
       },
       "engines": {
         "node": ">=18.0"
@@ -2675,35 +2672,23 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@docusaurus/react-loadable": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz",
-      "integrity": "sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==",
-      "dependencies": {
-        "@types/react": "*",
-        "prop-types": "^15.6.2"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.2.0.tgz",
-      "integrity": "sha512-4oSO5BQOJ5ja7WYdL6jK1n4J96tp+VJHamdwao6Ea252sA3W3vvR0otTflG4p4XVjNZH6hlPQoi5lKW0HeRgfQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.4.0.tgz",
+      "integrity": "sha512-0IPtmxsBYv2adr1GnZRdMkEQt1YW6tpzrUPj02YxNpvJ5+ju4E13J5tB4nfdaen/tfR1hmpSPlTFPvTf4kwy8Q==",
       "dependencies": {
-        "@docusaurus/core": "3.2.0",
-        "@docusaurus/mdx-loader": "3.2.0",
-        "@docusaurus/module-type-aliases": "3.2.0",
-        "@docusaurus/plugin-content-blog": "3.2.0",
-        "@docusaurus/plugin-content-docs": "3.2.0",
-        "@docusaurus/plugin-content-pages": "3.2.0",
-        "@docusaurus/theme-common": "3.2.0",
-        "@docusaurus/theme-translations": "3.2.0",
-        "@docusaurus/types": "3.2.0",
-        "@docusaurus/utils": "3.2.0",
-        "@docusaurus/utils-common": "3.2.0",
-        "@docusaurus/utils-validation": "3.2.0",
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/mdx-loader": "3.4.0",
+        "@docusaurus/module-type-aliases": "3.4.0",
+        "@docusaurus/plugin-content-blog": "3.4.0",
+        "@docusaurus/plugin-content-docs": "3.4.0",
+        "@docusaurus/plugin-content-pages": "3.4.0",
+        "@docusaurus/theme-common": "3.4.0",
+        "@docusaurus/theme-translations": "3.4.0",
+        "@docusaurus/types": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-common": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "copy-text-to-clipboard": "^3.2.0",
@@ -2739,17 +2724,17 @@
       }
     },
     "node_modules/@docusaurus/theme-common": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.2.0.tgz",
-      "integrity": "sha512-sFbw9XviNJJ+760kAcZCQMQ3jkNIznGqa6MQ70E5BnbP+ja36kGgPOfjcsvAcNey1H1Rkhh3p2Mhf4HVLdKVVw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.4.0.tgz",
+      "integrity": "sha512-0A27alXuv7ZdCg28oPE8nH/Iz73/IUejVaCazqu9elS4ypjiLhK3KfzdSQBnL/g7YfHSlymZKdiOHEo8fJ0qMA==",
       "dependencies": {
-        "@docusaurus/mdx-loader": "3.2.0",
-        "@docusaurus/module-type-aliases": "3.2.0",
-        "@docusaurus/plugin-content-blog": "3.2.0",
-        "@docusaurus/plugin-content-docs": "3.2.0",
-        "@docusaurus/plugin-content-pages": "3.2.0",
-        "@docusaurus/utils": "3.2.0",
-        "@docusaurus/utils-common": "3.2.0",
+        "@docusaurus/mdx-loader": "3.4.0",
+        "@docusaurus/module-type-aliases": "3.4.0",
+        "@docusaurus/plugin-content-blog": "3.4.0",
+        "@docusaurus/plugin-content-docs": "3.4.0",
+        "@docusaurus/plugin-content-pages": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-common": "3.4.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2780,18 +2765,18 @@
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.2.0.tgz",
-      "integrity": "sha512-PgvF4qHoqJp8+GfqClUbTF/zYNOsz4De251IuzXon7+7FAXwvb2qmYtA2nEwyMbB7faKOz33Pxzv+y+153KS/g==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.4.0.tgz",
+      "integrity": "sha512-aiHFx7OCw4Wck1z6IoShVdUWIjntC8FHCw9c5dR8r3q4Ynh+zkS8y2eFFunN/DL6RXPzpnvKCg3vhLQYJDmT9Q==",
       "dependencies": {
         "@docsearch/react": "^3.5.2",
-        "@docusaurus/core": "3.2.0",
-        "@docusaurus/logger": "3.2.0",
-        "@docusaurus/plugin-content-docs": "3.2.0",
-        "@docusaurus/theme-common": "3.2.0",
-        "@docusaurus/theme-translations": "3.2.0",
-        "@docusaurus/utils": "3.2.0",
-        "@docusaurus/utils-validation": "3.2.0",
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/logger": "3.4.0",
+        "@docusaurus/plugin-content-docs": "3.4.0",
+        "@docusaurus/theme-common": "3.4.0",
+        "@docusaurus/theme-translations": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
         "algoliasearch": "^4.18.0",
         "algoliasearch-helper": "^3.13.3",
         "clsx": "^2.0.0",
@@ -2810,9 +2795,9 @@
       }
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.2.0.tgz",
-      "integrity": "sha512-VXzZJBuyVEmwUYyud+7IgJQEBRM6R2u/s10Rp3DOP19CBQxeKgHYTKkKhFtDeKMHDassb665kjgOi0YlJfUT6w==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.4.0.tgz",
+      "integrity": "sha512-zSxCSpmQCCdQU5Q4CnX/ID8CSUUI3fvmq4hU/GNP/XoAWtXo9SAVnM3TzpU8Gb//H3WCsT8mJcTfyOk3d9ftNg==",
       "dependencies": {
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0"
@@ -2822,9 +2807,9 @@
       }
     },
     "node_modules/@docusaurus/types": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.2.0.tgz",
-      "integrity": "sha512-uG3FfTkkkbZIPPNYx6xRfZHKeGyRd/inIT1cqvYt1FobFLd+7WhRXrSBqwJ9JajJjEAjNioRMVFgGofGf/Wdww==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.4.0.tgz",
+      "integrity": "sha512-4jcDO8kXi5Cf9TcyikB/yKmz14f2RZ2qTRerbHAsS+5InE9ZgSLBNLsewtFTcTOXSVcbU3FoGOzcNWAmU1TR0A==",
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
         "@types/history": "^4.7.11",
@@ -2842,13 +2827,13 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.2.0.tgz",
-      "integrity": "sha512-3rgrE7iL60yV2JQivlcoxUNNTK2APmn+OHLUmTvX2pueIM8DEOCEFHpJO4MiWjFO7V/Wq3iA/W1M03JnjdugVw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.4.0.tgz",
+      "integrity": "sha512-fRwnu3L3nnWaXOgs88BVBmG1yGjcQqZNHG+vInhEa2Sz2oQB+ZjbEMO5Rh9ePFpZ0YDiDUhpaVjwmS+AU2F14g==",
       "dependencies": {
-        "@docusaurus/logger": "3.2.0",
-        "@docusaurus/utils-common": "3.2.0",
-        "@svgr/webpack": "^6.5.1",
+        "@docusaurus/logger": "3.4.0",
+        "@docusaurus/utils-common": "3.4.0",
+        "@svgr/webpack": "^8.1.0",
         "escape-string-regexp": "^4.0.0",
         "file-loader": "^6.2.0",
         "fs-extra": "^11.1.1",
@@ -2864,6 +2849,7 @@
         "shelljs": "^0.8.5",
         "tslib": "^2.6.0",
         "url-loader": "^4.1.1",
+        "utility-types": "^3.10.0",
         "webpack": "^5.88.1"
       },
       "engines": {
@@ -2879,9 +2865,9 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.2.0.tgz",
-      "integrity": "sha512-WEQT5L2lT/tBQgDRgeZQAIi9YJBrwEILb1BuObQn1St3T/4K1gx5fWwOT8qdLOov296XLd1FQg9Ywu27aE9svw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.4.0.tgz",
+      "integrity": "sha512-NVx54Wr4rCEKsjOH5QEVvxIqVvm+9kh7q8aYTU5WzUU9/Hctd6aTrcZ3G0Id4zYJ+AeaG5K5qHA4CY5Kcm2iyQ==",
       "dependencies": {
         "tslib": "^2.6.0"
       },
@@ -2898,15 +2884,17 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.2.0.tgz",
-      "integrity": "sha512-rCzMTqwNrBrEOyU8EaD1fYWdig4TDhfj+YLqB8DY68VUAqSIgbY+yshpqFKB0bznFYNBJbn0bGpvVuImQOa/vA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.4.0.tgz",
+      "integrity": "sha512-hYQ9fM+AXYVTWxJOT1EuNaRnrR2WGpRdLDQG07O8UOpsvCPWUVOeo26Rbm0JWY2sGLfzAb+tvJ62yF+8F+TV0g==",
       "dependencies": {
-        "@docusaurus/logger": "3.2.0",
-        "@docusaurus/utils": "3.2.0",
-        "@docusaurus/utils-common": "3.2.0",
+        "@docusaurus/logger": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-common": "3.4.0",
+        "fs-extra": "^11.2.0",
         "joi": "^17.9.2",
         "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -3270,11 +3258,11 @@
       }
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-6.5.1.tgz",
-      "integrity": "sha512-9PYGcXrAxitycIjRmZB+Q0JaN07GZIWaTBIGQzfaZv+qr1n8X1XUEJ5rZ/vx6OVD9RRYlrNnXWExQXcmZeD/BQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-8.0.0.tgz",
+      "integrity": "sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==",
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       },
       "funding": {
         "type": "github",
@@ -3315,11 +3303,11 @@
       }
     },
     "node_modules/@svgr/babel-plugin-replace-jsx-attribute-value": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-6.5.1.tgz",
-      "integrity": "sha512-8DPaVVE3fd5JKuIC29dqyMB54sA6mfgki2H2+swh+zNJoynC8pMPzOkidqHOSc6Wj032fhl8Z0TVn1GiPpAiJg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-8.0.0.tgz",
+      "integrity": "sha512-KVQ+PtIjb1BuYT3ht8M5KbzWBhdAjjUPdlMtpuw/VjT8coTrItWX6Qafl9+ji831JaJcu6PJNKCV0bp01lBNzQ==",
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       },
       "funding": {
         "type": "github",
@@ -3330,11 +3318,11 @@
       }
     },
     "node_modules/@svgr/babel-plugin-svg-dynamic-title": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-6.5.1.tgz",
-      "integrity": "sha512-FwOEi0Il72iAzlkaHrlemVurgSQRDFbk0OC8dSvD5fSBPHltNh7JtLsxmZUhjYBZo2PpcU/RJvvi6Q0l7O7ogw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-8.0.0.tgz",
+      "integrity": "sha512-omNiKqwjNmOQJ2v6ge4SErBbkooV2aAWwaPFs2vUY7p7GhVkzRkJ00kILXQvRhA6miHnNpXv7MRnnSjdRjK8og==",
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       },
       "funding": {
         "type": "github",
@@ -3345,11 +3333,11 @@
       }
     },
     "node_modules/@svgr/babel-plugin-svg-em-dimensions": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-6.5.1.tgz",
-      "integrity": "sha512-gWGsiwjb4tw+ITOJ86ndY/DZZ6cuXMNE/SjcDRg+HLuCmwpcjOktwRF9WgAiycTqJD/QXqL2f8IzE2Rzh7aVXA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-8.0.0.tgz",
+      "integrity": "sha512-mURHYnu6Iw3UBTbhGwE/vsngtCIbHE43xCRK7kCw4t01xyGqb2Pd+WXekRRoFOBIY29ZoOhUCTEweDMdrjfi9g==",
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       },
       "funding": {
         "type": "github",
@@ -3360,11 +3348,11 @@
       }
     },
     "node_modules/@svgr/babel-plugin-transform-react-native-svg": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-6.5.1.tgz",
-      "integrity": "sha512-2jT3nTayyYP7kI6aGutkyfJ7UMGtuguD72OjeGLwVNyfPRBD8zQthlvL+fAbAKk5n9ZNcvFkp/b1lZ7VsYqVJg==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-8.1.0.tgz",
+      "integrity": "sha512-Tx8T58CHo+7nwJ+EhUwx3LfdNSG9R2OKfaIXXs5soiy5HtgoAEkDay9LIimLOcG8dJQH1wPZp/cnAv6S9CrR1Q==",
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       },
       "funding": {
         "type": "github",
@@ -3375,9 +3363,9 @@
       }
     },
     "node_modules/@svgr/babel-plugin-transform-svg-component": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-6.5.1.tgz",
-      "integrity": "sha512-a1p6LF5Jt33O3rZoVRBqdxL350oge54iZWHNI6LJB5tQ7EelvD/Mb1mfBiZNAan0dt4i3VArkFRjA4iObuNykQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-8.0.0.tgz",
+      "integrity": "sha512-DFx8xa3cZXTdb/k3kfPeaixecQLgKh5NVBMwD0AQxOzcZawK4oo1Jh9LbrcACUivsCA7TLG8eeWgrDXjTMhRmw==",
       "engines": {
         "node": ">=12"
       },
@@ -3390,21 +3378,21 @@
       }
     },
     "node_modules/@svgr/babel-preset": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@svgr/babel-preset/-/babel-preset-6.5.1.tgz",
-      "integrity": "sha512-6127fvO/FF2oi5EzSQOAjo1LE3OtNVh11R+/8FXa+mHx1ptAaS4cknIjnUA7e6j6fwGGJ17NzaTJFUwOV2zwCw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-preset/-/babel-preset-8.1.0.tgz",
+      "integrity": "sha512-7EYDbHE7MxHpv4sxvnVPngw5fuR6pw79SkcrILHJ/iMpuKySNCl5W1qcwPEpU+LgyRXOaAFgH0KhwD18wwg6ug==",
       "dependencies": {
-        "@svgr/babel-plugin-add-jsx-attribute": "^6.5.1",
-        "@svgr/babel-plugin-remove-jsx-attribute": "*",
-        "@svgr/babel-plugin-remove-jsx-empty-expression": "*",
-        "@svgr/babel-plugin-replace-jsx-attribute-value": "^6.5.1",
-        "@svgr/babel-plugin-svg-dynamic-title": "^6.5.1",
-        "@svgr/babel-plugin-svg-em-dimensions": "^6.5.1",
-        "@svgr/babel-plugin-transform-react-native-svg": "^6.5.1",
-        "@svgr/babel-plugin-transform-svg-component": "^6.5.1"
+        "@svgr/babel-plugin-add-jsx-attribute": "8.0.0",
+        "@svgr/babel-plugin-remove-jsx-attribute": "8.0.0",
+        "@svgr/babel-plugin-remove-jsx-empty-expression": "8.0.0",
+        "@svgr/babel-plugin-replace-jsx-attribute-value": "8.0.0",
+        "@svgr/babel-plugin-svg-dynamic-title": "8.0.0",
+        "@svgr/babel-plugin-svg-em-dimensions": "8.0.0",
+        "@svgr/babel-plugin-transform-react-native-svg": "8.1.0",
+        "@svgr/babel-plugin-transform-svg-component": "8.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       },
       "funding": {
         "type": "github",
@@ -3415,18 +3403,18 @@
       }
     },
     "node_modules/@svgr/core": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@svgr/core/-/core-6.5.1.tgz",
-      "integrity": "sha512-/xdLSWxK5QkqG524ONSjvg3V/FkNyCv538OIBdQqPNaAta3AsXj/Bd2FbvR87yMbXO2hFSWiAe/Q6IkVPDw+mw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
+      "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dependencies": {
-        "@babel/core": "^7.19.6",
-        "@svgr/babel-preset": "^6.5.1",
-        "@svgr/plugin-jsx": "^6.5.1",
+        "@babel/core": "^7.21.3",
+        "@svgr/babel-preset": "8.1.0",
         "camelcase": "^6.2.0",
-        "cosmiconfig": "^7.0.1"
+        "cosmiconfig": "^8.1.3",
+        "snake-case": "^3.0.4"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       },
       "funding": {
         "type": "github",
@@ -3434,15 +3422,15 @@
       }
     },
     "node_modules/@svgr/hast-util-to-babel-ast": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-6.5.1.tgz",
-      "integrity": "sha512-1hnUxxjd83EAxbL4a0JDJoD3Dao3hmjvyvyEV8PzWmLK3B9m9NPlW7GKjFyoWE8nM7HnXzPcmmSyOW8yOddSXw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-8.0.0.tgz",
+      "integrity": "sha512-EbDKwO9GpfWP4jN9sGdYwPBU0kdomaPIL2Eu4YwmgP+sJeXT+L7bMwJUBnhzfH8Q2qMBqZ4fJwpCyYsAN3mt2Q==",
       "dependencies": {
-        "@babel/types": "^7.20.0",
+        "@babel/types": "^7.21.3",
         "entities": "^4.4.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       },
       "funding": {
         "type": "github",
@@ -3450,37 +3438,37 @@
       }
     },
     "node_modules/@svgr/plugin-jsx": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@svgr/plugin-jsx/-/plugin-jsx-6.5.1.tgz",
-      "integrity": "sha512-+UdQxI3jgtSjCykNSlEMuy1jSRQlGC7pqBCPvkG/2dATdWo082zHTTK3uhnAju2/6XpE6B5mZ3z4Z8Ns01S8Gw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@svgr/plugin-jsx/-/plugin-jsx-8.1.0.tgz",
+      "integrity": "sha512-0xiIyBsLlr8quN+WyuxooNW9RJ0Dpr8uOnH/xrCVO8GLUcwHISwj1AG0k+LFzteTkAA0GbX0kj9q6Dk70PTiPA==",
       "dependencies": {
-        "@babel/core": "^7.19.6",
-        "@svgr/babel-preset": "^6.5.1",
-        "@svgr/hast-util-to-babel-ast": "^6.5.1",
+        "@babel/core": "^7.21.3",
+        "@svgr/babel-preset": "8.1.0",
+        "@svgr/hast-util-to-babel-ast": "8.0.0",
         "svg-parser": "^2.0.4"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/gregberge"
       },
       "peerDependencies": {
-        "@svgr/core": "^6.0.0"
+        "@svgr/core": "*"
       }
     },
     "node_modules/@svgr/plugin-svgo": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@svgr/plugin-svgo/-/plugin-svgo-6.5.1.tgz",
-      "integrity": "sha512-omvZKf8ixP9z6GWgwbtmP9qQMPX4ODXi+wzbVZgomNFsUIlHA1sf4fThdwTWSsZGgvGAG6yE+b/F5gWUkcZ/iQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@svgr/plugin-svgo/-/plugin-svgo-8.1.0.tgz",
+      "integrity": "sha512-Ywtl837OGO9pTLIN/onoWLmDQ4zFUycI1g76vuKGEz6evR/ZTJlJuz3G/fIkb6OVBJ2g0o6CGJzaEjfmEo3AHA==",
       "dependencies": {
-        "cosmiconfig": "^7.0.1",
-        "deepmerge": "^4.2.2",
-        "svgo": "^2.8.0"
+        "cosmiconfig": "^8.1.3",
+        "deepmerge": "^4.3.1",
+        "svgo": "^3.0.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       },
       "funding": {
         "type": "github",
@@ -3491,21 +3479,21 @@
       }
     },
     "node_modules/@svgr/webpack": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@svgr/webpack/-/webpack-6.5.1.tgz",
-      "integrity": "sha512-cQ/AsnBkXPkEK8cLbv4Dm7JGXq2XrumKnL1dRpJD9rIO2fTIlJI9a1uCciYG1F2aUsox/hJQyNGbt3soDxSRkA==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@svgr/webpack/-/webpack-8.1.0.tgz",
+      "integrity": "sha512-LnhVjMWyMQV9ZmeEy26maJk+8HTIbd59cH4F2MJ439k9DqejRisfFNGAPvRYlKETuh9LrImlS8aKsBgKjMA8WA==",
       "dependencies": {
-        "@babel/core": "^7.19.6",
-        "@babel/plugin-transform-react-constant-elements": "^7.18.12",
-        "@babel/preset-env": "^7.19.4",
+        "@babel/core": "^7.21.3",
+        "@babel/plugin-transform-react-constant-elements": "^7.21.3",
+        "@babel/preset-env": "^7.20.2",
         "@babel/preset-react": "^7.18.6",
-        "@babel/preset-typescript": "^7.18.6",
-        "@svgr/core": "^6.5.1",
-        "@svgr/plugin-jsx": "^6.5.1",
-        "@svgr/plugin-svgo": "^6.5.1"
+        "@babel/preset-typescript": "^7.21.0",
+        "@svgr/core": "8.1.0",
+        "@svgr/plugin-jsx": "8.1.0",
+        "@svgr/plugin-svgo": "8.1.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       },
       "funding": {
         "type": "github",
@@ -3751,9 +3739,9 @@
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="
     },
     "node_modules/@types/prismjs": {
-      "version": "1.26.3",
-      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.3.tgz",
-      "integrity": "sha512-A0D0aTXvjlqJ5ZILMz3rNfDBOx9hHxLZYv2by47Sm/pqW35zzjusrZTryatjN/Rf8Us2gZrJD+KeHbUSTux1Cw=="
+      "version": "1.26.4",
+      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.4.tgz",
+      "integrity": "sha512-rlAnzkW2sZOjbqZ743IHUhFcvzaGbqijwOu8QZnZCjfQzBqFE3s4lOTJEsxikImav9uzz/42I+O7YUs1mWgMlg=="
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.12",
@@ -4174,31 +4162,31 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.23.2.tgz",
-      "integrity": "sha512-8aCl055IsokLuPU8BzLjwzXjb7ty9TPcUFFOk0pYOwsE5DMVhE3kwCMFtsCFKcnoPZK7oObm+H5mbnSO/9ioxQ==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.24.0.tgz",
+      "integrity": "sha512-bf0QV/9jVejssFBmz2HQLxUadxk574t4iwjCKp5E7NBzwKkrDEhKPISIIjAU/p6K5qDx3qoeh4+26zWN1jmw3g==",
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.23.2",
-        "@algolia/cache-common": "4.23.2",
-        "@algolia/cache-in-memory": "4.23.2",
-        "@algolia/client-account": "4.23.2",
-        "@algolia/client-analytics": "4.23.2",
-        "@algolia/client-common": "4.23.2",
-        "@algolia/client-personalization": "4.23.2",
-        "@algolia/client-search": "4.23.2",
-        "@algolia/logger-common": "4.23.2",
-        "@algolia/logger-console": "4.23.2",
-        "@algolia/recommend": "4.23.2",
-        "@algolia/requester-browser-xhr": "4.23.2",
-        "@algolia/requester-common": "4.23.2",
-        "@algolia/requester-node-http": "4.23.2",
-        "@algolia/transporter": "4.23.2"
+        "@algolia/cache-browser-local-storage": "4.24.0",
+        "@algolia/cache-common": "4.24.0",
+        "@algolia/cache-in-memory": "4.24.0",
+        "@algolia/client-account": "4.24.0",
+        "@algolia/client-analytics": "4.24.0",
+        "@algolia/client-common": "4.24.0",
+        "@algolia/client-personalization": "4.24.0",
+        "@algolia/client-search": "4.24.0",
+        "@algolia/logger-common": "4.24.0",
+        "@algolia/logger-console": "4.24.0",
+        "@algolia/recommend": "4.24.0",
+        "@algolia/requester-browser-xhr": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/requester-node-http": "4.24.0",
+        "@algolia/transporter": "4.24.0"
       }
     },
     "node_modules/algoliasearch-helper": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.17.0.tgz",
-      "integrity": "sha512-R5422OiQjvjlK3VdpNQ/Qk7KsTIGeM5ACm8civGifOVWdRRV/3SgXuKmeNxe94Dz6fwj/IgpVmXbHutU4mHubg==",
+      "version": "3.22.2",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.22.2.tgz",
+      "integrity": "sha512-3YQ6eo7uYOCHeQ2ZpD+OoT3aJJwMNKEnwtu8WMzm81XmBOSCwRjQditH9CeSOQ38qhHkuGw23pbq+kULkIJLcw==",
       "dependencies": {
         "@algolia/events": "^4.0.1"
       },
@@ -5266,18 +5254,28 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/cosmiconfig": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "version": "8.3.6",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
       "dependencies": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.2.1",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0",
+        "path-type": "^4.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/cross-spawn": {
@@ -5319,11 +5317,11 @@
       }
     },
     "node_modules/css-declaration-sorter": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.4.1.tgz",
-      "integrity": "sha512-rtdthzxKuyq6IzqX6jEcIzQF/YqccluefyCYheovBOLhFT/drQA9zj/UbRAa9J7C0o6EG6u3E6g+vKkay7/k3g==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.2.0.tgz",
+      "integrity": "sha512-h70rUM+3PNFuaBDTLe8wF/cdWu+dOZmb7pJt8Z2sedYbAcQVQV/tEchueg3GWxwqS0cxtbxmaHEdkNACqcvsow==",
       "engines": {
-        "node": "^10 || ^12 || >=14"
+        "node": "^14 || ^16 || >=18"
       },
       "peerDependencies": {
         "postcss": "^8.0.9"
@@ -5364,16 +5362,16 @@
       }
     },
     "node_modules/css-minimizer-webpack-plugin": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/css-minimizer-webpack-plugin/-/css-minimizer-webpack-plugin-4.2.2.tgz",
-      "integrity": "sha512-s3Of/4jKfw1Hj9CxEO1E5oXhQAxlayuHO2y/ML+C6I9sQ7FdzfEV6QgMLN3vI+qFsjJGIAFLKtQK7t8BOXAIyA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/css-minimizer-webpack-plugin/-/css-minimizer-webpack-plugin-5.0.1.tgz",
+      "integrity": "sha512-3caImjKFQkS+ws1TGcFn0V1HyDJFq1Euy589JlD6/3rV2kj+w7r5G9WDMgSHvpvXHNZ2calVypZWuEDQd9wfLg==",
       "dependencies": {
-        "cssnano": "^5.1.8",
-        "jest-worker": "^29.1.2",
-        "postcss": "^8.4.17",
-        "schema-utils": "^4.0.0",
-        "serialize-javascript": "^6.0.0",
-        "source-map": "^0.6.1"
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "cssnano": "^6.0.1",
+        "jest-worker": "^29.4.3",
+        "postcss": "^8.4.24",
+        "schema-utils": "^4.0.1",
+        "serialize-javascript": "^6.0.1"
       },
       "engines": {
         "node": ">= 14.15.0"
@@ -5422,15 +5420,15 @@
       }
     },
     "node_modules/css-tree": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
-      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
       "dependencies": {
-        "mdn-data": "2.0.14",
-        "source-map": "^0.6.1"
+        "mdn-data": "2.0.30",
+        "source-map-js": "^1.0.1"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
     "node_modules/css-what": {
@@ -5456,107 +5454,127 @@
       }
     },
     "node_modules/cssnano": {
-      "version": "5.1.15",
-      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.1.15.tgz",
-      "integrity": "sha512-j+BKgDcLDQA+eDifLx0EO4XSA56b7uut3BQFH+wbSaSTuGLuiyTa/wbRYthUXX8LC9mLg+WWKe8h+qJuwTAbHw==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-6.1.2.tgz",
+      "integrity": "sha512-rYk5UeX7VAM/u0lNqewCdasdtPK81CgX8wJFLEIXHbV2oldWRgJAsZrdhRXkV1NJzA2g850KiFm9mMU2HxNxMA==",
       "dependencies": {
-        "cssnano-preset-default": "^5.2.14",
-        "lilconfig": "^2.0.3",
-        "yaml": "^1.10.2"
+        "cssnano-preset-default": "^6.1.2",
+        "lilconfig": "^3.1.1"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^14 || ^16 || >=18.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/cssnano"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.31"
       }
     },
     "node_modules/cssnano-preset-advanced": {
-      "version": "5.3.10",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-advanced/-/cssnano-preset-advanced-5.3.10.tgz",
-      "integrity": "sha512-fnYJyCS9jgMU+cmHO1rPSPf9axbQyD7iUhLO5Df6O4G+fKIOMps+ZbU0PdGFejFBBZ3Pftf18fn1eG7MAPUSWQ==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-advanced/-/cssnano-preset-advanced-6.1.2.tgz",
+      "integrity": "sha512-Nhao7eD8ph2DoHolEzQs5CfRpiEP0xa1HBdnFZ82kvqdmbwVBUr2r1QuQ4t1pi+D1ZpqpcO4T+wy/7RxzJ/WPQ==",
       "dependencies": {
-        "autoprefixer": "^10.4.12",
-        "cssnano-preset-default": "^5.2.14",
-        "postcss-discard-unused": "^5.1.0",
-        "postcss-merge-idents": "^5.1.1",
-        "postcss-reduce-idents": "^5.2.0",
-        "postcss-zindex": "^5.1.0"
+        "autoprefixer": "^10.4.19",
+        "browserslist": "^4.23.0",
+        "cssnano-preset-default": "^6.1.2",
+        "postcss-discard-unused": "^6.0.5",
+        "postcss-merge-idents": "^6.0.3",
+        "postcss-reduce-idents": "^6.0.3",
+        "postcss-zindex": "^6.0.2"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.31"
       }
     },
     "node_modules/cssnano-preset-default": {
-      "version": "5.2.14",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.2.14.tgz",
-      "integrity": "sha512-t0SFesj/ZV2OTylqQVOrFgEh5uanxbO6ZAdeCrNsUQ6fVuXwYTxJPNAGvGTxHbD68ldIJNec7PyYZDBrfDQ+6A==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-6.1.2.tgz",
+      "integrity": "sha512-1C0C+eNaeN8OcHQa193aRgYexyJtU8XwbdieEjClw+J9d94E41LwT6ivKH0WT+fYwYWB0Zp3I3IZ7tI/BbUbrg==",
       "dependencies": {
-        "css-declaration-sorter": "^6.3.1",
-        "cssnano-utils": "^3.1.0",
-        "postcss-calc": "^8.2.3",
-        "postcss-colormin": "^5.3.1",
-        "postcss-convert-values": "^5.1.3",
-        "postcss-discard-comments": "^5.1.2",
-        "postcss-discard-duplicates": "^5.1.0",
-        "postcss-discard-empty": "^5.1.1",
-        "postcss-discard-overridden": "^5.1.0",
-        "postcss-merge-longhand": "^5.1.7",
-        "postcss-merge-rules": "^5.1.4",
-        "postcss-minify-font-values": "^5.1.0",
-        "postcss-minify-gradients": "^5.1.1",
-        "postcss-minify-params": "^5.1.4",
-        "postcss-minify-selectors": "^5.2.1",
-        "postcss-normalize-charset": "^5.1.0",
-        "postcss-normalize-display-values": "^5.1.0",
-        "postcss-normalize-positions": "^5.1.1",
-        "postcss-normalize-repeat-style": "^5.1.1",
-        "postcss-normalize-string": "^5.1.0",
-        "postcss-normalize-timing-functions": "^5.1.0",
-        "postcss-normalize-unicode": "^5.1.1",
-        "postcss-normalize-url": "^5.1.0",
-        "postcss-normalize-whitespace": "^5.1.1",
-        "postcss-ordered-values": "^5.1.3",
-        "postcss-reduce-initial": "^5.1.2",
-        "postcss-reduce-transforms": "^5.1.0",
-        "postcss-svgo": "^5.1.0",
-        "postcss-unique-selectors": "^5.1.1"
+        "browserslist": "^4.23.0",
+        "css-declaration-sorter": "^7.2.0",
+        "cssnano-utils": "^4.0.2",
+        "postcss-calc": "^9.0.1",
+        "postcss-colormin": "^6.1.0",
+        "postcss-convert-values": "^6.1.0",
+        "postcss-discard-comments": "^6.0.2",
+        "postcss-discard-duplicates": "^6.0.3",
+        "postcss-discard-empty": "^6.0.3",
+        "postcss-discard-overridden": "^6.0.2",
+        "postcss-merge-longhand": "^6.0.5",
+        "postcss-merge-rules": "^6.1.1",
+        "postcss-minify-font-values": "^6.1.0",
+        "postcss-minify-gradients": "^6.0.3",
+        "postcss-minify-params": "^6.1.0",
+        "postcss-minify-selectors": "^6.0.4",
+        "postcss-normalize-charset": "^6.0.2",
+        "postcss-normalize-display-values": "^6.0.2",
+        "postcss-normalize-positions": "^6.0.2",
+        "postcss-normalize-repeat-style": "^6.0.2",
+        "postcss-normalize-string": "^6.0.2",
+        "postcss-normalize-timing-functions": "^6.0.2",
+        "postcss-normalize-unicode": "^6.1.0",
+        "postcss-normalize-url": "^6.0.2",
+        "postcss-normalize-whitespace": "^6.0.2",
+        "postcss-ordered-values": "^6.0.2",
+        "postcss-reduce-initial": "^6.1.0",
+        "postcss-reduce-transforms": "^6.0.2",
+        "postcss-svgo": "^6.0.3",
+        "postcss-unique-selectors": "^6.0.4"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.31"
       }
     },
     "node_modules/cssnano-utils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
-      "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-4.0.2.tgz",
+      "integrity": "sha512-ZR1jHg+wZ8o4c3zqf1SIUSTIvm/9mU343FMR6Obe/unskbvpGhZOo1J6d/r8D1pzkRQYuwbcH3hToOuoA2G7oQ==",
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.31"
       }
     },
     "node_modules/csso": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz",
-      "integrity": "sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
       "dependencies": {
-        "css-tree": "^1.1.2"
+        "css-tree": "~2.2.0"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
       }
+    },
+    "node_modules/csso/node_modules/css-tree": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+      "dependencies": {
+        "mdn-data": "2.0.28",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/mdn-data": {
+      "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="
     },
     "node_modules/csstype": {
       "version": "3.1.3",
@@ -6168,15 +6186,11 @@
       }
     },
     "node_modules/estree-util-value-to-estree": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/estree-util-value-to-estree/-/estree-util-value-to-estree-3.0.1.tgz",
-      "integrity": "sha512-b2tdzTurEIbwRh+mKrEcaWfu1wgb8J1hVsgREg7FFiecWwK/PhO8X0kyc+0bIcKNtD4sqxIdNoRy6/p/TvECEA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/estree-util-value-to-estree/-/estree-util-value-to-estree-3.1.2.tgz",
+      "integrity": "sha512-S0gW2+XZkmsx00tU2uJ4L9hUT7IFabbml9pHh2WQqFmAbxit++YGZne0sKJbNwkj9Wvg9E4uqWl4nCIFQMmfag==",
       "dependencies": {
-        "@types/estree": "^1.0.0",
-        "is-plain-obj": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "@types/estree": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/remcohaszing"
@@ -7190,9 +7204,9 @@
       }
     },
     "node_modules/hast-util-raw": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.0.2.tgz",
-      "integrity": "sha512-PldBy71wO9Uq1kyaMch9AHIghtQvIwxBUkv823pKmkTM3oV1JxtsTNYdevMxvUHqcnOAuO65JKU2+0NOxc2ksA==",
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.0.4.tgz",
+      "integrity": "sha512-LHE65TD2YiNsHD3YuXcKPHXPLuYh/gjp12mOfU8jxSrm1f/yJpsb0F/KKljS6U9LJoP0Ux+tCe8iJ2AsPzTdgA==",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/unist": "^3.0.0",
@@ -8229,9 +8243,9 @@
       }
     },
     "node_modules/joi": {
-      "version": "17.12.3",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.12.3.tgz",
-      "integrity": "sha512-2RRziagf555owrm9IRVtdKynOBeITiDpuZqIpgwqXShPncPKNiRQoiGsl/T8SQdq+8ugRzH2LqY67irr2y/d+g==",
+      "version": "17.13.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
+      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
       "dependencies": {
         "@hapi/hoek": "^9.3.0",
         "@hapi/topo": "^5.1.0",
@@ -8383,11 +8397,14 @@
       }
     },
     "node_modules/lilconfig": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
-      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.2.tgz",
+      "integrity": "sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==",
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
       }
     },
     "node_modules/lines-and-columns": {
@@ -8987,9 +9004,9 @@
       }
     },
     "node_modules/mdast-util-to-hast": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.1.0.tgz",
-      "integrity": "sha512-/e2l/6+OdGp/FB+ctrJ9Avz71AN/GRH3oi/3KAx/kMnoUsD6q0woXlDT8lLEeViVKE7oZxE7RXzvO3T8kF2/sA==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
+      "integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/mdast": "^4.0.0",
@@ -9165,9 +9182,9 @@
       }
     },
     "node_modules/mdn-data": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
-      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
+      "version": "2.0.30",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -11296,17 +11313,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/normalize-url": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
-      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -11834,105 +11840,108 @@
       }
     },
     "node_modules/postcss-calc": {
-      "version": "8.2.4",
-      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-8.2.4.tgz",
-      "integrity": "sha512-SmWMSJmB8MRnnULldx0lQIyhSNvuDl9HfrZkaqqE/WHAhToYsAvDq+yAsA/kIyINDszOp3Rh0GFoNuH5Ypsm3Q==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-9.0.1.tgz",
+      "integrity": "sha512-TipgjGyzP5QzEhsOZUaIkeO5mKeMFpebWzRogWG/ysonUlnHcq5aJe0jOjpfzUU8PeSaBQnrE8ehR0QA5vs8PQ==",
       "dependencies": {
-        "postcss-selector-parser": "^6.0.9",
+        "postcss-selector-parser": "^6.0.11",
         "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
         "postcss": "^8.2.2"
       }
     },
     "node_modules/postcss-colormin": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-5.3.1.tgz",
-      "integrity": "sha512-UsWQG0AqTFQmpBegeLLc1+c3jIqBNB0zlDGRWR+dQ3pRKJL1oeMzyqmH3o2PIfn9MBdNrVPWhDbT769LxCTLJQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-6.1.0.tgz",
+      "integrity": "sha512-x9yX7DOxeMAR+BgGVnNSAxmAj98NX/YxEMNFP+SDCEeNLb2r3i6Hh1ksMsnW8Ub5SLCpbescQqn9YEbE9554Sw==",
       "dependencies": {
-        "browserslist": "^4.21.4",
+        "browserslist": "^4.23.0",
         "caniuse-api": "^3.0.0",
-        "colord": "^2.9.1",
+        "colord": "^2.9.3",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.31"
       }
     },
     "node_modules/postcss-convert-values": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.1.3.tgz",
-      "integrity": "sha512-82pC1xkJZtcJEfiLw6UXnXVXScgtBrjlO5CBmuDQc+dlb88ZYheFsjTn40+zBVi3DkfF7iezO0nJUPLcJK3pvA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-6.1.0.tgz",
+      "integrity": "sha512-zx8IwP/ts9WvUM6NkVSkiU902QZL1bwPhaVaLynPtCsOTqp+ZKbNi+s6XJg3rfqpKGA/oc7Oxk5t8pOQJcwl/w==",
       "dependencies": {
-        "browserslist": "^4.21.4",
+        "browserslist": "^4.23.0",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.31"
       }
     },
     "node_modules/postcss-discard-comments": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.2.tgz",
-      "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-6.0.2.tgz",
+      "integrity": "sha512-65w/uIqhSBBfQmYnG92FO1mWZjJ4GL5b8atm5Yw2UgrwD7HiNiSSNwJor1eCFGzUgYnN/iIknhNRVqjrrpuglw==",
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.31"
       }
     },
     "node_modules/postcss-discard-duplicates": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
-      "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-6.0.3.tgz",
+      "integrity": "sha512-+JA0DCvc5XvFAxwx6f/e68gQu/7Z9ud584VLmcgto28eB8FqSFZwtrLwB5Kcp70eIoWP/HXqz4wpo8rD8gpsTw==",
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.31"
       }
     },
     "node_modules/postcss-discard-empty": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.1.tgz",
-      "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-6.0.3.tgz",
+      "integrity": "sha512-znyno9cHKQsK6PtxL5D19Fj9uwSzC2mB74cpT66fhgOadEUPyXFkbgwm5tvc3bt3NAy8ltE5MrghxovZRVnOjQ==",
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.31"
       }
     },
     "node_modules/postcss-discard-overridden": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
-      "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-6.0.2.tgz",
+      "integrity": "sha512-j87xzI4LUggC5zND7KdjsI25APtyMuynXZSujByMaav2roV6OZX+8AaCUcZSWqckZpjAjRyFDdpqybgjFO0HJQ==",
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.31"
       }
     },
     "node_modules/postcss-discard-unused": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-5.1.0.tgz",
-      "integrity": "sha512-KwLWymI9hbwXmJa0dkrzpRbSJEh0vVUd7r8t0yOGPcfKzyJJxFM8kLyC5Ev9avji6nY95pOp1W6HqIrfT+0VGw==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-6.0.5.tgz",
+      "integrity": "sha512-wHalBlRHkaNnNwfC8z+ppX57VhvS+HWgjW508esjdaEYr3Mx7Gnn2xA4R/CKf5+Z9S5qsqC+Uzh4ueENWwCVUA==",
       "dependencies": {
-        "postcss-selector-parser": "^6.0.5"
+        "postcss-selector-parser": "^6.0.16"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.31"
       }
     },
     "node_modules/postcss-loader": {
@@ -11956,136 +11965,111 @@
         "webpack": "^5.0.0"
       }
     },
-    "node_modules/postcss-loader/node_modules/cosmiconfig": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
-      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
-      "dependencies": {
-        "import-fresh": "^3.3.0",
-        "js-yaml": "^4.1.0",
-        "parse-json": "^5.2.0",
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/d-fischer"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.9.5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/postcss-merge-idents": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-5.1.1.tgz",
-      "integrity": "sha512-pCijL1TREiCoog5nQp7wUe+TUonA2tC2sQ54UGeMmryK3UFGIYKqDyjnqd6RcuI4znFn9hWSLNN8xKE/vWcUQw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-6.0.3.tgz",
+      "integrity": "sha512-1oIoAsODUs6IHQZkLQGO15uGEbK3EAl5wi9SS8hs45VgsxQfMnxvt+L+zIr7ifZFIH14cfAeVe2uCTa+SPRa3g==",
       "dependencies": {
-        "cssnano-utils": "^3.1.0",
+        "cssnano-utils": "^4.0.2",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.31"
       }
     },
     "node_modules/postcss-merge-longhand": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.1.7.tgz",
-      "integrity": "sha512-YCI9gZB+PLNskrK0BB3/2OzPnGhPkBEwmwhfYk1ilBHYVAZB7/tkTHFBAnCrvBBOmeYyMYw3DMjT55SyxMBzjQ==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-6.0.5.tgz",
+      "integrity": "sha512-5LOiordeTfi64QhICp07nzzuTDjNSO8g5Ksdibt44d+uvIIAE1oZdRn8y/W5ZtYgRH/lnLDlvi9F8btZcVzu3w==",
       "dependencies": {
         "postcss-value-parser": "^4.2.0",
-        "stylehacks": "^5.1.1"
+        "stylehacks": "^6.1.1"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.31"
       }
     },
     "node_modules/postcss-merge-rules": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.1.4.tgz",
-      "integrity": "sha512-0R2IuYpgU93y9lhVbO/OylTtKMVcHb67zjWIfCiKR9rWL3GUk1677LAqD/BcHizukdZEjT8Ru3oHRoAYoJy44g==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-6.1.1.tgz",
+      "integrity": "sha512-KOdWF0gju31AQPZiD+2Ar9Qjowz1LTChSjFFbS+e2sFgc4uHOp3ZvVX4sNeTlk0w2O31ecFGgrFzhO0RSWbWwQ==",
       "dependencies": {
-        "browserslist": "^4.21.4",
+        "browserslist": "^4.23.0",
         "caniuse-api": "^3.0.0",
-        "cssnano-utils": "^3.1.0",
-        "postcss-selector-parser": "^6.0.5"
+        "cssnano-utils": "^4.0.2",
+        "postcss-selector-parser": "^6.0.16"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.31"
       }
     },
     "node_modules/postcss-minify-font-values": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-5.1.0.tgz",
-      "integrity": "sha512-el3mYTgx13ZAPPirSVsHqFzl+BBBDrXvbySvPGFnQcTI4iNslrPaFq4muTkLZmKlGk4gyFAYUBMH30+HurREyA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-6.1.0.tgz",
+      "integrity": "sha512-gklfI/n+9rTh8nYaSJXlCo3nOKqMNkxuGpTn/Qm0gstL3ywTr9/WRKznE+oy6fvfolH6dF+QM4nCo8yPLdvGJg==",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.31"
       }
     },
     "node_modules/postcss-minify-gradients": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-5.1.1.tgz",
-      "integrity": "sha512-VGvXMTpCEo4qHTNSa9A0a3D+dxGFZCYwR6Jokk+/3oB6flu2/PnPXAh2x7x52EkY5xlIHLm+Le8tJxe/7TNhzw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-6.0.3.tgz",
+      "integrity": "sha512-4KXAHrYlzF0Rr7uc4VrfwDJ2ajrtNEpNEuLxFgwkhFZ56/7gaE4Nr49nLsQDZyUe+ds+kEhf+YAUolJiYXF8+Q==",
       "dependencies": {
-        "colord": "^2.9.1",
-        "cssnano-utils": "^3.1.0",
+        "colord": "^2.9.3",
+        "cssnano-utils": "^4.0.2",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.31"
       }
     },
     "node_modules/postcss-minify-params": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.1.4.tgz",
-      "integrity": "sha512-+mePA3MgdmVmv6g+30rn57USjOGSAyuxUmkfiWpzalZ8aiBkdPYjXWtHuwJGm1v5Ojy0Z0LaSYhHaLJQB0P8Jw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-6.1.0.tgz",
+      "integrity": "sha512-bmSKnDtyyE8ujHQK0RQJDIKhQ20Jq1LYiez54WiaOoBtcSuflfK3Nm596LvbtlFcpipMjgClQGyGr7GAs+H1uA==",
       "dependencies": {
-        "browserslist": "^4.21.4",
-        "cssnano-utils": "^3.1.0",
+        "browserslist": "^4.23.0",
+        "cssnano-utils": "^4.0.2",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.31"
       }
     },
     "node_modules/postcss-minify-selectors": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-5.2.1.tgz",
-      "integrity": "sha512-nPJu7OjZJTsVUmPdm2TcaiohIwxP+v8ha9NehQ2ye9szv4orirRU3SDdtUmKH+10nzn0bAyOXZ0UEr7OpvLehg==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-6.0.4.tgz",
+      "integrity": "sha512-L8dZSwNLgK7pjTto9PzWRoMbnLq5vsZSTu8+j1P/2GB8qdtGQfn+K1uSvFgYvgh83cbyxT5m43ZZhUMTJDSClQ==",
       "dependencies": {
-        "postcss-selector-parser": "^6.0.5"
+        "postcss-selector-parser": "^6.0.16"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.31"
       }
     },
     "node_modules/postcss-modules-extract-imports": {
@@ -12144,186 +12128,185 @@
       }
     },
     "node_modules/postcss-normalize-charset": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
-      "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-6.0.2.tgz",
+      "integrity": "sha512-a8N9czmdnrjPHa3DeFlwqst5eaL5W8jYu3EBbTTkI5FHkfMhFZh1EGbku6jhHhIzTA6tquI2P42NtZ59M/H/kQ==",
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.31"
       }
     },
     "node_modules/postcss-normalize-display-values": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-5.1.0.tgz",
-      "integrity": "sha512-WP4KIM4o2dazQXWmFaqMmcvsKmhdINFblgSeRgn8BJ6vxaMyaJkwAzpPpuvSIoG/rmX3M+IrRZEz2H0glrQNEA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-6.0.2.tgz",
+      "integrity": "sha512-8H04Mxsb82ON/aAkPeq8kcBbAtI5Q2a64X/mnRRfPXBq7XeogoQvReqxEfc0B4WPq1KimjezNC8flUtC3Qz6jg==",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.31"
       }
     },
     "node_modules/postcss-normalize-positions": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-5.1.1.tgz",
-      "integrity": "sha512-6UpCb0G4eofTCQLFVuI3EVNZzBNPiIKcA1AKVka+31fTVySphr3VUgAIULBhxZkKgwLImhzMR2Bw1ORK+37INg==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-6.0.2.tgz",
+      "integrity": "sha512-/JFzI441OAB9O7VnLA+RtSNZvQ0NCFZDOtp6QPFo1iIyawyXg0YI3CYM9HBy1WvwCRHnPep/BvI1+dGPKoXx/Q==",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.31"
       }
     },
     "node_modules/postcss-normalize-repeat-style": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-5.1.1.tgz",
-      "integrity": "sha512-mFpLspGWkQtBcWIRFLmewo8aC3ImN2i/J3v8YCFUwDnPu3Xz4rLohDO26lGjwNsQxB3YF0KKRwspGzE2JEuS0g==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-6.0.2.tgz",
+      "integrity": "sha512-YdCgsfHkJ2jEXwR4RR3Tm/iOxSfdRt7jplS6XRh9Js9PyCR/aka/FCb6TuHT2U8gQubbm/mPmF6L7FY9d79VwQ==",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.31"
       }
     },
     "node_modules/postcss-normalize-string": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-5.1.0.tgz",
-      "integrity": "sha512-oYiIJOf4T9T1N4i+abeIc7Vgm/xPCGih4bZz5Nm0/ARVJ7K6xrDlLwvwqOydvyL3RHNf8qZk6vo3aatiw/go3w==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-6.0.2.tgz",
+      "integrity": "sha512-vQZIivlxlfqqMp4L9PZsFE4YUkWniziKjQWUtsxUiVsSSPelQydwS8Wwcuw0+83ZjPWNTl02oxlIvXsmmG+CiQ==",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.31"
       }
     },
     "node_modules/postcss-normalize-timing-functions": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-5.1.0.tgz",
-      "integrity": "sha512-DOEkzJ4SAXv5xkHl0Wa9cZLF3WCBhF3o1SKVxKQAa+0pYKlueTpCgvkFAHfk+Y64ezX9+nITGrDZeVGgITJXjg==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-6.0.2.tgz",
+      "integrity": "sha512-a+YrtMox4TBtId/AEwbA03VcJgtyW4dGBizPl7e88cTFULYsprgHWTbfyjSLyHeBcK/Q9JhXkt2ZXiwaVHoMzA==",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.31"
       }
     },
     "node_modules/postcss-normalize-unicode": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-5.1.1.tgz",
-      "integrity": "sha512-qnCL5jzkNUmKVhZoENp1mJiGNPcsJCs1aaRmURmeJGES23Z/ajaln+EPTD+rBeNkSryI+2WTdW+lwcVdOikrpA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-6.1.0.tgz",
+      "integrity": "sha512-QVC5TQHsVj33otj8/JD869Ndr5Xcc/+fwRh4HAsFsAeygQQXm+0PySrKbr/8tkDKzW+EVT3QkqZMfFrGiossDg==",
       "dependencies": {
-        "browserslist": "^4.21.4",
+        "browserslist": "^4.23.0",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.31"
       }
     },
     "node_modules/postcss-normalize-url": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-5.1.0.tgz",
-      "integrity": "sha512-5upGeDO+PVthOxSmds43ZeMeZfKH+/DKgGRD7TElkkyS46JXAUhMzIKiCa7BabPeIy3AQcTkXwVVN7DbqsiCew==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-6.0.2.tgz",
+      "integrity": "sha512-kVNcWhCeKAzZ8B4pv/DnrU1wNh458zBNp8dh4y5hhxih5RZQ12QWMuQrDgPRw3LRl8mN9vOVfHl7uhvHYMoXsQ==",
       "dependencies": {
-        "normalize-url": "^6.0.1",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.31"
       }
     },
     "node_modules/postcss-normalize-whitespace": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-5.1.1.tgz",
-      "integrity": "sha512-83ZJ4t3NUDETIHTa3uEg6asWjSBYL5EdkVB0sDncx9ERzOKBVJIUeDO9RyA9Zwtig8El1d79HBp0JEi8wvGQnA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-6.0.2.tgz",
+      "integrity": "sha512-sXZ2Nj1icbJOKmdjXVT9pnyHQKiSAyuNQHSgRCUgThn2388Y9cGVDR+E9J9iAYbSbLHI+UUwLVl1Wzco/zgv0Q==",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.31"
       }
     },
     "node_modules/postcss-ordered-values": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-5.1.3.tgz",
-      "integrity": "sha512-9UO79VUhPwEkzbb3RNpqqghc6lcYej1aveQteWY+4POIwlqkYE21HKWaLDF6lWNuqCobEAyTovVhtI32Rbv2RQ==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-6.0.2.tgz",
+      "integrity": "sha512-VRZSOB+JU32RsEAQrO94QPkClGPKJEL/Z9PCBImXMhIeK5KAYo6slP/hBYlLgrCjFxyqvn5VC81tycFEDBLG1Q==",
       "dependencies": {
-        "cssnano-utils": "^3.1.0",
+        "cssnano-utils": "^4.0.2",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.31"
       }
     },
     "node_modules/postcss-reduce-idents": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-5.2.0.tgz",
-      "integrity": "sha512-BTrLjICoSB6gxbc58D5mdBK8OhXRDqud/zodYfdSi52qvDHdMwk+9kB9xsM8yJThH/sZU5A6QVSmMmaN001gIg==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-6.0.3.tgz",
+      "integrity": "sha512-G3yCqZDpsNPoQgbDUy3T0E6hqOQ5xigUtBQyrmq3tn2GxlyiL0yyl7H+T8ulQR6kOcHJ9t7/9H4/R2tv8tJbMA==",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.31"
       }
     },
     "node_modules/postcss-reduce-initial": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.1.2.tgz",
-      "integrity": "sha512-dE/y2XRaqAi6OvjzD22pjTUQ8eOfc6m/natGHgKFBK9DxFmIm69YmaRVQrGgFlEfc1HePIurY0TmDeROK05rIg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-6.1.0.tgz",
+      "integrity": "sha512-RarLgBK/CrL1qZags04oKbVbrrVK2wcxhvta3GCxrZO4zveibqbRPmm2VI8sSgCXwoUHEliRSbOfpR0b/VIoiw==",
       "dependencies": {
-        "browserslist": "^4.21.4",
+        "browserslist": "^4.23.0",
         "caniuse-api": "^3.0.0"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.31"
       }
     },
     "node_modules/postcss-reduce-transforms": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-5.1.0.tgz",
-      "integrity": "sha512-2fbdbmgir5AvpW9RLtdONx1QoYG2/EtqpNQbFASDlixBbAYuTcJ0dECwlqNqH7VbaUnEnh8SrxOe2sRIn24XyQ==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-6.0.2.tgz",
+      "integrity": "sha512-sB+Ya++3Xj1WaT9+5LOOdirAxP7dJZms3GRcYheSPi1PiTMigsxHAdkrbItHxwYHr4kt1zL7mmcHstgMYT+aiA==",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.31"
       }
     },
     "node_modules/postcss-selector-parser": {
@@ -12339,46 +12322,46 @@
       }
     },
     "node_modules/postcss-sort-media-queries": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/postcss-sort-media-queries/-/postcss-sort-media-queries-4.4.1.tgz",
-      "integrity": "sha512-QDESFzDDGKgpiIh4GYXsSy6sek2yAwQx1JASl5AxBtU1Lq2JfKBljIPNdil989NcSKRQX1ToiaKphImtBuhXWw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-sort-media-queries/-/postcss-sort-media-queries-5.2.0.tgz",
+      "integrity": "sha512-AZ5fDMLD8SldlAYlvi8NIqo0+Z8xnXU2ia0jxmuhxAU+Lqt9K+AlmLNJ/zWEnE9x+Zx3qL3+1K20ATgNOr3fAA==",
       "dependencies": {
-        "sort-css-media-queries": "2.1.0"
+        "sort-css-media-queries": "2.2.0"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4.16"
+        "postcss": "^8.4.23"
       }
     },
     "node_modules/postcss-svgo": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-5.1.0.tgz",
-      "integrity": "sha512-D75KsH1zm5ZrHyxPakAxJWtkyXew5qwS70v56exwvw542d9CRtTo78K0WeFxZB4G7JXKKMbEZtZayTGdIky/eA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-6.0.3.tgz",
+      "integrity": "sha512-dlrahRmxP22bX6iKEjOM+c8/1p+81asjKT+V5lrgOH944ryx/OHpclnIbGsKVd3uWOXFLYJwCVf0eEkJGvO96g==",
       "dependencies": {
         "postcss-value-parser": "^4.2.0",
-        "svgo": "^2.7.0"
+        "svgo": "^3.2.0"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^14 || ^16 || >= 18"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.31"
       }
     },
     "node_modules/postcss-unique-selectors": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-5.1.1.tgz",
-      "integrity": "sha512-5JiODlELrz8L2HwxfPnhOWZYWDxVHWL83ufOv84NrcgipI7TaeRsatAhK4Tr2/ZiYldpK/wBvw5BD3qfaK96GA==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-6.0.4.tgz",
+      "integrity": "sha512-K38OCaIrO8+PzpArzkLKB42dSARtC2tmG6PvD4b1o1Q2E9Os8jzfWFfSy/rixsHwohtsDdFtAWGjFVFUdwYaMg==",
       "dependencies": {
-        "postcss-selector-parser": "^6.0.5"
+        "postcss-selector-parser": "^6.0.16"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.31"
       }
     },
     "node_modules/postcss-value-parser": {
@@ -12387,14 +12370,14 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "node_modules/postcss-zindex": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-5.1.0.tgz",
-      "integrity": "sha512-fgFMf0OtVSBR1va1JNHYgMxYk73yhn/qb4uQDq1DLGYolz8gHCyr/sesEuGUaYs58E3ZJRcpoGuPVoB7Meiq9A==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-6.0.2.tgz",
+      "integrity": "sha512-5BxW9l1evPB/4ZIc+2GobEBoKC+h8gPGCMi+jxsYvd2x0mjq7wazk6DrP71pStqxE9Foxh5TVnonbWpFZzXaYg==",
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.31"
       }
     },
     "node_modules/pretty-error": {
@@ -12776,9 +12759,9 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-json-view-lite": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/react-json-view-lite/-/react-json-view-lite-1.3.0.tgz",
-      "integrity": "sha512-aN1biKC5v4DQkmQBlZjuMFR09MKZGMPtIg+cut8zEeg2HXd6gl2gRy0n4HMacHf0dznQgo0SVXN7eT8zV3hEuQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/react-json-view-lite/-/react-json-view-lite-1.4.0.tgz",
+      "integrity": "sha512-wh6F6uJyYAmQ4fK0e8dSQMEWuvTs2Wr3el3sLD9bambX1+pSWUVXIz1RFaoy3TI1mZ0FqdpKq9YgbgTTgyrmXA==",
       "engines": {
         "node": ">=14"
       },
@@ -12788,12 +12771,11 @@
     },
     "node_modules/react-loadable": {
       "name": "@docusaurus/react-loadable",
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz",
-      "integrity": "sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-6.0.0.tgz",
+      "integrity": "sha512-YMMxTUQV/QFSnbgrP3tjDzLHRg7vsbMn8e9HAa8o/1iXoiomo48b7sk/kkmWEuWNDPJVlKSJRB6Y2fHqdJk+SQ==",
       "dependencies": {
-        "@types/react": "*",
-        "prop-types": "^15.6.2"
+        "@types/react": "*"
       },
       "peerDependencies": {
         "react": "*"
@@ -13565,9 +13547,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sax": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
-      "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
     },
     "node_modules/scheduler": {
       "version": "0.23.0",
@@ -13627,9 +13609,9 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/search-insights": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.13.0.tgz",
-      "integrity": "sha512-Orrsjf9trHHxFRuo9/rzm0KIWmgzE8RMlZMzuhZOJ01Rnz3D0YBAe+V6473t6/H6c7irs6Lt48brULAiRWb3Vw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.14.0.tgz",
+      "integrity": "sha512-OLN6MsPMCghDOqlCtsIsYgtsC0pnwVTyT9Mu6A3ewOj1DxvzZF6COrn2g86E/c05xbktB0XN04m/t1Z+n+fTGw==",
       "peer": true
     },
     "node_modules/section-matter": {
@@ -13987,9 +13969,9 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
     },
     "node_modules/sitemap": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-7.1.1.tgz",
-      "integrity": "sha512-mK3aFtjz4VdJN0igpIJrinf3EO8U8mxOPsTBzSsy06UtjZQJ3YY3o3Xa7zSc5nMqcMrRwlChHZ18Kxg0caiPBg==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-7.1.2.tgz",
+      "integrity": "sha512-ARCqzHJ0p4gWt+j7NlU5eDlIO9+Rkr/JhPFZKKQ1l5GCus7rJH4UdrlVAh0xC/gDS/Qir2UMxqYNHtsKr2rpCw==",
       "dependencies": {
         "@types/node": "^17.0.5",
         "@types/sax": "^1.2.1",
@@ -14028,6 +14010,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/sockjs": {
       "version": "0.3.24",
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.24.tgz",
@@ -14039,9 +14030,9 @@
       }
     },
     "node_modules/sort-css-media-queries": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sort-css-media-queries/-/sort-css-media-queries-2.1.0.tgz",
-      "integrity": "sha512-IeWvo8NkNiY2vVYdPa27MCQiR0MN0M80johAYFVxWWXQ44KU84WNxjslwBHmc/7ZL2ccwkM7/e6S5aiKZXm7jA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/sort-css-media-queries/-/sort-css-media-queries-2.2.0.tgz",
+      "integrity": "sha512-0xtkGhWCC9MGt/EzgnvbbbKhqWjl1+/rncmhTh5qCpbYguXh6S/qwePfv/JQ8jePXXmqingylxoC49pCkSPIbA==",
       "engines": {
         "node": ">= 6.3.0"
       }
@@ -14123,12 +14114,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/stable": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
-      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
-      "deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility"
     },
     "node_modules/statuses": {
       "version": "2.0.1",
@@ -14280,18 +14265,18 @@
       }
     },
     "node_modules/stylehacks": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.1.tgz",
-      "integrity": "sha512-sBpcd5Hx7G6seo7b1LkpttvTz7ikD0LlH5RmdcBNb6fFR0Fl7LQwHDFr300q4cwUqi+IYrFGmsIHieMBfnN/Bw==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-6.1.1.tgz",
+      "integrity": "sha512-gSTTEQ670cJNoaeIp9KX6lZmm8LJ3jPB5yJmX8Zq/wQxOsAFXV3qjWzHas3YYk1qesuVIyYWWUpZ0vSE/dTSGg==",
       "dependencies": {
-        "browserslist": "^4.21.4",
-        "postcss-selector-parser": "^6.0.4"
+        "browserslist": "^4.23.0",
+        "postcss-selector-parser": "^6.0.16"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14.0"
+        "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
-        "postcss": "^8.2.15"
+        "postcss": "^8.4.31"
       }
     },
     "node_modules/supports-color": {
@@ -14322,23 +14307,27 @@
       "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ=="
     },
     "node_modules/svgo": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
-      "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.2.tgz",
+      "integrity": "sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw==",
       "dependencies": {
         "@trysound/sax": "0.2.0",
         "commander": "^7.2.0",
-        "css-select": "^4.1.3",
-        "css-tree": "^1.1.3",
-        "csso": "^4.2.0",
-        "picocolors": "^1.0.0",
-        "stable": "^0.1.8"
+        "css-select": "^5.1.0",
+        "css-tree": "^2.3.1",
+        "css-what": "^6.1.0",
+        "csso": "^5.0.5",
+        "picocolors": "^1.0.0"
       },
       "bin": {
         "svgo": "bin/svgo"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/svgo"
       }
     },
     "node_modules/svgo/node_modules/commander": {
@@ -14347,69 +14336,6 @@
       "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/svgo/node_modules/css-select": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
-      "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^6.0.1",
-        "domhandler": "^4.3.1",
-        "domutils": "^2.8.0",
-        "nth-check": "^2.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/svgo/node_modules/dom-serializer": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.0",
-        "entities": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/svgo/node_modules/domhandler": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
-      "dependencies": {
-        "domelementtype": "^2.2.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/svgo/node_modules/domutils": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-      "dependencies": {
-        "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/svgo/node_modules/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/tapable": {

--- a/docusaurus/package.json
+++ b/docusaurus/package.json
@@ -15,8 +15,8 @@
   },
   "dependencies": {
     "@akebifiky/remark-simple-plantuml": "^1.0.2",
-    "@docusaurus/core": "3.2.0",
-    "@docusaurus/preset-classic": "3.2.0",
+    "@docusaurus/core": "^3.4.0",
+    "@docusaurus/preset-classic": "^3.4.0",
     "@mdx-js/react": "^3.0.1",
     "clsx": "^2.1.0",
     "prism-react-renderer": "^1.3.5",
@@ -25,7 +25,7 @@
     "remark-math": "^6.0.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.2.0",
+    "@docusaurus/module-type-aliases": "^3.4.0",
     "remark-code-import": "^1.2.0"
   },
   "browserslist": {

--- a/spec/index.md
+++ b/spec/index.md
@@ -127,15 +127,13 @@ This specification may refer to certain constants and limits without specifying 
 
     Maximum wall clock time spent on evaluation of a query call.
 
-### Principals
-<h3 id="principal" style={{ display: "none" }} />
+### Principals {#principal}
 
 Principals are generic identifiers for canisters, users and possibly other concepts in the future. As far as most uses of the IC are concerned they are *opaque* binary blobs with a length between 0 and 29 bytes, and there is intentionally no mechanism to tell canister ids and user ids apart.
 
 There is, however, some structure to them to encode specific authentication and authorization behavior.
 
-#### Special forms of Principals
-<h4 id="id-classes" style={{ display: "none" }} />
+#### Special forms of Principals {#id-classes}
 
 In this section, `H` denotes SHA-224, `·` denotes blob concatenation and `|p|` denotes the length of `p` in bytes, encoded as a single byte.
 
@@ -181,8 +179,7 @@ Derived IDs are currently not explicitly used in this document, but they may be 
 
 When the IC creates a *fresh* id, it never creates a self-authenticating id, reserved id, an anonymous id or an id derived from what could be a canister or user.
 
-#### Textual representation of principals
-<h4 id="textual-ids" style={{ display: "none" }} />
+#### Textual representation of principals {#textual-ids}
 
 We specify a *canonical textual format* that is recommended whenever principals need to be printed or read in textual format, e.g. in log messages, transactions browser, command line tools, source code.
 
@@ -221,8 +218,7 @@ function textual_decode() {
 
 :::
 
-### Canister lifecycle
-<h3 id="canister-lifecycle" style={{ display: "none" }} />
+### Canister lifecycle {#canister-lifecycle}
 
 Dapps on the Internet Computer are called *canisters*. Conceptually, they consist of the following pieces of state:
 
@@ -250,8 +246,7 @@ Canisters are empty after creation and uninstallation, and become non-empty thro
 
 If an empty canister receives a response, that response is dropped, as if the canister trapped when processing the response. The cycles set aside for its processing and the cycles carried on the responses are added to the canister's *cycles* balance.
 
-#### Canister cycles
-<h4 id="canister-cycles" style={{ display: "none" }} />
+#### Canister cycles {#canister-cycles}
 
 The IC relies on *cycles*, a utility token, to manage its resources. A canister pays for the resources it uses from its *cycle balances*. A *cycle\_balance* is stored as 128-bit unsigned integers and operations on them are saturating. In particular, if *cycles* are added to a canister that would bring its main cycle balance beyond 2<sup>128</sup>-1, then the balance will be capped at 2<sup>128</sup>-1 and any additional cycles will be lost.
 
@@ -269,8 +264,7 @@ Once the IC frees the resources of a canister, its id, *cycle* balances, *contro
 
 :::
 
-#### Canister status
-<h4 id="canister-status" style={{ display: "none" }} />
+#### Canister status {#canister-status}
 
 The canister status can be used to control whether the canister is processing calls:
 
@@ -296,8 +290,7 @@ This status is orthogonal to whether a canister is frozen or not: a frozen canis
 
 :::
 
-### Signatures
-<h3 id="signatures" style={{ display: "none" }} />
+### Signatures {#signatures}
 
 Digital signature schemes are used for authenticating messages in various parts of the IC infrastructure. Signatures are domain separated, which means that every message is prefixed with a byte string that is unique to the purpose of the signature.
 
@@ -305,8 +298,7 @@ The IC supports multiple signature schemes, with details given in the following 
 
 In all cases, the signed *payload* is the concatenation of the domain separator and the message. All uses of signatures in this specification indicate a domain separator, to uniquely identify the purpose of the signature. The domain separators are prefix-free by construction, as their first byte indicates their length.
 
-#### Ed25519 and ECDSA signatures
-<h4 id="ecdsa" style={{ display: "none" }} />
+#### Ed25519 and ECDSA signatures {#ecdsa}
 
 Plain signatures are supported for the schemes
 
@@ -322,8 +314,7 @@ Plain signatures are supported for the schemes
 
 -   The signatures are encoded as the concatenation of the 32-byte big endian encodings of the two values *r* and *s*.
 
-#### Web Authentication
-<h4 id="webauthn" style={{ display: "none" }} />
+#### Web Authentication {#webauthn}
 
 The allowed signature schemes for web authentication are
 
@@ -365,8 +356,7 @@ You can also view the wrapping in [an online ASN.1 JavaScript decoder](https://l
 
     -   `signature` (`blob`): Signature as specified in the [WebAuthn w3c recommendation](https://www.w3.org/TR/webauthn/#signature-attestation-types), which means DER encoding in the case of an ECDSA signature.
 
-#### Canister signatures
-<h4 id="canister-signatures" style={{ display: "none" }} />
+#### Canister signatures {#canister-signatures}
 
 The IC also supports a scheme where a canister can sign a payload by declaring a special "certified variable".
 
@@ -402,11 +392,9 @@ This section makes forward references to other concepts in this document, in par
 
     where `s` is the SHA-256 hash of the `seed` used in the public key and `m` is the SHA-256 hash of the payload.
 
-### Supplementary Technologies
-<h3 id="supplementary-technologies" style={{ display: "none" }} />
+### Supplementary Technologies {#supplementary-technologies}
 
-#### CBOR
-<h4 id="cbor" style={{ display: "none" }} />
+#### CBOR {#cbor}
 
 [Concise Binary Object Representation (CBOR)](https://www.rfc-editor.org/rfc/rfc8949) is a data format with a small code footprint, small message size and an extensible interface. CBOR is used extensively throughout the Internet Computer as the primary format for data exchange between components within the system.
 
@@ -430,13 +418,11 @@ Particular concepts to note from the spec are:
 
 -   [CBOR Self-Describe](https://www.rfc-editor.org/rfc/rfc8949#self-describe)
 
-#### CDDL
-<h4 id="cddl" style={{ display: "none" }} />
+#### CDDL {#cddl}
 
 The [Concise Data Definition Language (CDDL)](https://datatracker.ietf.org/doc/html/rfc8610) is a data description language for CBOR. It is used at various points throughout this document to describe how certain data structures are encoded with CBOR.
 
-## The system state tree
-<h2 id="state-tree" style={{ display: "none" }} />
+## The system state tree {#state-tree}
 
 Parts of the IC state are publicly exposed (e.g. via [Request: Read state](#http-read-state) or [Certified data](#system-api-certified-data)) in a verified way (see [Certification](#certification) for the machinery for certifying). This section describes the content of this system state abstractly.
 
@@ -446,15 +432,13 @@ Labels are always blobs (but often with a human readable representation). In thi
 
 This section specifies the publicly relevant paths in the tree.
 
-### Time
-<h3 id="state-tree-time" style={{ display: "none" }} />
+### Time {#state-tree-time}
 
 -   `/time` (natural):
 
     All partial state trees include a timestamp, expressed in nanoseconds since 1970-01-01, indicating the time at which the state is current.
 
-### Api boundary nodes information
-<h3 id="state-tree-api-bn" style={{ display: "none" }} />
+### Api boundary nodes information {#state-tree-api-bn}
 
 The state tree contains information about all API boundary nodes (the source of truth for these API boundary node records is stored in the NNS registry canister).
 
@@ -474,8 +458,7 @@ The state tree contains information about all API boundary nodes (the source of 
     Public IPv6 address of a node in the hexadecimal notation with colons.
     Example: `3002:0bd6:0000:0000:0000:ee00:0033:6778`.
 
-### Subnet information
-<h3 id="state-tree-subnet" style={{ display: "none" }} />
+### Subnet information {#state-tree-subnet}
 
 The state tree contains information about the topology of the Internet Computer.
 
@@ -513,8 +496,7 @@ Because this uses the lexicographic ordering of princpials, and the byte disting
 
     The public key of a node (a DER-encoded Ed25519 signing key, see [RFC 8410](https://tools.ietf.org/html/rfc8410) for reference) with principal `<node_id>` belonging to the subnet with principal `<subnet_id>`.
 
-### Request status
-<h3 id="state-tree-request-status" style={{ display: "none" }} />
+### Request status {#state-tree-request-status}
 
 For each asynchronous request known to the Internet Computer, its status is in a subtree at `/request_status/<request_id>`. Please see [Overview of canister calling](#http-call-overview) for more details on how asynchronous requests work.
 
@@ -550,15 +532,13 @@ Request statuses will not actually be kept around indefinitely, and eventually t
 
 :::
 
-### Certified data
-<h3 id="state-tree-certified-data" style={{ display: "none" }} />
+### Certified data {#state-tree-certified-data}
 
 -   `/canister/<canister_id>/certified_data` (blob):
 
     The certified data of the canister with the given id, see [Certified data](#system-api-certified-data).
 
-### Canister information
-<h3 id="state-tree-canister-information" style={{ display: "none" }} />
+### Canister information {#state-tree-canister-information}
 
 Users have the ability to learn about the hash of the canister's module, its current controllers, and metadata in a certified way.
 
@@ -576,8 +556,7 @@ Users have the ability to learn about the hash of the canister's module, its cur
 
     It is recommended for the canister to have a custom section called "icp:public candid:service", which contains the UTF-8 encoding of [the Candid interface](https://github.com/dfinity/candid/blob/master/spec/Candid.md#core-grammar) for the canister.
 
-## HTTPS Interface
-<h2 id="http-interface" style={{ display: "none" }} />
+## HTTPS Interface {#http-interface}
 
 The concrete mechanism that users use to send requests to the Internet Computer is via an HTTPS API, which exposes three endpoints to handle interactions, plus one for diagnostics:
 
@@ -599,8 +578,7 @@ This document does not yet explain how to find the location and port of the Inte
 
 :::
 
-### Overview of canister calling
-<h3 id="http-call-overview" style={{ display: "none" }} />
+### Overview of canister calling {#http-call-overview}
 
 Users interact with the Internet Computer by calling canisters. By the very nature of a blockchain protocol, they cannot be acted upon immediately, but only with a delay. Moreover, the actual node that the user talks to may not be honest or, for other reasons, may fail to get the request on the way. This implies the following high-level workflow:
 
@@ -661,8 +639,7 @@ Calls must stay in `replied` or `rejected` long enough for polling users to catc
 
 When asking the IC about the state or call of a request, the user uses the request id (see [Request ids](#request-id)) to read the request status (see [Request status](#state-tree-request-status)) from the state tree (see [Request: Read state](#http-read-state)).
 
-### Request: Call
-<h3 id="http-call" style={{ display: "none" }} />
+### Request: Call {#http-call}
 
 In order to call a canister, the user makes a POST request to `/api/v2/canister/<effective_canister_id>/call`. The request body consists of an authentication envelope with a `content` map with the following fields:
 
@@ -700,8 +677,7 @@ The functionality exposed via the [The IC management canister](#ic-management-ca
 
 :::
 
-### Request: Read state
-<h3 id="http-read-state" style={{ display: "none" }} />
+### Request: Read state {#http-read-state}
 
 :::note
 
@@ -786,8 +762,7 @@ Note that the paths `/canisters/<canister_id>/certified_data` are not accessible
 
 See [The system state tree](#state-tree) for details on the state tree.
 
-### Request: Query call
-<h3 id="http-query" style={{ display: "none" }} />
+### Request: Query call {#http-query}
 
 A query call is a fast, but less secure way to call a canister. Only methods that are explicitly marked as "query methods" and "composite query methods" by the canister can be called this way. In contrast to a query method, a composite query method can make further calls to query and composite query methods of canisters on the same subnet.
 
@@ -887,8 +862,7 @@ This specification leaves it up to the client to define expiry times for the tim
 
 :::
 
-### Effective canister id
-<h3 id="http-effective-canister-id" style={{ display: "none" }} />
+### Effective canister id {#http-effective-canister-id}
 
 The `<effective_canister_id>` in the URL paths of requests is the *effective* destination of the request.
 It must be contained in the canister ranges of a subnet, otherwise the corresponding HTTP request is rejected.
@@ -919,8 +893,7 @@ In development instances of the Internet Computer Protocol (e.g. testnets), the 
 
 :::
 
-### Authentication
-<h3 id="authentication" style={{ display: "none" }} />
+### Authentication {#authentication}
 
 All requests coming in via the HTTPS interface need to be either *anonymous* or *authenticated* using a cryptographic signature. To that end, the following fields are present in the `content` map in all cases:
 
@@ -968,8 +941,7 @@ The `sender_sig` field is calculated by signing the concatenation of the 11 byte
 
 The delegation field, if present, must not contain more than 20 delegations.
 
-### Representation-independent hashing of structured data
-<h3 id="hash-of-map" style={{ display: "none" }} />
+### Representation-independent hashing of structured data {#hash-of-map}
 
 Structured data, such as (recursive) maps, are authenticated by signing a representation-independent hash of the data. This hash is computed as follows (using SHA256 in the steps below):
 
@@ -1009,8 +981,7 @@ hash_of_map({ "reply": { "arg": "DIDL\x00\x00" } })
 
 :::
 
-### Request ids
-<h3 id="request-id" style={{ display: "none" }} />
+### Request ids {#request-id}
 
 When signing requests or querying the status of a request (see [Request status](#state-tree-request-status)) in the state tree, the user identifies the request using a *request id*, which is the [representation-independent hash](#hash-of-map) of the `content` map of the original request. A request id must have length of 32 bytes.
 
@@ -1060,8 +1031,7 @@ hash_of_map({ request_type: "call", sender: 0x04, ingress_expiry: 16855704000000
 
 :::
 
-### Reject codes
-<h3 id="reject-codes" style={{ display: "none" }} />
+### Reject codes {#reject-codes}
 
 An API request or inter-canister call that is pending in the IC will eventually result in either a *reply* (indicating success, and carrying data) or a *reject* (indicating an error of some sorts). A reject contains a *rejection code* that classifies the error and a hopefully helpful *reject message* string.
 
@@ -1083,13 +1053,11 @@ The error message is guaranteed to be a string, i.e. not arbitrary binary data.
 
 When canisters explicitly reject a message (see [Public methods](#system-api-requests)), they can specify the reject message, but *not* the reject code; it is always `CANISTER_REJECT`. In this sense, the reject code is trustworthy: If the IC responds with a `SYS_FATAL` reject, then it really was the IC issuing this reject.
 
-### Error codes
-<h3 id="error-codes" style={{ display: "none" }} />
+### Error codes {#error-codes}
 
 Implementations of the API can provide additional details for rejected messages in the form of a textual label identifying the error condition. API clients can use these labels to handle errors programmatically or suggest recovery paths to the user. The specification reserves error codes matching the regular expression `IC[0-9]+` (e.g., `IC502`) for the DFINITY implementation of the API.
 
-### Status endpoint
-<h3 id="api-status" style={{ display: "none" }} />
+### Status endpoint {#api-status}
 
 Additionally, the Internet Computer provides an API endpoint to obtain various status fields at
 
@@ -1107,8 +1075,7 @@ Future additions may include local time, geographic location, and other useful i
 
 :::
 
-### CBOR encoding of requests and responses
-<h3 id="api-cbor" style={{ display: "none" }} />
+### CBOR encoding of requests and responses {#api-cbor}
 
 Requests and responses are specified here as records with named fields and using suggestive human readable syntax. The actual format in the body of the HTTP request or response, however, is CBOR (see [CBOR](#cbor)).
 
@@ -1152,8 +1119,7 @@ A typical request would be (written in [CBOR diagnostic notation](https://www.rf
 
 :::
 
-### CDDL description of requests and responses
-<h3 id="api-cddl" style={{ display: "none" }} />
+### CDDL description of requests and responses {#api-cddl}
 
 This section summarizes the format of the CBOR data passed to and from the entry points described above. You can also [download the file](_attachments/requests.cddl) and see [CDDL](#cddl) for more information.
 
@@ -1187,20 +1153,17 @@ Applications can work around these problems. For the first problem, the query re
 
 :::
 
-## Canister module format
-<h2 id="canister-module-format" style={{ display: "none" }} />
+## Canister module format {#canister-module-format}
 
 A canister module is a [WebAssembly module](https://webassembly.github.io/spec/core/index.html) that is either in binary format (typically `.wasm`) or gzip-compressed (typically `.wasm.gz`). If the module starts with byte sequence `[0x1f, 0x8b, 0x08]`, then the system decompresses the contents as a gzip stream according to [RFC-1952](https://datatracker.ietf.org/doc/html/rfc1952.html) and then parses the output as a WebAssembly binary.
 
-## Canister interface (System API)
-<h2 id="system-api" style={{ display: "none" }} />
+## Canister interface (System API) {#system-api}
 
 The System API is the interface between the running canister and the Internet Computer. It allows the WebAssembly module of a canister to expose functionality to the users (method entry points) and the IC (e.g. initialization), and exposes functionality of the IC to the canister (e.g. calling other canisters). Because WebAssembly is rather low-level, it also explains how to express higher level concepts (e.g. binary blobs).
 
 We want to leverage advanced WebAssembly features, such as WebAssembly host references. But as they are not yet supported by all tools involved, this section describes an initial System API that does not rely on host references. In section [Outlook: Using Host References](#host-references), we outline some of the proposed uses of WebAssembly host references.
 
-### WebAssembly module requirements
-<h3 id="system-api-module" style={{ display: "none" }} />
+### WebAssembly module requirements {#system-api-module}
 
 In order for a WebAssembly module to be usable as the code for the canister, it needs to conform to the following requirements:
 
@@ -1248,8 +1211,7 @@ In order for a WebAssembly module to be usable as the code for the canister, it 
 
 WebAssembly number types (`i32`, `i64`) do not indicate if the numbers are to be interpreted as signed or unsigned. Unless noted otherwise, whenever the System API interprets them as numbers (e.g. memory pointers, buffer offsets, array sizes), they are to be interpreted as unsigned.
 
-### Entry points
-<h3 id="entry-points" style={{ display: "none" }} />
+### Entry points {#entry-points}
 
 The canister provides entry points which are invoked by the IC under various circumstances:
 
@@ -1275,15 +1237,13 @@ The canister provides entry points which are invoked by the IC under various cir
 
 If the execution of any of these entry points traps for any reason, then all changes to the WebAssembly state, as well as the effect of any externally visible system call (like `ic0.msg_reply`, `ic0.msg_reject`, `ic0.call_perform`), are discarded. For upgrades, this transactional behavior applies to the `canister_pre_upgrade`/`canister_post_upgrade` sequence as a whole.
 
-#### Canister initialization
-<h4 id="system-api-init" style={{ display: "none" }} />
+#### Canister initialization {#system-api-init}
 
 If `canister_init` is present, then this is the first exported WebAssembly function invoked by the IC. The argument that was passed along with the canister initialization call (see [IC method](#ic-install_code)) is available to the canister via `ic0.msg_arg_data_size/copy`.
 
 The IC assumes the canister to be fully instantiated if the `canister_init` method entry point returns. If the `canister_init` method entry point traps, then canister installation has failed, and the canister is reverted to its previous state (i.e. empty with `install`, or whatever it was for a `reinstall`).
 
-#### Canister upgrades
-<h4 id="system-api-upgrades" style={{ display: "none" }} />
+#### Canister upgrades {#system-api-upgrades}
 
 When a canister is upgraded to a new WebAssembly module, the IC:
 
@@ -1307,8 +1267,7 @@ Skipping the pre-upgrade can lead to data loss.
 Use it only as the last resort and only if the stable memory already contains the entire canister state.
 :::
 
-#### Public methods
-<h4 id="system-api-requests" style={{ display: "none" }} />
+#### Public methods {#system-api-requests}
 
 To define a public method of name `name`, a WebAssembly module exports a function with name `canister_update <name>`, `canister_query <name>`, or `canister_composite_query <name>` and type `() -> ()`. We call this the *method entry point*. The name of the exported function distinguishes update, query, and composite query methods.
 
@@ -1372,8 +1331,7 @@ The following table captures the modes that different canister methods can be ex
 | canister_heartbeat       | Yes             | No                  |
 | canister_global_timer    | Yes             | No                  |
 
-### Overview of imports
-<h3 id="system-api-imports" style={{ display: "none" }} />
+### Overview of imports {#system-api-imports}
 
 :::note
 
@@ -1534,8 +1492,7 @@ The canister can access an argument. For `canister_init`, `canister_post_upgrade
 
     The reject message. Traps if there is no reject message (i.e. if `reject_code` is `0`).
 
-### Responding
-<h3 id="responding" style={{ display: "none" }} />
+### Responding {#responding}
 
 Eventually, the canister will want to respond to the original call, either by replying (indicating success) or rejecting (signalling an error):
 
@@ -1573,8 +1530,7 @@ This can be invoked multiple times within the same message execution to build up
 
     See [Cycles](#system-api-cycles) for how this interacts with cycles available on this call.
 
-### Ingress message inspection
-<h3 id="system-api-inspect-message" style={{ display: "none" }} />
+### Ingress message inspection {#system-api-inspect-message}
 
 A canister can inspect ingress messages before executing them. When the IC receives an update call from a user, the IC will use the canister method `canister_inspect_message` to determine whether the message shall be accepted. If the canister is empty (i.e. does not have a Wasm module), then the ingress message will be rejected. If the canister is not empty and does not implement `canister_inspect_message`, then the ingress message will be accepted.
 
@@ -1595,8 +1551,7 @@ The `canister_inspect_message` is *not* invoked for query calls, inter-canister 
 
 :::
 
-### Self-identification
-<h3 id="system-api-canister-self" style={{ display: "none" }} />
+### Self-identification {#system-api-canister-self}
 
 A canister can learn about its own identity:
 
@@ -1604,8 +1559,7 @@ A canister can learn about its own identity:
 
     These functions allow the canister to query its own canister id (as a blob).
 
-### Canister status
-<h3 id="system-api-canister-status" style={{ display: "none" }} />
+### Canister status {#system-api-canister-status}
 
 This function allows a canister to find out if it is running, stopping or stopped (see [IC method](#ic-canister_status) and [IC method](#ic-stop_canister) for context).
 
@@ -1617,8 +1571,7 @@ This function allows a canister to find out if it is running, stopping or stoppe
 
     Status `3` (stopped) can be observed, for example, in `canister_pre_upgrade` and can be used to prevent accidentally upgrading a canister that is not fully stopped.
 
-### Canister version
-<h3 id="system-api-canister-version" style={{ display: "none" }} />
+### Canister version {#system-api-canister-version}
 
 For each canister, the system maintains a *canister version*. Upon canister creation, it is set to 0, and it is **guaranteed** to be incremented upon every change of the canister's code, settings, running status (Running, Stopping, Stopped), and memory (WASM and stable memory), i.e., upon every successful management canister call of methods `update_settings`, `install_code`, `install_chunked_code`, `uninstall_code`, `start_canister`, and `stop_canister` on that canister, code uninstallation due to that canister running out of cycles, canister's running status transitioning from Stopping to Stopped, and successful execution of update methods, response callbacks, heartbeats, and global timers. The system can arbitrarily increment the canister version also if the canister's code, settings, running status, and memory do not change.
 
@@ -1628,8 +1581,7 @@ For each canister, the system maintains a *canister version*. Upon canister crea
 
 During the canister upgrade process, `canister_pre_upgrade` sees the old counter value, and `canister_post_upgrade` sees the new counter value.
 
-### Inter-canister method calls
-<h3 id="system-api-call" style={{ display: "none" }} />
+### Inter-canister method calls {#system-api-call}
 
 When handling an update call (or a callback), a canister can do further calls to another canister. Calls are assembled in a builder-like fashion, starting with `ic0.call_new`, adding more attributes using the `ic0.call_*` functions, and eventually performing the call with `ic0.call_perform`.
 
@@ -1712,8 +1664,7 @@ There must be at most one call to `ic0.call_on_cleanup` between `ic0.call_new` a
 
     After `ic0.call_perform` and before the next call to `ic0.call_new`, all other `ic0.call_*` function calls trap.
 
-### Cycles
-<h3 id="system-api-cycles" style={{ display: "none" }} />
+### Cycles {#system-api-cycles}
 
 Each canister maintains a balance of *cycles*, which are used to pay for platform usage. Cycles are represented by 128-bit values.
 
@@ -1817,8 +1768,7 @@ This call traps if the amount of cycles refunded does not fit into a 64-bit valu
 
     This function can only be used in a callback handler (reply or reject), and indicates the amount of cycles that came back with the response as a refund. The refund has already been added to the canister balance automatically.
 
-### Stable memory
-<h3 id="system-api-stable-memory" style={{ display: "none" }} />
+### Stable memory {#system-api-stable-memory}
 
 :::note
 
@@ -1884,8 +1834,7 @@ The stable memory is initially empty and can be grown up to the [Wasm stable mem
 
     This system call traps if `dst+size` exceeds the size of the WebAssembly memory or `offset+size` exceeds the size of the stable memory.
 
-### System time
-<h3 id="system-api-time" style={{ display: "none" }} />
+### System time {#system-api-time}
 
 The canister can query the IC for the current time.
 
@@ -1915,8 +1864,7 @@ The function returns the previous value of the timer. If no timer is set before 
 
 Passing zero as an argument to the function deactivates the timer and thus prevents the system from scheduling calls to the canister's `canister_global_timer` Wasm method.
 
-### Performance counter
-<h3 id="system-api-performance-counter" style={{ display: "none" }} />
+### Performance counter {#system-api-performance-counter}
 
 The canister can query one of the "performance counters", which is a deterministic monotonically increasing integer approximating the amount of work the canister has done. Developers might use this data to profile and optimize the canister performance.
 
@@ -1934,8 +1882,7 @@ The argument `type` decides which performance counter to return:
 
 In the future, the IC might expose more performance counters.
 
-### Replicated execution check
-<h3 id="system-api-replicated-execution-check" style={{ display: "none" }} />
+### Replicated execution check {#system-api-replicated-execution-check}
 
 The canister can check whether it is currently running in replicated or non replicated execution. 
 
@@ -1943,8 +1890,7 @@ The canister can check whether it is currently running in replicated or non repl
 
 Returns 1 if the canister is being run in replicated mode and 0 otherwise. 
 
-### Controller check
-<h3 id="system-api-controller-check" style={{ display: "none" }} />
+### Controller check {#system-api-controller-check}
 
 The canister can check whether a given principal is one of its controllers.
 
@@ -1954,8 +1900,7 @@ Checks whether the principal identified by `src`/`size` is one of the controller
 
 This system call traps if `src+size` exceeds the size of the WebAssembly memory or the principal identified by `src`/`size` is not a valid binary encoding of a principal.
 
-### Certified data
-<h3 id="system-api-certified-data" style={{ display: "none" }} />
+### Certified data {#system-api-certified-data}
 
 For each canister, the IC keeps track of "certified data", a canister-defined blob. For fresh canisters (upon install or reinstall), this blob is the empty blob (`""`).
 
@@ -2001,8 +1946,7 @@ Similarly, the System API allows the canister to effectively trap, but give some
 
     The environment may copy out the data specified by `src` and `size`, and log, print or store it in an environment-appropriate way, or include it in system-generated reject messages where appropriate. The copied data may likely be a valid string in UTF8-encoding, but the environment should be prepared to handle binary data (e.g. by printing it in escaped form or substituting invalid characters).
 
-### Outlook: Using Host References
-<h3 id="host-references" style={{ display: "none" }} />
+### Outlook: Using Host References {#host-references}
 
 The Internet Computer aims to make the most of the WebAssembly platform, and embraces WebAssembly features. With WebAssembly host references, we can make the platform more secure, the interfaces more abstract and more compositional. The above `ic0` System API does not yet use WebAssembly host references. Once they become available on our platform, a new version of the System API using host references will be available via the `ic` module. The changes will be, at least
 
@@ -2014,8 +1958,7 @@ The Internet Computer aims to make the most of the WebAssembly platform, and emb
 
 A canister may only use the old *or* the new interface; the IC detects which interface the canister intends to use based on the names and types of its function imports and exports.
 
-## The IC management canister
-<h2 id="ic-management-canister" style={{ display: "none" }} />
+## The IC management canister {#ic-management-canister}
 
 The interfaces above provide the fundamental ability for external users and canisters to contact other canisters. But the Internet Computer provides additional functionality, such as canister and user management. This functionality is exposed to external users and canisters via the *IC management canister*.
 
@@ -2029,8 +1972,7 @@ The IC management canister address is `aaaaa-aa` (i.e. the empty blob).
 
 It is possible to use the management canister via external requests (a.k.a. ingress messages). The cost of processing that request is charged to the canister that is being managed. Most methods only permit the controllers to call them. Calls to `raw_rand` and `deposit_cycles` are never accepted as ingress messages.
 
-### Interface overview
-<h3 id="ic-candid" style={{ display: "none" }} />
+### Interface overview {#ic-candid}
 
 The [interface description](_attachments/ic.did) below, in [Candid syntax](https://github.com/dfinity/candid/blob/master/spec/Candid.md), describes the available functionality.
 ``` candid name= ic-interface file file=_attachments/ic.did
@@ -2038,8 +1980,7 @@ The [interface description](_attachments/ic.did) below, in [Candid syntax](https
 
 The binary encoding of arguments and results are as per Candid specification.
 
-### IC method `create_canister`
-<h3 id="ic-create_canister" style={{ display: "none" }} />
+### IC method `create_canister` {#ic-create_canister}
 
 This method can only be called by canisters, i.e., it cannot be called by external users via ingress messages.
 
@@ -2107,8 +2048,7 @@ Until code is installed, the canister is `Empty` and behaves like a canister tha
 
 Cycles to pay for the call must be explicitly transferred with the call, i.e., they are not automatically deducted from the caller's balance implicitly (e.g., as for inter-canister calls).
 
-### IC method `update_settings`
-<h3 id="ic-update_settings" style={{ display: "none" }} />
+### IC method `update_settings` {#ic-update_settings}
 
 This method can be called by canisters as well as by external users via ingress messages.
 
@@ -2118,29 +2058,25 @@ Not including a setting in the `settings` record means not changing that field. 
 
 The optional `sender_canister_version` parameter can contain the caller's canister version. If provided, its value must be equal to `ic0.canister_version`.
 
-### IC method `upload_chunk`
-<h3 id="ic-upload_chunk" style={{ display: "none" }} />
+### IC method `upload_chunk` {#ic-upload_chunk}
 
 This method can be called by canisters as well as by external users via ingress messages.
 
 Canisters have associated some storage space (hence forth chunk storage) where they can hold chunks of Wasm modules that are too lage to fit in a single message. This method allows the controllers of a canister (and the canister itself) to upload such chunks. The method returns the hash of the chunk that was stored. The size of each chunk must be at most 1MiB. The maximum number of chunks in the chunk store is `CHUNK_STORE_SIZE` chunks. The storage cost of each chunk is fixed and corresponds to storing 1MiB of data.
  
-### IC method `clear_chunk_store`
-<h3 id="ic-clear_chunk_store" style={{ display: "none" }} />
+### IC method `clear_chunk_store` {#ic-clear_chunk_store}
 
 This method can be called by canisters as well as by external users via ingress messages.
 
 Canister controllers (and the canister itself) can clear the entire chunk storage of a canister. 
 
-### IC method `stored_chunks`
-<h3 id="ic-stored_chunks" style={{ display: "none" }} />
+### IC method `stored_chunks` {#ic-stored_chunks}
 
 This method can be called by canisters as well as by external users via ingress messages.
 
 Canister controllers (and the canister itself) can list the hashes of chunks in the chunk storage of a canister.
 
-### IC method `install_code`
-<h3 id="ic-install_code" style={{ display: "none" }} />
+### IC method `install_code` {#ic-install_code}
 
 This method can be called by canisters as well as by external users via ingress messages.
 
@@ -2174,8 +2110,7 @@ The optional `sender_canister_version` parameter can contain the caller's canist
 
 This method traps if the canister's cycle balance decreases below the canister's freezing limit after executing the method.
 
-### IC method `install_chunked_code`
-<h3 id="ic-install_chunked_code" style={{ display: "none" }} />
+### IC method `install_chunked_code` {#ic-install_chunked_code}
 
 This method can be called by canisters as well as by external users via ingress messages.
 
@@ -2190,8 +2125,7 @@ For the call to succeed, the caller must be a controller of the `store_canister`
 
 The `chunk_hashes_list` specifies a list of hash values `[h1,...,hk]` with `k <= MAX_CHUNKS_IN_LARGE_WASM`. The system looks up in the chunk store of `store_canister` (or that of the target canister if `store_canister` is not specified) blobs corresponding to `h1,...,hk` and concatenates them to obtain a blob of bytes referred to as `wasm_module` in `install_code`. It then checks that the SHA-256 hash of `wasm_module` is equal to the `wasm_module_hash` parameter and calls `install_code` with parameters `(record {mode; target_canister; wasm_module; arg; sender_canister_version})`.
 
-### IC method `uninstall_code`
-<h3 id="ic-uninstall_code" style={{ display: "none" }} />
+### IC method `uninstall_code` {#ic-uninstall_code}
 
 This method can be called by canisters as well as by external users via ingress messages.
 
@@ -2207,8 +2141,7 @@ A canister after *uninstalling* retains its *cycle* balances, *controllers*, his
 
 The optional `sender_canister_version` parameter can contain the caller's canister version. If provided, its value must be equal to `ic0.canister_version`.
 
-### IC method `canister_status`
-<h3 id="ic-canister_status" style={{ display: "none" }} />
+### IC method `canister_status` {#ic-canister_status}
 
 This method can be called by canisters as well as by external users via ingress messages.
 
@@ -2252,8 +2185,7 @@ Indicates various information about the canister. It contains:
 
 Only the controllers of the canister or the canister itself can request its status.
 
-### IC method `canister_info`
-<h3 id="ic-canister-info" style={{ display: "none" }} />
+### IC method `canister_info` {#ic-canister-info}
 
 This method can only be called by canisters, i.e., it cannot be called by external users via ingress messages.
 
@@ -2279,8 +2211,7 @@ The returned response contains the following fields:
 
 -   `controllers`: the current set of canister controllers. The order of returned controllers may vary depending on the implementation.
 
-### IC method `stop_canister`
-<h3 id="ic-stop_canister" style={{ display: "none" }} />
+### IC method `stop_canister` {#ic-stop_canister}
 
 This method can be called by canisters as well as by external users via ingress messages.
 
@@ -2288,8 +2219,7 @@ The controllers of a canister may stop a canister (e.g., to prepare for a canist
 
 Stopping a canister is not an atomic action. The immediate effect is that the status of the canister is changed to `stopping` (unless the canister is already stopped). The IC will reject all calls to a stopping canister, indicating that the canister is stopping. Responses to a stopping canister are processed as usual. When all outstanding responses have been processed (so there are no open call contexts), the canister status is changed to `stopped` and the management canister responds to the caller of the `stop_canister` request.
 
-### IC method `start_canister`
-<h3 id="ic-start_canister" style={{ display: "none" }} />
+### IC method `start_canister` {#ic-start_canister}
 
 This method can be called by canisters as well as by external users via ingress messages.
 
@@ -2299,8 +2229,7 @@ If the canister status was `stopped` or `stopping` then the canister status is s
 
 If the canister was already `running` then the status stays unchanged.
 
-### IC method `delete_canister`
-<h3 id="ic-delete_canister" style={{ display: "none" }} />
+### IC method `delete_canister` {#ic-delete_canister}
 
 This method can be called by canisters as well as by external users via ingress messages.
 
@@ -2308,22 +2237,19 @@ This method deletes a canister from the IC.
 
 Only controllers of the canister can delete it and the canister must already be stopped. Deleting a canister cannot be undone, any state stored on the canister is permanently deleted and its cycles are discarded. Once a canister is deleted, its ID cannot be reused.
 
-### IC method `deposit_cycles`
-<h3 id="ic-deposit_cycles" style={{ display: "none" }} />
+### IC method `deposit_cycles` {#ic-deposit_cycles}
 
 This method can only be called by canisters, i.e., it cannot be called by external users via ingress messages.
 
 This method deposits the cycles included in this call into the specified canister.
 
-### IC method `raw_rand`
-<h3 id="ic-raw_rand" style={{ display: "none" }} />
+### IC method `raw_rand` {#ic-raw_rand}
 
 This method can only be called by canisters, i.e., it cannot be called by external users via ingress messages.
 
 This method takes no input and returns 32 pseudo-random bytes to the caller. The return value is unknown to any part of the IC at time of the submission of this call. A new return value is generated for each call to this method.
 
-### IC method `ecdsa_public_key`
-<h3 id="ic-ecdsa_public_key" style={{ display: "none" }} />
+### IC method `ecdsa_public_key` {#ic-ecdsa_public_key}
 
 This method can only be called by canisters, i.e., it cannot be called by external users via ingress messages.
 
@@ -2333,8 +2259,7 @@ For curve `secp256k1`, the public key is derived using a generalization of BIP32
 
 The return result is an extended public key consisting of an ECDSA `public_key`, encoded in [SEC1](https://www.secg.org/sec1-v2.pdf) compressed form, and a `chain_code`, which can be used to deterministically derive child keys of the `public_key`.
 
-### IC method `sign_with_ecdsa`
-<h3 id="ic-sign_with_ecdsa" style={{ display: "none" }} />
+### IC method `sign_with_ecdsa` {#ic-sign_with_ecdsa}
 
 This method can only be called by canisters, i.e., it cannot be called by external users via ingress messages.
 
@@ -2346,8 +2271,7 @@ This call requires that the ECDSA feature is enabled, the caller is a canister, 
 
 Cycles to pay for the call must be explicitly transferred with the call, i.e., they are not automatically deducted from the caller's balance implicitly (e.g., as for inter-canister calls).
 
-### IC method `http_request`
-<h3 id="ic-http_request" style={{ display: "none" }} />
+### IC method `http_request` {#ic-http_request}
 
 This method can only be called by canisters, i.e., it cannot be called by external users via ingress messages.
 
@@ -2424,8 +2348,7 @@ If you do not specify the `max_response_bytes` parameter, the maximum of a `2MB`
 
 :::
 
-### IC method `node_metrics_history`
-<h3 id="ic-node-metrics-history" style={{ display: "none" }} />
+### IC method `node_metrics_history` {#ic-node-metrics-history}
 
 This method can only be called by canisters, i.e., it cannot be called by external users via ingress messages.
 
@@ -2447,8 +2370,7 @@ A single metric entry is a record with the following fields:
 
 - `num_block_failures_total` (`nat64`): the number of failed block proposals by this node.
 
-### IC method `provisional_create_canister_with_cycles`
-<h3 id="ic-provisional_create_canister_with_cycles" style={{ display: "none" }} />
+### IC method `provisional_create_canister_with_cycles` {#ic-provisional_create_canister_with_cycles}
 
 This method can be called by canisters as well as by external users via ingress messages.
 
@@ -2460,8 +2382,7 @@ Cycles added to this call via `ic0.call_cycles_add` and `ic0.call_cycles_add128`
 
 This method is only available in local development instances.
 
-### IC method `provisional_top_up_canister`
-<h3 id="ic-provisional_top_up_canister" style={{ display: "none" }} />
+### IC method `provisional_top_up_canister` {#ic-provisional_top_up_canister}
 
 This method can be called by canisters as well as by external users via ingress messages.
 
@@ -2473,13 +2394,11 @@ Any user can top-up any canister this way.
 
 This method is only available in local development instances.
 
-## The IC Bitcoin API
-<h2 id="ic-bitcoin-api" style={{ display: "none" }} />
+## The IC Bitcoin API {#ic-bitcoin-api}
 
 The Bitcoin functionality is exposed via the management canister. Information about Bitcoin can be found in the [Bitcoin developer guides](https://developer.bitcoin.org/devguide/). Invoking the functions of the Bitcoin API will cost cycles. We refer the reader to the [Bitcoin documentation](https://internetcomputer.org/docs/current/developer-docs/integrations/bitcoin/bitcoin-how-it-works) for further relevant information and the [IC pricing page](https://internetcomputer.org/docs/current/developer-docs/gas-cost) for information on pricing for the Bitcoin mainnet and testnet.
 
-### IC method `bitcoin_get_utxos`
-<h3 id="ic-bitcoin_get_utxos" style={{ display: "none" }} />
+### IC method `bitcoin_get_utxos` {#ic-bitcoin_get_utxos}
 
 This method can only be called by canisters, i.e., it cannot be called by external users via ingress messages.
 
@@ -2513,8 +2432,7 @@ A `get_utxos_request` without the optional `filter` results in a request that co
 
 The recommended workflow is to issue a request with the desired number of confirmations. If the `next_page` field in the response is not empty, there are more UTXOs than in the returned vector. In that case, the `page` field should be set to the `next_page` bytes in the subsequent request to obtain the next batch of UTXOs.
 
-### IC method `bitcoin_get_balance`
-<h3 id="ic-bitcoin_get_balance" style={{ display: "none" }} />
+### IC method `bitcoin_get_balance` {#ic-bitcoin_get_balance}
 
 This method can only be called by canisters, i.e., it cannot be called by external users via ingress messages.
 
@@ -2526,8 +2444,7 @@ The optional `min_confirmations` parameter can be used to limit the set of consi
 
 Given an address and the optional `min_confirmations` parameter, `bitcoin_get_balance` iterates over all UTXOs, i.e., the same balance is returned as when calling [`bitcoin_get_utxos`](#ic-bitcoin_get_utxos) for the same address and the same number of confirmations and, if necessary, using pagination to get all UTXOs for the same tip hash.
 
-### IC method `bitcoin_send_transaction`
-<h3 id="ic-bitcoin_send_transaction" style={{ display: "none" }} />
+### IC method `bitcoin_send_transaction` {#ic-bitcoin_send_transaction}
 
 This method can only be called by canisters, i.e., it cannot be called by external users via ingress messages.
 
@@ -2543,8 +2460,7 @@ If at least one of these checks fails, the call is rejected.
 
 If the transaction passes these tests, the transaction is forwarded to the specified Bitcoin network. Note that the function does not provide any guarantees that the transaction will make it into the mempool or that the transaction will ever appear in a block.
 
-### IC method `bitcoin_get_current_fee_percentiles`
-<h3 id="ic-bitcoin_get_current_fee_percentiles" style={{ display: "none" }} />
+### IC method `bitcoin_get_current_fee_percentiles` {#ic-bitcoin_get_current_fee_percentiles}
 
 This method can only be called by canisters, i.e., it cannot be called by external users via ingress messages.
 
@@ -2565,7 +2481,7 @@ The canister logs management canister API is considered EXPERIMENTAL. Canister d
 :::
 
 Given a canister ID as input, this method returns a vector of logs of that canister including its trap messages.
-The canister logs are *not* collected in canister methods running in non-replicated mode (NRQ, CQ, CRy, CRt, CC, and F modes, as defined in [Overview of imports](#overview-of-imports)) and the canister logs are *purged* when the canister is reinstalled or uninstalled.
+The canister logs are *not* collected in canister methods running in non-replicated mode (NRQ, CQ, CRy, CRt, CC, and F modes, as defined in [Overview of imports](#system-api-imports)) and the canister logs are *purged* when the canister is reinstalled or uninstalled.
 The total size of all returned logs does not exceed 4KiB.
 If new logs are added resulting in exceeding the maximum total log size of 4KiB, the oldest logs will be removed.
 Logs persist across canister upgrades and they are deleted if the canister is reinstalled or uninstalled.
@@ -2584,8 +2500,7 @@ Replica-signed queries may improve security because the recipient can verify the
 
 :::
 
-## Certification
-<h2 id="certification" style={{ display: "none" }} />
+## Certification {#certification}
 
 Some parts of the IC state are exposed to users in a tamperproof way via certification: the IC can reveal a *partial state tree* which includes just the data of interest, together with a signature on the root hash of the state tree. This means that a user can be sure that the response is correct, even if the user happens to be communicating with a malicious node, or has received the certificate via some other untrusted way.
 
@@ -2656,8 +2571,7 @@ is the [BLS signature verification function](https://datatracker.ietf.org/doc/ht
 
 All state trees include the time at path `/time` (see [Time](#state-tree-time)). Users that get a certificate with a state tree can look up the timestamp to guard against working on obsolete data.
 
-### Lookup
-<h3 id="lookup" style={{ display: "none" }} />
+### Lookup {#lookup}
 
 Given a (verified) tree, the user can fetch the value at a given path, which is a sequence of labels (blobs). In this document, we write paths suggestively with slashes as separators; the actual encoding is not actually using slashes as delimiters.
 
@@ -2712,8 +2626,7 @@ The IC will only produce well-formed state trees, and the above algorithm assume
       ∀ Label _ t ∈ trees. well_formed(t) ∧
       ∀ t ∈ trees. t ≠ Leaf _
 
-### Delegation
-<h3 id="certification-delegation" style={{ display: "none" }} />
+### Delegation {#certification-delegation}
 
 The root key can delegate certification authority to other keys.
 
@@ -2755,8 +2668,7 @@ implements DER decoding of the public key, following [RFC5480](https://datatrack
 
 Delegations are *scoped*, i.e., they indicate which set of canister principals the delegatee subnet may certify for. This set can be obtained from a delegation `d` using `lookup(["subnet",d.subnet_id,"canister_ranges"],d.certificate)`, which must be present, and is encoded as described in [Subnet information](#state-tree-subnet). The various applications of certificates describe if and how the subnet scope comes into play.
 
-### Encoding of certificates
-<h3 id="certification-encoding" style={{ display: "none" }} />
+### Encoding of certificates {#certification-encoding}
 
 The binary encoding of a certificate is a CBOR (see [CBOR](#cbor)) value according to the following CDDL (see [CDDL](#cddl)). You can also [download the file](_attachments/certificates.cddl).
 
@@ -2828,13 +2740,11 @@ In the pruned tree, the `lookup_path` function behaves as follows:
     lookup_path(["d"],      pruned_tree) = Found "morning"
     lookup_path(["e"],      pruned_tree) = Absent
 
-## The HTTP Gateway protocol
-<h2 id="http-gateway" style={{ display: "none" }} />
+## The HTTP Gateway protocol {#http-gateway}
 
 The HTTP Gateway Protocol has been moved into its own [specification](./http-gateway-protocol-spec.md).
 
-## Abstract behavior
-<h2 id="abstract-behavior" style={{ display: "none" }} />
+## Abstract behavior {#abstract-behavior}
 
 The previous sections describe the interfaces, i.e. outer edges of the Internet Computer, but give only intuitive and vague information in prose about what these interfaces actually do.
 
@@ -2905,8 +2815,7 @@ Method names can be arbitrary pieces of text:
 ```
 MethodName = Text
 ```
-#### Abstract canisters
-<h4 id="abstract-canisters" style={{ display: "none" }} />
+#### Abstract canisters {#abstract-canisters}
 
 The [WebAssembly System API](#system-api) is relatively low-level, and some of its details (e.g. that the argument data is queried using separate calls, and that closures are represented by a function pointer and a number, that method names need to be mangled) would clutter this section. Therefore, we abstract over the WebAssembly details as follows:
 
@@ -3631,8 +3540,7 @@ messages = Older_messages · Younger_messages  ·
 
 ```
 
-#### Call context creation
-<h4 id="call-context-creation" style={{ display: "none" }} />
+#### Call context creation {#call-context-creation}
 
 Before invoking a heartbeat, a global timer, or a message to a public entry point, a call context is created for bookkeeping purposes. For these invocations the canister must be running (so not stopped or stopping). Additionally, these invocations only happen for "real" canisters, not the IC management canister.
 
@@ -3803,8 +3711,7 @@ The IC can execute any message that is at the head of its queue, i.e. there is n
 
 Note that new messages are executed only if the canister is Running and is not frozen.
 
-#### Message execution
-<h4 id="rule-message-execution" style={{ display: "none" }} />
+#### Message execution {#rule-message-execution}
 
 The transition models the actual execution of a message, whether it is an initial call to a public method or a response. In either case, a call context already exists (see transition "Call context creation").
 
@@ -3977,11 +3884,11 @@ This transition detects certain behavior that will appear as a trap (and which a
 
 -   Consuming more cycles than allowed (and reserved)
 
-If message execution [*traps* (in the sense of a Wasm function)](#define-wasm-fn), the message gets dropped. No response is generated (as some other message may still fulfill this calling context). Any state mutation is discarded. If the message was a call, the associated cycles are held by its associated call context and will be refunded to the caller, see [Call context starvation](#rule-starvation).
+If message execution [*traps* (in the sense of a Wasm function)](#system-api-module), the message gets dropped. No response is generated (as some other message may still fulfill this calling context). Any state mutation is discarded. If the message was a call, the associated cycles are held by its associated call context and will be refunded to the caller, see [Call context starvation](#rule-starvation).
 
-If message execution [*returns* (in the sense of a Wasm function)](#define-wasm-fn), the state is updated and possible outbound calls and responses are enqueued.
+If message execution [*returns* (in the sense of a Wasm function)](#system-api-module), the state is updated and possible outbound calls and responses are enqueued.
 
-Note that returning does *not* imply that the call associated with this message now *succeeds* in the sense defined in [section responding](#responding); that would require a (unique) call to `ic0.reply`. Note also that the state changes are persisted even when the IC is set to synthesize a [CANISTER\_ERROR](#CANISTER_ERROR) reject immediately afterward (which happens when this returns without calling `ic0.reply` or `ic0.reject`, the corresponding call has not been responded to and there are no outstanding callbacks, see [Call context starvation](#rule-starvation)).
+Note that returning does *not* imply that the call associated with this message now *succeeds* in the sense defined in [section responding](#responding); that would require a (unique) call to `ic0.reply`. Note also that the state changes are persisted even when the IC is set to synthesize a [CANISTER\_ERROR](#reject-codes) reject immediately afterward (which happens when this returns without calling `ic0.reply` or `ic0.reject`, the corresponding call has not been responded to and there are no outstanding callbacks, see [Call context starvation](#rule-starvation)).
 
 The function `validate_sender_canister_version` checks that `sender_canister_version` matches the actual canister version of the sender in all calls to the methods of the management canister that take `sender_canister_version`:
 ```
@@ -4020,8 +3927,7 @@ system_task_as_update(f, env) = λ wasm_state →
 
 Note that by construction, a query function will either trap or return with a response; it will never send calls, and it will never change the state of the canister.
 
-#### Spontaneous request rejection
-<h4 id="request-rejection" style={{ display: "none" }} />
+#### Spontaneous request rejection {#request-rejection}
 
 The system can reject a request at any point in time, e.g., because it is overloaded.
 
@@ -4042,8 +3948,7 @@ S.messages =
       }
 ```
 
-#### Call context starvation
-<h4 id="rule-starvation" style={{ display: "none" }} />
+#### Call context starvation {#rule-starvation}
 
 If the call context needs to respond (in particular, if the call context is not for a system task) and there is no call, downstream call context, or response that references a call context, then a reject is synthesized. The error message below is *not* indicative. In particular, if the IC has an idea about *why* this starved, it can put that in there (e.g. the initial message handler trapped with an out-of-memory access).
 
@@ -4076,8 +3981,7 @@ S with
 
 ```
 
-#### Call context removal
-<h4 id="call-context-removal" style={{ display: "none" }} />
+#### Call context removal {#call-context-removal}
 
 If there is no call, downstream call context, or response that references a call context, and the call context does not need to respond (because it has already responded or its origin is a system task that does not await a response), then the call context can be removed.
 
@@ -4905,8 +4809,7 @@ S with
 
 ```
 
-#### IC Management Canister: Code uninstallation
-<h4 id="rule-uninstall" style={{ display: "none" }} />
+#### IC Management Canister: Code uninstallation {#rule-uninstall}
 
 Upon uninstallation, the canister is reverted to an empty canister, and all outstanding call contexts are rejected and marked as deleted.
 
@@ -5877,8 +5780,7 @@ verify_response(Q, R, Cert') ∧ lookup(["time"], Cert') = Found S.system_time /
 
 ```
 
-#### Query call
-<h4 id="query-call" style={{ display: "none" }} />
+#### Query call {#query-call}
 
 This section specifies query calls `Q` whose `Q.canister_id` is a non-empty canister `S.canisters[Q.canister_id]`. Query calls to the management canister, i.e., `Q.canister_id = ic_principal`, are specified in Section [Canister logs](#ic-mgmt-canister-fetch-canister-logs).
 
@@ -6175,8 +6077,7 @@ request_status_tree(Done) =
 
 and where `lookup_in_tree` is a function that returns `Found v` for a value `v`, `Absent`, or `Error`, appropriately. See the Section [Lookup](#lookup) for more details.
 
-### Abstract Canisters to System API
-<h3 id="concrete-canisters" style={{ display: "none" }} />
+### Abstract Canisters to System API {#concrete-canisters}
 
 In Section [Abstract canisters](#abstract-canisters) we introduced an abstraction over the interface to a canister, to avoid cluttering the abstract specification of the Internet Computer from WebAssembly details. In this section, we will fill the gap and explain how the abstract canister interface maps to the [concrete System API](#system-api) and the WebAssembly concepts as defined in the [WebAssembly specification](https://webassembly.github.io/spec/core/index.html).
 


### PR DESCRIPTION
- Update all headings to use `{#heading}` syntax
- Fix broken links where the heading name was changed
- Update docusaurus version to latest