### PR TITLE
Fix the anchor of canister_info

### DIFF
--- a/spec/index.md
+++ b/spec/index.md
@@ -2185,7 +2185,7 @@ Indicates various information about the canister. It contains:
 
 Only the controllers of the canister or the canister itself can request its status.
 
-### IC method `canister_info` {#ic-canister-info}
+### IC method `canister_info` {#ic-canister_info}
 
 This method can only be called by canisters, i.e., it cannot be called by external users via ingress messages.
 


### PR DESCRIPTION
Change from `ic-canister-info` to `ic-canister_info` to align with other management canister API anchors.