### PR TITLE
[FINAL] feat: Add sections for new subnet_info endpoint

### DIFF
--- a/spec/_attachments/ic.did
+++ b/spec/_attachments/ic.did
@@ -342,6 +342,14 @@ type node_metrics_history_result = vec record {
     node_metrics : vec node_metrics;
 };
 
+type subnet_stats_args = record {
+    subnet_id : principal;
+};
+
+type subnet_stats_result = record {
+    replica_version : text;
+};
+
 type provisional_create_canister_with_cycles_args = record {
     amount : opt nat;
     settings : opt canister_settings;
@@ -443,6 +451,9 @@ service ic : {
 
     // metrics interface
     node_metrics_history : (node_metrics_history_args) -> (node_metrics_history_result);
+
+    // subnet stats
+    subnet_stats : (subnet_stats_args) -> (subnet_stats_result);
 
     // provisional interfaces for the pre-ledger world
     provisional_create_canister_with_cycles : (provisional_create_canister_with_cycles_args) -> (provisional_create_canister_with_cycles_result);

--- a/spec/_attachments/ic.did
+++ b/spec/_attachments/ic.did
@@ -342,11 +342,11 @@ type node_metrics_history_result = vec record {
     node_metrics : vec node_metrics;
 };
 
-type subnet_stats_args = record {
+type subnet_metrics_args = record {
     subnet_id : principal;
 };
 
-type subnet_stats_result = record {
+type subnet_metrics_result = record {
     replica_version : text;
 };
 
@@ -452,8 +452,8 @@ service ic : {
     // metrics interface
     node_metrics_history : (node_metrics_history_args) -> (node_metrics_history_result);
 
-    // subnet stats
-    subnet_stats : (subnet_stats_args) -> (subnet_stats_result);
+    // subnet metrics
+    subnet_metrics : (subnet_metrics_args) -> (subnet_metrics_result);
 
     // provisional interfaces for the pre-ledger world
     provisional_create_canister_with_cycles : (provisional_create_canister_with_cycles_args) -> (provisional_create_canister_with_cycles_result);

--- a/spec/_attachments/ic.did
+++ b/spec/_attachments/ic.did
@@ -342,11 +342,11 @@ type node_metrics_history_result = vec record {
     node_metrics : vec node_metrics;
 };
 
-type subnet_metrics_args = record {
+type subnet_info_args = record {
     subnet_id : principal;
 };
 
-type subnet_metrics_result = record {
+type subnet_info_result = record {
     replica_version : text;
 };
 
@@ -452,8 +452,8 @@ service ic : {
     // metrics interface
     node_metrics_history : (node_metrics_history_args) -> (node_metrics_history_result);
 
-    // subnet metrics
-    subnet_metrics : (subnet_metrics_args) -> (subnet_metrics_result);
+    // subnet info
+    subnet_info : (subnet_info_args) -> (subnet_info_result);
 
     // provisional interfaces for the pre-ledger world
     provisional_create_canister_with_cycles : (provisional_create_canister_with_cycles_args) -> (provisional_create_canister_with_cycles_result);

--- a/spec/index.md
+++ b/spec/index.md
@@ -5454,17 +5454,23 @@ The management canister returns subnet metadata given a subnet ID.
 Conditions
 
 ```html
-S.messages = Older_messages · CallMessage M · Younger_messages (M.queue =
-Unordered) or (∀ CallMessage M' | FuncMessage M' ∈ Older_messages. M'.queue ≠
-M.queue) M.callee = ic_principal M.method_name = 'subnet_stats' R =
-<implementation-specific> </implementation-specific>
+S.messages = Older_messages · CallMessage M · Younger_messages 
+(M.queue = Unordered) or (∀ CallMessage M' | FuncMessage M' ∈ Older_messages. M'.queue ≠ M.queue) 
+M.callee = ic_principal 
+M.method_name = 'subnet_stats' 
+R = <implementation-specific> 
 ```
 
 State after
 
 ```html
-S with messages = Older_messages · Younger_messages · ResponseMessage { origin =
-M.origin response = Reply (candid(R)) refunded_cycles = M.transferred_cycles }
+S with 
+    messages = Older_messages · Younger_messages · 
+      ResponseMessage { 
+        origin = M.origin 
+        response = Reply (candid(R)) 
+        refunded_cycles = M.transferred_cycles 
+      }
 ```
 
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -2548,6 +2548,14 @@ A single metric entry is a record with the following fields:
 
 - `num_block_failures_total` (`nat64`): the number of failed block proposals by this node.
 
+### IC method `subnet_stats` {#ic-subnet-stats}
+
+This method can only be called by canisters, i.e., it cannot be called by external users via ingress messages.
+
+Given a subnet ID as input, this method returns a record `subnet_stats` containing metadata about that subnet.
+
+Currently, the only field returned is the `replica_version` (`text`) of the targeted subnet.
+
 ### IC method `take_canister_snapshot` {#ic-take_canister_snapshot}
 
 This method can be called by canisters as well as by external users via ingress messages.
@@ -5438,6 +5446,27 @@ S with
       }
 
 ```
+
+#### IC Management Canister: Subnet Stats
+
+The management canister returns subnet metadata given a subnet ID.
+
+Conditions
+
+```html
+S.messages = Older_messages · CallMessage M · Younger_messages (M.queue =
+Unordered) or (∀ CallMessage M' | FuncMessage M' ∈ Older_messages. M'.queue ≠
+M.queue) M.callee = ic_principal M.method_name = 'subnet_stats' R =
+<implementation-specific> </implementation-specific>
+```
+
+State after
+
+```html
+S with messages = Older_messages · Younger_messages · ResponseMessage { origin =
+M.origin response = Reply (candid(R)) refunded_cycles = M.transferred_cycles }
+```
+
 
 #### IC Management Canister: Canister creation with cycles
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -2548,11 +2548,11 @@ A single metric entry is a record with the following fields:
 
 - `num_block_failures_total` (`nat64`): the number of failed block proposals by this node.
 
-### IC method `subnet_metrics` {#ic-subnet-metrics}
+### IC method `subnet_info` {#ic-subnet-info}
 
 This method can only be called by canisters, i.e., it cannot be called by external users via ingress messages.
 
-Given a subnet ID as input, this method returns a record `subnet_metrics` containing metadata about that subnet.
+Given a subnet ID as input, this method returns a record `subnet_info` containing metadata about that subnet.
 
 Currently, the only field returned is the `replica_version` (`text`) of the targeted subnet.
 
@@ -5457,7 +5457,7 @@ Conditions
 S.messages = Older_messages · CallMessage M · Younger_messages 
 (M.queue = Unordered) or (∀ CallMessage M' | FuncMessage M' ∈ Older_messages. M'.queue ≠ M.queue) 
 M.callee = ic_principal 
-M.method_name = 'subnet_metrics' 
+M.method_name = 'subnet_info'
 R = <implementation-specific> 
 ```
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -2548,11 +2548,11 @@ A single metric entry is a record with the following fields:
 
 - `num_block_failures_total` (`nat64`): the number of failed block proposals by this node.
 
-### IC method `subnet_stats` {#ic-subnet-stats}
+### IC method `subnet_metrics` {#ic-subnet-metrics}
 
 This method can only be called by canisters, i.e., it cannot be called by external users via ingress messages.
 
-Given a subnet ID as input, this method returns a record `subnet_stats` containing metadata about that subnet.
+Given a subnet ID as input, this method returns a record `subnet_metrics` containing metadata about that subnet.
 
 Currently, the only field returned is the `replica_version` (`text`) of the targeted subnet.
 
@@ -5447,7 +5447,7 @@ S with
 
 ```
 
-#### IC Management Canister: Subnet Stats
+#### IC Management Canister: Subnet Metrics
 
 The management canister returns subnet metadata given a subnet ID.
 
@@ -5457,7 +5457,7 @@ Conditions
 S.messages = Older_messages · CallMessage M · Younger_messages 
 (M.queue = Unordered) or (∀ CallMessage M' | FuncMessage M' ∈ Older_messages. M'.queue ≠ M.queue) 
 M.callee = ic_principal 
-M.method_name = 'subnet_stats' 
+M.method_name = 'subnet_metrics' 
 R = <implementation-specific> 
 ```
 


### PR DESCRIPTION
In certain circumstances, canisters wish to learn about subnet-specific data or metadata. This endpoint enables these use cases, starting with exposing the replica version a subnet is currently running. 

Open questions: 
- [x] Should this method be restricted to canisters or can any principal call it? **Update:** Yes, to pass on the cost to the caller
- [x] Naming: Is 'stats' fine if we anticipate that data like number of canisters, memory occupied etc might be added to the response struct? **Update:** Renamed to subnet_metrics **Update** Renaming to subnet_info! 