### PR TITLE
fix: simplify definition of Delegation type

### DIFF
--- a/spec/index.md
+++ b/spec/index.md
@@ -2755,9 +2755,9 @@ A certificate by the root subnet does not have a delegation field. A certificate
 The certificate included in the delegation (if present) must not itself again contain a delegation.
 
 :::
+
 ```
-Delegation =
- Delegation {
+Delegation = {
    subnet_id : Principal;
    certificate : Certificate;
  }


### PR DESCRIPTION
This PR simplifies the definition of the `Delegation` type which is a simple record type and thus there's no need to formally define it as an enumeration type with a single variant `Delegation`.