### PR TITLE
[FINAL] feat: [EXC-1676] add allowed viewers variant to canister's log visibility

### DIFF
--- a/spec/_attachments/ic.did
+++ b/spec/_attachments/ic.did
@@ -3,8 +3,8 @@ type wasm_module = blob;
 
 type log_visibility = variant {
     controllers;
-    allowed_viewers : vec principal;
     public;
+    allowed_viewers : vec principal;
 };
 
 type canister_settings = record {

--- a/spec/_attachments/ic.did
+++ b/spec/_attachments/ic.did
@@ -3,6 +3,7 @@ type wasm_module = blob;
 
 type log_visibility = variant {
     controllers;
+    allowlist : opt vec principal;
     public;
 };
 

--- a/spec/_attachments/ic.did
+++ b/spec/_attachments/ic.did
@@ -3,7 +3,7 @@ type wasm_module = blob;
 
 type log_visibility = variant {
     controllers;
-    allowlist : opt vec principal;
+    allowlist : vec principal;
     public;
 };
 

--- a/spec/_attachments/ic.did
+++ b/spec/_attachments/ic.did
@@ -3,7 +3,7 @@ type wasm_module = blob;
 
 type log_visibility = variant {
     controllers;
-    allowlist : vec principal;
+    allowed_viewers : vec principal;
     public;
 };
 

--- a/spec/_attachments/interface-spec-changelog.md
+++ b/spec/_attachments/interface-spec-changelog.md
@@ -2,6 +2,7 @@
 
 ### ∞ (unreleased)
 * Allow anonymous query and read state requests with invalid `ingress_expiry`.
+* Add allowed viewers variant to canister log visibility.
 
 ### 0.28.0 (2024-10-11) {#0_28_0}
 * Add new management canister methods for canister snapshot support.

--- a/spec/index.md
+++ b/spec/index.md
@@ -2607,7 +2607,7 @@ Logs persist across canister upgrades and they are deleted if the canister is re
 The log visibility is defined in the `log_visibility` field of `canister_settings` and can be one of the following variants:
 
 - `controllers`: only canister's controllers can fetch logs (by default)
-- `allowed_viewers` (`vec principal`): only provided list of principals can fetch logs, the maximum length of the list is 10
+- `allowed_viewers` (`vec principal`): only the provided list of principals can fetch logs, the maximum length of the list is 10
 - `public`: everyone can fetch logs
 
 A single log is a record with the following fields:

--- a/spec/index.md
+++ b/spec/index.md
@@ -2607,7 +2607,7 @@ Logs persist across canister upgrades and they are deleted if the canister is re
 The log visibility is defined in the `log_visibility` field of `canister_settings` and it can be:
 
 - `controllers`: only visible to the canister's controllers (by default)
-- `allowlist`: visible to the provided list of principals
+- `allowlist`: visible to the provided list of principals, max number is limited by 10
 - `public`: visible to everyone
 
 A single log is a record with the following fields:

--- a/spec/index.md
+++ b/spec/index.md
@@ -2506,9 +2506,15 @@ Logs persist across canister upgrades and they are deleted if the canister is re
 
 The log visibility is defined in the `log_visibility` field of `canister_settings` and can be one of the following variants:
 
-- `controllers`: only canister's controllers can fetch logs (by default)
-- `public`: everyone can fetch logs
-- `allowed_viewers` (`vec principal`): only principals in the provided list and the canister's controllers can fetch logs, the maximum length of the list is 10
+- `controllers`: only the canister's controllers can fetch logs (default);
+- `public`: everyone can fetch logs;
+- `allowed_viewers` (`vec principal`): only principals in the provided list and the canister's controllers can fetch logs, the maximum length of the list is 10.
+
+A single log is a record with the following fields:
+
+- `idx` (`nat64`): the unique sequence number of the log for this particular canister;
+- `timestamp_nanos` (`nat64`): the timestamp as nanoseconds since 1970-01-01 at which the log was recorded;
+- `content` (`blob`): the actual content of the log;
 
 :::warning
 
@@ -5903,9 +5909,9 @@ Q.method_name = 'fetch_canister_logs'
 Q.arg = candid(A)
 A.canister_id = effective_canister_id
 (S[A.canister_id].canister_log_visibility = Public)
-  or 
+  or
   (S[A.canister_id].canister_log_visibility = Controllers and Q.sender in S[A.canister_id].controllers)
-  or 
+  or
   (S[A.canister_id].canister_log_visibility = AllowedViewers Principals and (Q.sender in S[A.canister_id].controllers or Q.sender in Principals))
 
 ```

--- a/spec/index.md
+++ b/spec/index.md
@@ -2603,7 +2603,12 @@ The canister logs are *not* collected in canister methods running in non-replica
 The total size of all returned logs does not exceed 4KiB.
 If new logs are added resulting in exceeding the maximum total log size of 4KiB, the oldest logs will be removed.
 Logs persist across canister upgrades and they are deleted if the canister is reinstalled or uninstalled.
-The log visibility is defined in the `log_visibility` field of `canister_settings`: logs can be either public (visible to everyone) or only visible to the canister's controllers (by default).
+
+The log visibility is defined in the `log_visibility` field of `canister_settings` and it can be:
+
+- `controllers`: only visible to the canister's controllers (by default)
+- `allowlist`: visible to the provided list of principals
+- `public`: visible to everyone
 
 A single log is a record with the following fields:
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -2604,10 +2604,10 @@ The total size of all returned logs does not exceed 4KiB.
 If new logs are added resulting in exceeding the maximum total log size of 4KiB, the oldest logs will be removed.
 Logs persist across canister upgrades and they are deleted if the canister is reinstalled or uninstalled.
 
-The log visibility is defined in the `log_visibility` field of `canister_settings`:
+The log visibility is defined in the `log_visibility` field of `canister_settings` and can be one of the following variants:
 
 - `controllers`: only canister's controllers can fetch logs (by default)
-- `allowed_viewers`: only provided list of principals can fetch logs, the maximum length of the list is 10
+- `allowed_viewers` (`vec principal`): only provided list of principals can fetch logs, the maximum length of the list is 10
 - `public`: everyone can fetch logs
 
 A single log is a record with the following fields:

--- a/spec/index.md
+++ b/spec/index.md
@@ -5884,8 +5884,7 @@ Q.canister_id = ic_principal
 Q.method_name = 'fetch_canister_logs'
 Q.arg = candid(A)
 A.canister_id = effective_canister_id
-S[A.canister_id].canister_log_visibility = 
-  Public 
+(S[A.canister_id].canister_log_visibility = Public)
   or 
   (S[A.canister_id].canister_log_visibility = AllowedViewers Principals and Q.sender in Principals) 
   or 

--- a/spec/index.md
+++ b/spec/index.md
@@ -3247,7 +3247,7 @@ CanisterHistory = {
 }
 CanisterLogVisibility
   = Controllers
-  | AllowList
+  | AllowedViewers
   | Public
 CanisterLog = {
   idx : Nat;

--- a/spec/index.md
+++ b/spec/index.md
@@ -3283,7 +3283,6 @@ S = {
   certified_data: CanisterId ↦ Blob;
   canister_history: CanisterId ↦ CanisterHistory;
   canister_log_visibility: CanisterId ↦ CanisterLogVisibility;
-  canister_log_allowlist: CanisterId ↦ Set Principal;
   canister_logs: CanisterId ↦ [CanisterLog];
   query_stats: CanisterId ↦ [QueryStats];
   system_time : Timestamp
@@ -3361,7 +3360,6 @@ The initial state of the IC is
   certified_data = ();
   canister_history = ();
   canister_log_visibility = ();
-  canister_log_allowlist = ();
   canister_logs = ();
   query_stats = ();
   system_time = T;
@@ -4211,8 +4209,6 @@ New_canister_history = {
 
 if A.settings.log_visibility is not null:
   New_canister_log_visibility = A.settings.log_visibility
-  if New_canister_log_visibility is AllowList:
-    New_canister_log_allowlist = A.settings.log_visibility ?? how to get allowlist?
 else:
   New_canister_log_visibility = Controllers
 
@@ -4239,7 +4235,6 @@ S with
     query_stats[Canister_id] = []
     canister_history[Canister_id] = New_canister_history
     canister_log_visibility[Canister_id] = New_canister_log_visibility
-    canister_log_allowlist[Canister_id] = New_canister_log_allowlist
     canister_logs[Canister_id] = []
     messages = Older_messages · Younger_messages ·
       ResponseMessage {
@@ -4371,7 +4366,6 @@ S with
     canister_version[A.canister_id] = S.canister_version[A.canister_id] + 1
     if A.settings.log_visibility is not null:
       canister_log_visibility[A.canister_id] = A.settings.log_visibility
-      // TODO: update canister_log_allowlist
     messages = Older_messages · Younger_messages ·
       ResponseMessage {
         origin = M.origin

--- a/spec/index.md
+++ b/spec/index.md
@@ -2607,8 +2607,8 @@ Logs persist across canister upgrades and they are deleted if the canister is re
 The log visibility is defined in the `log_visibility` field of `canister_settings` and can be one of the following variants:
 
 - `controllers`: only canister's controllers can fetch logs (by default)
-- `allowed_viewers` (`vec principal`): only the provided list of principals can fetch logs, the maximum length of the list is 10
 - `public`: everyone can fetch logs
+- `allowed_viewers` (`vec principal`): only the provided list of principals can fetch logs, the maximum length of the list is 10
 
 A single log is a record with the following fields:
 
@@ -3247,8 +3247,8 @@ CanisterHistory = {
 }
 CanisterLogVisibility
   = Controllers
-  | AllowedViewers [Principal]
   | Public
+  | AllowedViewers [Principal]
 CanisterLog = {
   idx : Nat;
   timestamp_nanos : Nat;
@@ -5886,9 +5886,9 @@ Q.arg = candid(A)
 A.canister_id = effective_canister_id
 (S[A.canister_id].canister_log_visibility = Public)
   or 
-  (S[A.canister_id].canister_log_visibility = AllowedViewers Principals and Q.sender in Principals) 
-  or 
   (S[A.canister_id].canister_log_visibility = Controllers and Q.sender in S[A.canister_id].controllers)
+  or 
+  (S[A.canister_id].canister_log_visibility = AllowedViewers Principals and Q.sender in Principals) 
 
 ```
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -2607,7 +2607,7 @@ Logs persist across canister upgrades and they are deleted if the canister is re
 The log visibility is defined in the `log_visibility` field of `canister_settings` and it can be:
 
 - `controllers`: only visible to the canister's controllers (by default)
-- `allowlist`: visible to the provided list of principals, max number is limited by 10
+- `allowlist`: visible to the provided list of principals, the maximum length of the list is 10
 - `public`: visible to everyone
 
 A single log is a record with the following fields:

--- a/spec/index.md
+++ b/spec/index.md
@@ -2604,11 +2604,11 @@ The total size of all returned logs does not exceed 4KiB.
 If new logs are added resulting in exceeding the maximum total log size of 4KiB, the oldest logs will be removed.
 Logs persist across canister upgrades and they are deleted if the canister is reinstalled or uninstalled.
 
-The log visibility is defined in the `log_visibility` field of `canister_settings` and it can be:
+The log visibility is defined in the `log_visibility` field of `canister_settings`:
 
-- `controllers`: only visible to the canister's controllers (by default)
-- `allowlist`: visible to the provided list of principals, the maximum length of the list is 10
-- `public`: visible to everyone
+- `controllers`: only canister's controllers can fetch logs (by default)
+- `allowed_viewers`: only provided list of principals can fetch logs, the maximum length of the list is 10
+- `public`: everyone can fetch logs
 
 A single log is a record with the following fields:
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -5257,7 +5257,6 @@ S with
     certified_data[A.canister_id] = (deleted)
     canister_history[A.canister_id] = (deleted)
     canister_log_visibility[A.canister_id] = (deleted)
-    canister_log_allowlist[A.canister_id] = (deleted)
     canister_logs[A.canister_id] = (deleted)
     query_stats[A.canister_id] = (deleted)
     messages = Older_messages · Younger_messages ·
@@ -5452,7 +5451,6 @@ New_canister_history {
 
 if A.settings.log_visibility is not null:
   New_canister_log_visibility = A.settings.log_visibility
-  // TODO: update New_canister_log_allowlist
 else:
   New_canister_log_visibility = Controllers
 
@@ -5477,7 +5475,6 @@ S with
     certified_data[Canister_id] = ""
     canister_history[Canister_id] = New_canister_history
     canister_log_visibility[Canister_id] = New_canister_log_visibility
-    canister_log_allowlist[Canister_id] = New_canister_log_allowlist
     canister_logs[Canister_id] = []
     query_stats[CanisterId] = []
     messages = Older_messages · Younger_messages ·
@@ -5887,7 +5884,7 @@ Q.canister_id = ic_principal
 Q.method_name = 'fetch_canister_logs'
 Q.arg = candid(A)
 A.canister_id = effective_canister_id
-S[A.canister_id].canister_log_visibility = Public or Q.sender in S[A.canister_id].controllers or Q.sender in S[A.canister_id].canister_log_allowlist
+S[A.canister_id].canister_log_visibility = Public or (S[A.canister_id].canister_log_visibility = AllowedViewers Principals and Q.sender in Principals) or Q.sender in S[A.canister_id].controllers
 
 ```
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -2608,7 +2608,7 @@ The log visibility is defined in the `log_visibility` field of `canister_setting
 
 - `controllers`: only canister's controllers can fetch logs (by default)
 - `public`: everyone can fetch logs
-- `allowed_viewers` (`vec principal`): only the provided list of principals can fetch logs, the maximum length of the list is 10
+- `allowed_viewers` (`vec principal`): only the provided list of principals and the canister's controllers can fetch logs, the maximum length of the list is 10
 
 A single log is a record with the following fields:
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -5884,7 +5884,12 @@ Q.canister_id = ic_principal
 Q.method_name = 'fetch_canister_logs'
 Q.arg = candid(A)
 A.canister_id = effective_canister_id
-S[A.canister_id].canister_log_visibility = Public or (S[A.canister_id].canister_log_visibility = AllowedViewers Principals and Q.sender in Principals) or Q.sender in S[A.canister_id].controllers
+S[A.canister_id].canister_log_visibility = 
+  Public 
+  or 
+  (S[A.canister_id].canister_log_visibility = AllowedViewers Principals and Q.sender in Principals) 
+  or 
+  (S[A.canister_id].canister_log_visibility = Controllers and Q.sender in S[A.canister_id].controllers)
 
 ```
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -3247,7 +3247,7 @@ CanisterHistory = {
 }
 CanisterLogVisibility
   = Controllers
-  | AllowedViewers
+  | AllowedViewers [Principal]
   | Public
 CanisterLog = {
   idx : Nat;

--- a/spec/index.md
+++ b/spec/index.md
@@ -5888,7 +5888,7 @@ A.canister_id = effective_canister_id
   or 
   (S[A.canister_id].canister_log_visibility = Controllers and Q.sender in S[A.canister_id].controllers)
   or 
-  (S[A.canister_id].canister_log_visibility = AllowedViewers Principals and Q.sender in Principals) 
+  (S[A.canister_id].canister_log_visibility = AllowedViewers Principals and (Q.sender in S[A.canister_id].controllers or Q.sender in Principals))
 
 ```
 


### PR DESCRIPTION
This PR adds `allowed_viewers` variant to canister's `log_visibility` which allows to fetch logs by specified number of principals.