### PR TITLE
fix: chunk store of a deleted canister is dropped

### DIFF
--- a/spec/index.md
+++ b/spec/index.md
@@ -5277,6 +5277,7 @@ S with
     canister_log_visibility[A.canister_id] = (deleted)
     canister_logs[A.canister_id] = (deleted)
     query_stats[A.canister_id] = (deleted)
+    chunk_store[A.canister_id] = (deleted)
     messages = Older_messages · Younger_messages ·
       ResponseMessage {
         origin = M.origin


### PR DESCRIPTION
This PR fixes the specification to drop the chunk store of a deleted canister. The implementation removes the chunk store by removing the entire canister from the replicated state including the chunk store stored in the canister's system state.